### PR TITLE
feat(connection): GitHub 地址可选默认官方 + 单活动连接收敛

### DIFF
--- a/apps/desktop/src/main/adapters.ts
+++ b/apps/desktop/src/main/adapters.ts
@@ -1,6 +1,12 @@
 import { BitbucketServerAdapter } from '@meebox/platform-bitbucket-server';
 import { GitHubAdapter } from '@meebox/platform-github';
-import type { Connection, PlatformAdapter, PlatformKind, ProxyConfig } from '@meebox/shared';
+import {
+  GITHUB_DOTCOM_API_BASE,
+  type Connection,
+  type PlatformAdapter,
+  type PlatformKind,
+  type ProxyConfig,
+} from '@meebox/shared';
 import { proxyFetchForHost } from './utils/proxy.js';
 
 export interface BuiltAdapter {
@@ -37,10 +43,13 @@ export function buildDraftAdapter(
   proxy: ProxyConfig,
   kind: PlatformKind = 'bitbucket-server',
 ): PlatformAdapter {
-  const fetchFn = proxyFetchForHost(proxy, hostOf(baseUrl));
   if (kind === 'github') {
-    return new GitHubAdapter({ baseUrl, token, cloneProtocol: 'pat', fetch: fetchFn });
+    // GitHub 草稿 base_url 可留空 → 默认官方 api.github.com
+    const ghBase = baseUrl.trim() || GITHUB_DOTCOM_API_BASE;
+    const fetchFn = proxyFetchForHost(proxy, hostOf(ghBase));
+    return new GitHubAdapter({ baseUrl: ghBase, token, cloneProtocol: 'pat', fetch: fetchFn });
   }
+  const fetchFn = proxyFetchForHost(proxy, hostOf(baseUrl));
   return new BitbucketServerAdapter({ baseUrl, token, cloneProtocol: 'pat', fetch: fetchFn });
 }
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -462,7 +462,13 @@ export function registerIpcHandlers({
 
   ipcMain.handle(
     'prs:list',
-    async (): Promise<IpcChannels['prs:list']['response']> => listStoredPullRequests(stateStore),
+    async (): Promise<IpcChannels['prs:list']['response']> => {
+      // 单活动连接模型：只展示当前活动连接的 PR。状态库可能仍存着切换前其他连接的
+      // 历史 PR（poller 只轮询活动连接，不会清理旧的），故在出口按 connectionId 过滤。
+      const activeId = bootstrap.config.active_connection_id;
+      const all = await listStoredPullRequests(stateStore);
+      return activeId ? all.filter((pr) => pr.connectionId === activeId) : all;
+    },
   );
   ipcMain.handle(
     'prs:refresh',
@@ -1690,7 +1696,11 @@ function buildConnectionSummaries(
   bootstrap: BootstrapResult,
   adapters: readonly BuiltAdapter[],
 ): ConnectionSummary[] {
-  return adapters.map(({ connectionId, adapter }) => {
+  // 单活动连接模型：状态栏只展示当前活动连接的启用状态（与 poller 只轮询活动连接一致）。
+  const activeId = bootstrap.config.active_connection_id;
+  return adapters
+    .filter(({ connectionId }) => connectionId === activeId)
+    .map(({ connectionId, adapter }) => {
     const conn = bootstrap.config.connections.find((c) => c.id === connectionId);
     return {
       connectionId,

--- a/apps/desktop/src/renderer/src/components/ConnectionForm.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Config } from '@meebox/shared';
+import { GITHUB_DOTCOM_API_BASE, type Config } from '@meebox/shared';
 import { invoke } from '../api';
 import { EyeIcon, EyeOffIcon } from './icons';
 
@@ -29,10 +29,13 @@ export function toConnDraft(c: ConnEntry): ConnDraft {
 }
 
 export function fromConnDraft(d: ConnDraft): ConnEntry {
+  // GitHub 的 Base URL 可留空 → 默认官方 api.github.com（GHE 才需手填 /api/v3）。
+  const trimmed = d.base_url.trim();
+  const base_url = d.kind === 'github' && trimmed === '' ? GITHUB_DOTCOM_API_BASE : trimmed;
   const common = {
     id: d.id,
-    base_url: d.base_url.trim(),
-    display_name: d.display_name.trim() || d.base_url.trim(),
+    base_url,
+    display_name: d.display_name.trim() || base_url,
     auth: { type: 'pat' as const, token: d.token },
     clone: { protocol: d.protocol },
   };
@@ -50,14 +53,16 @@ const KIND_HINTS: Record<ConnKind, { name: string; baseUrl: string; token: strin
   },
   github: {
     name: '如 公司 GitHub',
-    baseUrl: 'https://api.github.com 或 https://<ghe-host>/api/v3',
+    baseUrl: '留空默认 https://api.github.com；GHE 填 https://<host>/api/v3',
     token: 'GitHub Personal Access Token',
   },
 };
 
-/** Base URL 形如 http(s)://… 才算合法 */
+/** Base URL 形如 http(s)://… 才算合法；GitHub 允许留空（默认官方 api.github.com）。 */
 export function connUrlValid(d: ConnDraft): boolean {
-  return /^https?:\/\/.+/i.test(d.base_url.trim());
+  const u = d.base_url.trim();
+  if (d.kind === 'github' && u === '') return true;
+  return /^https?:\/\/.+/i.test(u);
 }
 /** 名称 + 合法 URL + token 三者齐全才允许保存 */
 export function connDraftCanSave(d: ConnDraft): boolean {
@@ -136,7 +141,12 @@ export function ConnectionForm({
           />
         </div>
         <div className="modal-kv-key">
-          Base URL <span className="settings-required">*</span>
+          Base URL{' '}
+          {draft.kind === 'github' ? (
+            <span className="settings-optional">(可选)</span>
+          ) : (
+            <span className="settings-required">*</span>
+          )}
         </div>
         <div className="modal-kv-val">
           <input

--- a/apps/desktop/src/renderer/src/styles/modal.scss
+++ b/apps/desktop/src/renderer/src/styles/modal.scss
@@ -286,6 +286,11 @@ select.settings-input {
   color: $color-danger;
   margin-left: $space-1;
 }
+.settings-optional {
+  color: $text-muted;
+  margin-left: $space-1;
+  font-size: 0.85em;
+}
 .settings-input-error {
   border-color: $color-danger !important;
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -23,15 +23,21 @@ export const BitbucketServerConnectionSchema = z.object({
   clone: CloneSettingsSchema,
 });
 
+/** github.com 官方 REST API base。GitHub 连接的 base_url 留空时默认走这里。 */
+export const GITHUB_DOTCOM_API_BASE = 'https://api.github.com';
+
 export const GitHubConnectionSchema = z.object({
   id: z.string().min(1),
   kind: z.literal('github'),
   /**
-   * GitHub REST API base。github.com 用 `https://api.github.com`；GitHub Enterprise
-   * Server 用 `https://<ghe-host>/api/v3`。clone / web host 由 adapter 推导
-   * （api.github.com → github.com；GHE → 同 host）。
+   * GitHub REST API base。**可选**：留空 / 缺省时默认 `https://api.github.com`（github.com）；
+   * GitHub Enterprise Server 填 `https://<ghe-host>/api/v3`。clone / web host 由 adapter
+   * 推导（api.github.com → github.com；GHE → 同 host）。
    */
-  base_url: z.string().url(),
+  base_url: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().url().default(GITHUB_DOTCOM_API_BASE),
+  ),
   display_name: z.string(),
   auth: z.object({
     type: z.literal('pat'),


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

feat(connection): Default GitHub API base + single active connection views
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## 背景
面向单代码平台日常评审，把连接体验从「多连接聚合」收敛到「单一活动连接」，并降低 GitHub(github.com) 接入门槛。

## 改动
- **GitHub Base URL 可选**：留空 / 缺省默认 `https://api.github.com`，GHE Server 仍手填 `/api/v3`。
  - schema `preprocess` 把空串归一成默认；表单留空即合法、保存兜底、标签「(可选)」+ 占位提示；测试连接草稿同样兜底。
- **单活动连接**：
  - `prs:list` 按 `active_connection_id` 过滤 → 只展示活动连接的 PR（状态库里切换前残留的其他连接历史 PR 不再露出）。
  - `buildConnectionSummaries` 只汇总活动连接 → 状态栏只显示一个连接的启用状态，且不再 ping 非活动连接。
  - 与 poller「只轮询活动连接」一致；App 用 selected PR 的 connectionId 找 capabilities 仍命中。

## 验证
lint ✓ · typecheck ✓ · test ✓(7 projects) · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Allow GitHub Base URL to be empty, defaulting to api.github.com.
• Filter PR list and status summaries to only the active connection.
• Add UI hinting and schema normalization to prevent invalid empty GitHub URLs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  UI["Renderer: ConnectionForm"] --> IPC["Main: IPC handlers"] --> STATE[("State store: stored PRs")]
  UI --> SHARED["Shared: config schema"] --> ADAPTERS["Main: buildDraftAdapter"] --> GHAPI{{"GitHub REST API"}}

  subgraph Legend
    direction LR
    _ui["UI/Component"] ~~~ _db[("Stored data")] ~~~ _ext{{"External"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Migrate/clean state store when switching active connection</b></summary>

- ➕ Eliminates stale PRs at the data source (less conditional filtering).
- ➕ Reduces ambiguity for any other consumer of stored PRs.
- ➖ Potentially destructive; users may want historical PRs preserved.
- ➖ Requires careful migration and rollback handling.

</details>

<details>
<summary><b>2. Enforce single-active semantics deeper (store only active connection PRs)</b></summary>

- ➕ Makes invariants explicit; fewer UI/IPC filters needed.
- ➕ Reduces risk of future endpoints forgetting to filter.
- ➖ Broader refactor of poller + persistence; higher risk/effort.
- ➖ Harder to preserve history across connection switches.

</details>

<details>
<summary><b>3. Default GitHub base_url only at persistence/schema layer (not in UI/main)</b></summary>

- ➕ Single source of truth for defaulting; fewer duplicated fallbacks.
- ➕ Simplifies UI and adapter code paths.
- ➖ UI still needs to treat empty input as valid for UX.
- ➖ Draft/test-connection flows may still need explicit runtime defaults.

</details>

**Recommendation:** Current approach is pragmatic: schema preprocess + UI validity + main-process draft adapter fallback ensures empty GitHub base_url works end-to-end, and IPC-boundary filtering prevents stale PRs from leaking without needing destructive state migrations. Consider adding a defensive fallback in buildConnectionSummaries when active_connection_id is unset (e.g., show all or first), if that state is possible during bootstrap/first-run.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>adapters.ts</strong> <code>Default GitHub draft base URL to api.github.com for adapter/proxy</code> <code>+12/-3</code></summary>

<br/>

>Default GitHub draft base URL to api.github.com for adapter/proxy
>
><pre>
>• Imports the shared GITHUB_DOTCOM_API_BASE constant and applies it when building a GitHub draft adapter if baseUrl is empty. Also ensures proxy host resolution uses the normalized GitHub base URL.
></pre>
>
><a href='https://github.com/huhamhire/code-meeseeks/pull/1/files#diff-8333b31208963e6d7d6147963b233bb025e24046dc4f57326887a8c842824673'>apps/desktop/src/main/adapters.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ConnectionForm.tsx</strong> <code>Make GitHub Base URL optional with defaulting and UI messaging</code> <code>+17/-7</code></summary>

<br/>

>Make GitHub Base URL optional with defaulting and UI messaging
>
><pre>
>• Uses GITHUB_DOTCOM_API_BASE when saving GitHub connections with an empty Base URL, and derives display_name from the normalized base URL. Adjusts validation to allow empty Base URL for GitHub only, updates hint text, and renders &#x27;(可选)&#x27; for GitHub in the form label.
></pre>
>
><a href='https://github.com/huhamhire/code-meeseeks/pull/1/files#diff-7c5caf155caa3916c8e74b5387ab07194906a94c169016f145f6ce5145b432a6'>apps/desktop/src/renderer/src/components/ConnectionForm.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>modal.scss</strong> <code>Add muted &#x27;(optional)&#x27; label styling for settings forms</code> <code>+5/-0</code></summary>

<br/>

>Add muted &#x27;(optional)&#x27; label styling for settings forms
>
><pre>
>• Introduces a .settings-optional style variant to visually differentiate optional fields in the modal settings UI.
></pre>
>
><a href='https://github.com/huhamhire/code-meeseeks/pull/1/files#diff-df7effc43bf17399ba115f00592586de6e7366b9e8c57683155eb71e736d47fc'>apps/desktop/src/renderer/src/styles/modal.scss</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>ipc.ts</strong> <code>Filter PR listing and connection summaries to active connection</code> <code>+12/-2</code></summary>

<br/>

>Filter PR listing and connection summaries to active connection
>
><pre>
>• Updates the prs:list IPC handler to filter stored PRs by bootstrap.config.active_connection_id, preventing historical PRs from other connections from showing. Updates buildConnectionSummaries to only include the active connection so the status bar reflects a single active connection and avoids pinging inactive ones.
></pre>
>
><a href='https://github.com/huhamhire/code-meeseeks/pull/1/files#diff-a471b27e653d39114f9a737b0741f68dc1a6f36f3830e9454fd4e00704e24727'>apps/desktop/src/main/ipc.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>config.ts</strong> <code>Normalize empty GitHub base_url and default to api.github.com in schema</code> <code>+10/-4</code></summary>

<br/>

>Normalize empty GitHub base_url and default to api.github.com in schema
>
><pre>
>• Exports a GITHUB_DOTCOM_API_BASE constant and updates GitHubConnectionSchema to preprocess empty strings to undefined, enabling a default URL. Documentation is updated to clarify that base_url is optional for github.com and required for GitHub Enterprise Server.
></pre>
>
><a href='https://github.com/huhamhire/code-meeseeks/pull/1/files#diff-3c75982220cc3680e072e8f43bb57f784cf618861b4e9b2678e3a082158fb344'>packages/shared/src/config.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>