### PR TITLE
feat(app): 版本更新检测 + 提示（检测层级 A，不自动安装）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - **Mermaid 图渲染**：markdown 里的 ```mermaid``` 代码块（Qodo `/describe` 常生成的架构图）渲染为图形，
   覆盖 PR 描述 / 评论 / chat 评审输出。mermaid 懒加载（独立 chunk，仅出现图表时才拉取，不进入口包）；
   深色主题、`securityLevel: strict`，渲染失败回退原始代码块。
+- **版本更新检测**：启动时（及设置页「检查更新」）查 GitHub Releases 最新稳定版与当前版本比对，
+  有新版在状态栏提示并可点击前往下载（仅检测 + 提示，不自动下载 / 安装）。检测走配置的出站代理
+  （内网友好），可经 `update.check_enabled` 关闭。
 
 ## [0.2.0] - 2026-06-09
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import { JsonFileStateStore } from '@meebox/state-store';
 import { buildAdapters, type ConnectionRuntime } from './adapters.js';
 import { registerIpcHandlers } from './ipc.js';
 import { buildProxyEnv } from './utils/proxy.js';
+import { checkForUpdate } from './utils/update-check.js';
 
 // 进程（模块加载）起点：用于度量到主窗口首帧（ready-to-show）的启动耗时。
 const PROCESS_START_MS = Date.now();
@@ -294,6 +295,26 @@ function resolveSplashLogo(): string | null {
 }
 
 /**
+ * 启动后异步检测版本更新（config.update.check_enabled 开启时）。仅检测 + 提示：
+ * 有新版才把结果推给渲染层（StatusBar 提示 + 跳转下载），不下载 / 不安装。失败静默。
+ */
+async function maybeCheckUpdate(win: BrowserWindow): Promise<void> {
+  if (!bootstrap.config.update.check_enabled) return;
+  try {
+    const result = await checkForUpdate(app.getVersion(), bootstrap.config.proxy);
+    if (result.ok && result.hasUpdate && !win.isDestroyed()) {
+      win.webContents.send('app:updateAvailable', result);
+      logger.info(
+        { current: result.currentVersion, latest: result.latestVersion },
+        'update available',
+      );
+    }
+  } catch {
+    /* 检测失败不影响使用，静默 */
+  }
+}
+
+/**
  * 启动闪屏：独立的无边框轻量窗口，加载内联 data URL（品牌 logo + 纯 CSS spinner），
  * 几十 ms 即可呈现，遮住主窗口首帧前的渲染层加载空窗。主窗口 ready-to-show 时关闭。
  * logo 经 base64 内联（见 resolveSplashLogo），data URL 自包含、dev/打包行为一致。
@@ -368,6 +389,8 @@ function createWindow(splash?: BrowserWindow): void {
       { elapsedMs: Date.now() - PROCESS_START_MS },
       'main window first paint (ready-to-show)',
     );
+    // 启动后异步检测版本更新（不阻塞、不打断）；有新版才推给渲染层提示。
+    void maybeCheckUpdate(win);
   });
 
   // 把 <a target="_blank"> / window.open 都路由到 OS 默认浏览器，不在 Electron 内开新窗口

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -47,6 +47,7 @@ import { buildDraftAdapter, type BuiltAdapter, type ConnectionRuntime } from './
 import { sniffImageContentType } from './utils/image.js';
 import { buildPragentEnv, resolveActiveLlmProfile } from './utils/agent.js';
 import { buildProxyEnv, testProxyConnectivity } from './utils/proxy.js';
+import { checkForUpdate } from './utils/update-check.js';
 import { buildPrContext } from './utils/pr-context.js';
 
 interface RegisterDeps {
@@ -433,6 +434,11 @@ export function registerIpcHandlers({
   ipcMain.handle('app:openDevTools', (evt) => {
     evt.sender.openDevTools({ mode: 'detach' });
   });
+  ipcMain.handle(
+    'app:checkUpdate',
+    (): Promise<IpcChannels['app:checkUpdate']['response']> =>
+      checkForUpdate(app.getVersion(), bootstrap.config.proxy),
+  );
   ipcMain.handle(
     'app:openExternal',
     async (_evt, req: IpcChannels['app:openExternal']['request']): Promise<void> => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -436,8 +436,18 @@ export function registerIpcHandlers({
   });
   ipcMain.handle(
     'app:checkUpdate',
-    (): Promise<IpcChannels['app:checkUpdate']['response']> =>
-      checkForUpdate(app.getVersion(), bootstrap.config.proxy),
+    (): Promise<IpcChannels['app:checkUpdate']['response']> => {
+      // 与启动检测一致受 check_enabled 控制：关闭时不发起请求，直接返回禁用结果。
+      if (!bootstrap.config.update.check_enabled) {
+        return Promise.resolve({
+          ok: false,
+          hasUpdate: false,
+          currentVersion: app.getVersion(),
+          error: 'update check disabled by config',
+        });
+      }
+      return checkForUpdate(app.getVersion(), bootstrap.config.proxy);
+    },
   );
   ipcMain.handle(
     'app:openExternal',

--- a/apps/desktop/src/main/utils/update-check.ts
+++ b/apps/desktop/src/main/utils/update-check.ts
@@ -17,9 +17,14 @@ interface ParsedVersion {
   pre: string[];
 }
 
-/** 解析 `v1.2.3` / `1.2.3-alpha.2` → 结构；解析不出返回 null。 */
+/**
+ * 解析 `v1.2.3` / `1.2.3-alpha.2` → 结构；解析不出返回 null。
+ * 整体锚定匹配（`$` 结尾）+ 先剥离 build metadata（`+...`），避免 `1.2.3beta` / `1.2.3.4`
+ * 这类「前缀像 semver」的串被当成 1.2.3 误判。
+ */
 function parseVersion(raw: string): ParsedVersion | null {
-  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(raw.trim());
+  const trimmed = raw.trim().split('+', 1)[0]!;
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.exec(trimmed);
   if (!m) return null;
   return {
     core: [Number(m[1]), Number(m[2]), Number(m[3])],
@@ -59,6 +64,8 @@ interface GithubRelease {
   tag_name?: string;
   html_url?: string;
   published_at?: string;
+  prerelease?: boolean;
+  draft?: boolean;
 }
 
 /**
@@ -87,12 +94,17 @@ export async function checkForUpdate(
       signal: ctrl.signal,
       headers: {
         Accept: 'application/vnd.github+json',
-        // GitHub API 要求 UA；用产品标识
-        'User-Agent': `${REPO}-updater`,
+        // GitHub API 要求 UA；用内部代号（OWNER/REPO 是真实仓库路径，属对外内容，保留）
+        'User-Agent': 'meebox-updater',
       },
     });
     if (!res.ok) return fail(`GitHub API ${String(res.status)}`);
     const data = (await res.json()) as GithubRelease;
+    // 只提示正式版：/releases/latest 本就排除 prerelease/draft；此处再防御一道，
+    // 万一拿到 prerelease/draft 一律视为「无更新」，不引导用户升到预发布。
+    if (data.prerelease || data.draft) {
+      return { ok: true, hasUpdate: false, currentVersion };
+    }
     const tag = data.tag_name;
     if (!tag) return fail('Release 缺少 tag_name');
     const latest = parseVersion(tag);

--- a/apps/desktop/src/main/utils/update-check.ts
+++ b/apps/desktop/src/main/utils/update-check.ts
@@ -1,0 +1,114 @@
+// 版本更新检测（仅检测 + 提示，不下载 / 安装）。查 GitHub Releases 最新**稳定版**
+// （/releases/latest 天然排除 prerelease/alpha），与当前版本做 semver 比对。
+// 走配置的出站代理（企业内网友好）；匿名 GitHub API（低频，启动 + 手动），无需 token。
+
+import type { ProxyConfig, UpdateCheckResult } from '@meebox/shared';
+import { proxyFetchForHost } from './proxy.js';
+
+const OWNER = 'huhamhire';
+const REPO = 'code-meeseeks';
+const API_HOST = 'api.github.com';
+const LATEST_URL = `https://${API_HOST}/repos/${OWNER}/${REPO}/releases/latest`;
+const TIMEOUT_MS = 8000;
+
+interface ParsedVersion {
+  core: [number, number, number];
+  /** 预发布标识（`-` 之后），稳定版为空数组 */
+  pre: string[];
+}
+
+/** 解析 `v1.2.3` / `1.2.3-alpha.2` → 结构；解析不出返回 null。 */
+function parseVersion(raw: string): ParsedVersion | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(raw.trim());
+  if (!m) return null;
+  return {
+    core: [Number(m[1]), Number(m[2]), Number(m[3])],
+    pre: m[4] ? m[4].split('.') : [],
+  };
+}
+
+/** semver 比较：返回 a-b 的符号（1 / 0 / -1）。预发布优先级低于同核心的正式版。 */
+function compareVersion(a: ParsedVersion, b: ParsedVersion): number {
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i]! !== b.core[i]!) return a.core[i]! > b.core[i]! ? 1 : -1;
+  }
+  // 核心相同：有 pre < 无 pre
+  if (a.pre.length === 0 && b.pre.length === 0) return 0;
+  if (a.pre.length === 0) return 1;
+  if (b.pre.length === 0) return -1;
+  // 都有 pre：逐段比较（数字段按数值，否则按字典序）
+  const n = Math.max(a.pre.length, b.pre.length);
+  for (let i = 0; i < n; i++) {
+    const x = a.pre[i];
+    const y = b.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      const d = Number(x) - Number(y);
+      if (d !== 0) return d > 0 ? 1 : -1;
+    } else if (x !== y) {
+      return x > y ? 1 : -1;
+    }
+  }
+  return 0;
+}
+
+interface GithubRelease {
+  tag_name?: string;
+  html_url?: string;
+  published_at?: string;
+}
+
+/**
+ * 检测是否有新版本。任何网络 / 解析失败都收敛成 ok=false + error，不抛。
+ */
+export async function checkForUpdate(
+  currentVersion: string,
+  proxy: ProxyConfig,
+): Promise<UpdateCheckResult> {
+  const fail = (error: string): UpdateCheckResult => ({
+    ok: false,
+    hasUpdate: false,
+    currentVersion,
+    error,
+  });
+
+  const current = parseVersion(currentVersion);
+  if (!current) return fail(`无法解析当前版本号：${currentVersion}`);
+
+  // 代理感知 fetch（命中本地/代理关闭则用全局 fetch 直连）
+  const doFetch = proxyFetchForHost(proxy, API_HOST) ?? fetch;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await doFetch(LATEST_URL, {
+      signal: ctrl.signal,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        // GitHub API 要求 UA；用产品标识
+        'User-Agent': `${REPO}-updater`,
+      },
+    });
+    if (!res.ok) return fail(`GitHub API ${String(res.status)}`);
+    const data = (await res.json()) as GithubRelease;
+    const tag = data.tag_name;
+    if (!tag) return fail('Release 缺少 tag_name');
+    const latest = parseVersion(tag);
+    if (!latest) return fail(`无法解析最新版本号：${tag}`);
+    const hasUpdate = compareVersion(latest, current) > 0;
+    return {
+      ok: true,
+      hasUpdate,
+      currentVersion,
+      latestVersion: tag.replace(/^v/, ''),
+      url: data.html_url,
+      publishedAt: data.published_at,
+    };
+  } catch (e) {
+    return fail(e instanceof Error ? e.message : String(e));
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import type {
   PrAgentStatus,
   PrDiscoveryFilter,
   StoredPullRequest,
+  UpdateCheckResult,
 } from '@meebox/shared';
 import { invoke, subscribe } from './api';
 import { ChatPane, CHAT_MAX_WIDTH, CHAT_MIN_WIDTH } from './components/ChatPane';
@@ -38,6 +39,8 @@ export default function App() {
   const [merging, setMerging] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [fatalError, setFatalError] = useState<string | null>(null);
+  // 启动检测到的新版本（main 推 app:updateAvailable）；StatusBar 据此提示跳转下载。
+  const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);
   // 操作级 toast（审批 / 合并等远端动作失败时提示，区别于 fatalError 整屏报错）。
   // key 用随机数：同样文案连续触发也能重置自动消失计时器。
   const [toast, setToast] = useState<{ text: string; key: number } | null>(null);
@@ -158,6 +161,32 @@ export default function App() {
   useEffect(() => wireRepoSyncStore(), []);
   // M4 草稿事件 → store；写盘后 drafts:changed 触发指定 PR 的草稿列表自动刷新
   useEffect(() => wireDraftsStore(), []);
+  // 启动版本更新检测：main 仅在有新版时推 app:updateAvailable
+  useEffect(() => subscribe('app:updateAvailable', (info) => setUpdateInfo(info)), []);
+  // dev 调试钩子：控制台 dispatch CustomEvent 模拟「发现新版」以验证状态栏 chip
+  // （dev 版本通常高于 latest，自然不会触发）。detail=null 清除。
+  //   window.dispatchEvent(new CustomEvent('meebox:debug-update'))
+  //   window.dispatchEvent(new CustomEvent('meebox:debug-update', { detail: { latestVersion: '1.2.3' } }))
+  //   window.dispatchEvent(new CustomEvent('meebox:debug-update', { detail: null }))
+  useEffect(() => {
+    const onDebug = (e: Event): void => {
+      const d = (e as CustomEvent<Partial<UpdateCheckResult> | null>).detail;
+      setUpdateInfo(
+        d === null
+          ? null
+          : {
+              ok: true,
+              hasUpdate: true,
+              currentVersion: '0.0.0',
+              latestVersion: '9.9.9',
+              url: 'https://github.com/huhamhire/code-meeseeks/releases/latest',
+              ...d,
+            },
+      );
+    };
+    window.addEventListener('meebox:debug-update', onDebug);
+    return () => window.removeEventListener('meebox:debug-update', onDebug);
+  }, []);
 
   // 全局外链跳转防护 — 所有 UGC 场景 (评论 / PR 描述 / finding / chat 等) 内
   // 的 <a href="http(s)://"> 点击都走系统默认浏览器，不允许 Electron 在 app
@@ -416,6 +445,7 @@ export default function App() {
           setBoot((b) => (b ? { ...b, config: { ...b.config, llm: next } } : b));
         }}
         onJumpToPr={setSelectedId}
+        updateInfo={updateInfo}
       />
       {showSettings && (
         <SettingsModal

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -621,6 +621,7 @@ export function SettingsModal({
               <button
                 className="btn"
                 type="button"
+                style={{ marginLeft: 'auto' }}
                 onClick={() => void invoke('app:openDevTools', undefined)}
                 title="打开 Electron 开发者工具（分离窗口）"
               >

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -617,7 +617,7 @@ export function SettingsModal({
               <div className="modal-kv-val">{info.platform}</div>
             </div>
             <div className="settings-actions" style={{ marginTop: 10, alignItems: 'center' }}>
-              <UpdateCheckButton />
+              <UpdateCheckButton enabled={config.update.check_enabled} />
               <button
                 className="btn"
                 type="button"
@@ -705,10 +705,21 @@ export function SettingsModal({
   );
 }
 
-/** 「检查更新」按钮（运行环境段）：手动查 GitHub 最新版，自管 loading + 结果展示。 */
-function UpdateCheckButton() {
+/** 「检查更新」按钮（运行环境段）：手动查 GitHub 最新版，自管 loading + 结果展示。
+ *  enabled=false（config.update.check_enabled 关闭）时禁用按钮并提示，不发起检测。 */
+function UpdateCheckButton({ enabled }: { enabled: boolean }) {
   const [checking, setChecking] = useState(false);
   const [result, setResult] = useState<UpdateCheckResult | null>(null);
+  if (!enabled) {
+    return (
+      <>
+        <button className="btn" type="button" disabled title="更新检测已在配置中关闭">
+          检查更新
+        </button>
+        <span className="muted">更新检测已在配置中关闭（config.yaml `update.check_enabled`）</span>
+      </>
+    );
+  }
   const run = async (): Promise<void> => {
     setChecking(true);
     try {

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type CSSProperties } from 'react';
-import type { AppInfo, AppPaths, Config, LlmProfile } from '@meebox/shared';
+import type { AppInfo, AppPaths, Config, LlmProfile, UpdateCheckResult } from '@meebox/shared';
 import { invoke } from '../api';
 import { ConfirmModal } from './ConfirmModal';
 import {
@@ -616,7 +616,8 @@ export function SettingsModal({
               <div className="modal-kv-key">平台</div>
               <div className="modal-kv-val">{info.platform}</div>
             </div>
-            <div className="settings-actions" style={{ marginTop: 10 }}>
+            <div className="settings-actions" style={{ marginTop: 10, alignItems: 'center' }}>
+              <UpdateCheckButton />
               <button
                 className="btn"
                 type="button"
@@ -701,6 +702,57 @@ export function SettingsModal({
         />
       )}
     </div>
+  );
+}
+
+/** 「检查更新」按钮（运行环境段）：手动查 GitHub 最新版，自管 loading + 结果展示。 */
+function UpdateCheckButton() {
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<UpdateCheckResult | null>(null);
+  const run = async (): Promise<void> => {
+    setChecking(true);
+    try {
+      setResult(await invoke('app:checkUpdate', undefined));
+    } catch (e) {
+      setResult({
+        ok: false,
+        hasUpdate: false,
+        currentVersion: '',
+        error: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setChecking(false);
+    }
+  };
+  return (
+    <>
+      <button
+        className="btn"
+        type="button"
+        onClick={() => void run()}
+        disabled={checking}
+        title="查 GitHub 最新版本（仅检测，不自动安装）"
+      >
+        {checking ? '检查中…' : '检查更新'}
+      </button>
+      {result &&
+        !checking &&
+        (result.ok ? (
+          result.hasUpdate ? (
+            <button
+              className="btn btn-sm"
+              type="button"
+              onClick={() => result.url && void invoke('app:openExternal', { url: result.url })}
+            >
+              ↑ 新版本 v{result.latestVersion} · 前往下载
+            </button>
+          ) : (
+            <span className="muted">已是最新版</span>
+          )
+        ) : (
+          <span className="error-text">检查失败：{result.error}</span>
+        ))}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { Config, ConnectionSummary, PrAgentStatus } from '@meebox/shared';
+import type { Config, ConnectionSummary, PrAgentStatus, UpdateCheckResult } from '@meebox/shared';
 import { invoke } from '../api';
 import { useChatRunStore } from '../stores/chat-run-store';
 import { useRepoSyncStore } from '../stores/repo-sync-store';
@@ -32,6 +32,8 @@ interface StatusBarProps {
    * 不可点击。父组件传 `setSelectedId` 即可
    */
   onJumpToPr?: (localId: string) => void;
+  /** 启动检测到的新版本；非空且 hasUpdate 时展示「新版本」chip，点击跳转下载页。 */
+  updateInfo?: UpdateCheckResult | null;
 }
 
 export function StatusBar({
@@ -49,6 +51,7 @@ export function StatusBar({
   onOpenSettings,
   onSwitchActiveLlm,
   onJumpToPr,
+  updateInfo,
 }: StatusBarProps) {
   return (
     <footer className="app-statusbar" role="contentinfo">
@@ -82,6 +85,16 @@ export function StatusBar({
           信息。pr-agent 不可用时不显示 (上方 PrAgentChip 已经红色提示) */}
       {prAgent?.available && <PrAgentActiveChip onJumpToPr={onJumpToPr} />}
       <LlmChip llm={llm} onSwitch={onSwitchActiveLlm} onOpenSettings={onOpenSettings} />
+      {updateInfo?.hasUpdate && updateInfo.url && (
+        <button
+          type="button"
+          className="statusbar-chip statusbar-chip-update"
+          title={`发现新版本 v${updateInfo.latestVersion ?? ''}（当前 v${updateInfo.currentVersion}）· 点击前往下载`}
+          onClick={() => void invoke('app:openExternal', { url: updateInfo.url! })}
+        >
+          ↑ 新版本 v{updateInfo.latestVersion}
+        </button>
+      )}
       <button
         type="button"
         className="icon-btn"

--- a/apps/desktop/src/renderer/src/styles/statusbar.scss
+++ b/apps/desktop/src/renderer/src/styles/statusbar.scss
@@ -17,10 +17,21 @@
 .statusbar-chip {
   background: $border-default;
   color: $text-primary;
-  padding: 1px $space-3;
-  border-radius: $radius-sm;
+  // 按钮型 chip（LLM / 更新 / pragent 等）默认不继承字体、且带 UA 边框，会比 span 型
+  // chip 略高。在基类统一继承字体 + 去边框，保证所有 chip 同字体同高；各 chip 仅在此
+  // 基础上叠加配色 / cursor。
+  font: inherit;
   font-size: $fs-xs;
   font-weight: 600;
+  border: none;
+  // 固定高度 + flex 居中：CJK / 箭头等高字形不再撑高行盒，所有 chip 等高且紧凑
+  // （16px ≈ 原 latin chip 高度，11px 字号居中不裁切 CJK）。
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  box-sizing: border-box;
+  padding: 0 $space-3;
+  border-radius: $radius-sm;
   white-space: nowrap;
 }
 
@@ -28,6 +39,18 @@
 .statusbar-chip-ok {
   background: $color-success;
   color: $text-on-accent;
+}
+
+// 新版本提示 chip：强调蓝底，点击跳转下载页
+.statusbar-chip-update {
+  background: $color-accent;
+  color: $text-on-accent;
+  cursor: pointer;
+  border: none;
+
+  &:hover {
+    filter: brightness(1.1);
+  }
 }
 
 // PR 数 chip：图标 + 数字横排，svg 跟数字基线对齐

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -156,3 +156,13 @@ localStorage.removeItem('meebox.forceOnboarding'); location.reload();
 ### 首启向导里打开 DevTools
 
 首启向导没有菜单 / 状态栏入口。欢迎页（第 1 步）**连续点击 logo 7 次**（每次间隔 < 800ms）即可打开 DevTools，用于在向导阶段排障。
+
+### 模拟「发现新版本」状态栏 chip
+
+dev 版本通常高于线上 latest，自然不会触发更新提示。在 DevTools Console 模拟以验证状态栏 chip：
+
+```js
+window.dispatchEvent(new CustomEvent('meebox:debug-update')); // 显示 v9.9.9
+window.dispatchEvent(new CustomEvent('meebox:debug-update', { detail: { latestVersion: '1.2.3' } })); // 自定义版本号
+window.dispatchEvent(new CustomEvent('meebox:debug-update', { detail: null })); // 清除
+```

--- a/packages/shared/src/app-info.ts
+++ b/packages/shared/src/app-info.ts
@@ -38,3 +38,22 @@ export interface AppInfo {
   /** ~/.code-meeseeks was newly created on this run */
   firstRun: boolean;
 }
+
+/**
+ * 版本更新检测结果。仅检测 + 提示，不自动下载 / 安装。
+ * - ok=false：检测未完成（网络 / 解析失败），error 给原因；hasUpdate 恒 false。
+ * - ok=true：检测完成；hasUpdate 表示是否有更新版本。
+ */
+export interface UpdateCheckResult {
+  ok: boolean;
+  hasUpdate: boolean;
+  currentVersion: string;
+  /** 最新稳定版版本号（ok=true 时给出） */
+  latestVersion?: string;
+  /** 最新版 Release 页 URL（hasUpdate=true 时给出，供用户手动下载） */
+  url?: string;
+  /** 最新版发布时间 ISO（可选） */
+  publishedAt?: string;
+  /** ok=false 时的失败原因 */
+  error?: string;
+}

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -148,6 +148,15 @@ export const ConfigSchema = z.object({
   /** 出站网络代理。默认关闭 = 全部直连，等同历史行为。 */
   proxy: ProxySchema.default({}),
   /**
+   * 版本更新检测。启动时（及设置页手动）查 GitHub Releases 最新稳定版与当前版本比对，
+   * 有新版仅**提示**用户去下载（不自动下载 / 安装）。check_enabled=false 关闭检测。
+   */
+  update: z
+    .object({
+      check_enabled: z.boolean().default(true),
+    })
+    .default({}),
+  /**
    * pr-agent 运行时策略选择。
    * - 'auto'（默认）：优先嵌入式运行时（随 app 打包，正常安装恒可用），缺失则
    *   回退探测系统 local-cli；

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,4 +1,4 @@
-import type { AppInfo, AppPaths } from './app-info.js';
+import type { AppInfo, AppPaths, UpdateCheckResult } from './app-info.js';
 import type { Config } from './config.js';
 import type {
   PingResult,
@@ -126,6 +126,8 @@ export interface IpcEvents {
     active: PragentRunInfo[];
     waiting: PragentRunInfo[];
   };
+  /** 启动检测到新版本时推送（仅 hasUpdate=true 时发），renderer 据此提示。 */
+  'app:updateAvailable': UpdateCheckResult;
 }
 
 export type IpcEventName = keyof IpcEvents;
@@ -155,6 +157,8 @@ export interface IpcChannels {
   'app:openConfigFile': { request: void; response: void };
   /** 打开 Electron DevTools（分离窗口） */
   'app:openDevTools': { request: void; response: void };
+  /** 手动检测版本更新（设置页「检查更新」）。仅检测 + 返回结果，不下载 / 安装。 */
+  'app:checkUpdate': { request: void; response: UpdateCheckResult };
   /**
    * 渲染层日志回传：把渲染进程的错误 / 未捕获异常转发到 main，落进同一份 meebox.log
    * （renderer 自己的 console 不进文件）。preload 装 window.onerror / unhandledrejection


### PR DESCRIPTION
启动时（及设置页「检查更新」）查 GitHub Releases 最新稳定版与当前版本 semver 比对，有新版**仅提示**用户去下载（不下载 / 不安装）。

> 设计取舍：macOS 当前 ad-hoc 签名无法走 Squirrel 自动更新（需 Apple Developer ID + 公证），故先做跨平台一致、零签名依赖的**检测层**；将来若购置签名再上全量自动更新（electron-updater）。

## 改动

- **shared**：`config.update.check_enabled`；`UpdateCheckResult` 类型；IPC `app:checkUpdate` + 事件 `app:updateAvailable`。
- **main**：`update-check`（查 `/releases/latest` 排除 prerelease、**走配置出站代理**内网友好、8s 超时、失败收敛不抛、匿名 API 无需 token）；启动首帧后异步检测，有新版才推事件。
- **渲染层**：状态栏「↑ 新版本 vX」chip（点击 `openExternal` 跳下载页）；设置页运行环境段「检查更新」按钮 + 结果（已是最新 / 可跳转 / 失败）；App 加 `meebox:debug-update` 控制台调试钩子。
- **statusbar.scss**：chip 基类统一字体继承 + 固定 16px 高 + flex 居中，消除 CJK / 按钮字形导致的高度不一。
- **docs**：开发指南补「模拟新版本 chip」调试说明。

## 验证

- `lint` / `typecheck` / `test` / `build` 全绿。
- 手动（dev 版本高于 latest 不会自然触发）：DevTools Console `window.dispatchEvent(new CustomEvent('meebox:debug-update'))` → 状态栏出现新版本 chip，点击跳转下载页；`{ detail: null }` 清除。设置页「检查更新」返回真实结果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)