### PR TITLE
feat(pragent): 启用 /improve 指令（逐行代码改进建议）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   文件走查保留多级分类、每个分类独立成可收起/展开的折叠块（去掉无意义的 +1/-1 统计）；
   mermaid 图点击进入模态预览，支持滚轮缩放、拖拽平移与「适应窗口」，预览区为固定纯色背景。
 - **清空执行历史**：chat 面板标题栏新增垃圾桶按钮，清空**当前 PR**的 PR Agent 执行历史记录（仅该 PR）。
+- **启用 `/improve` 指令**：逐行代码改进建议（带 1-10 重要度评分）。依托 shim 的 GFM 支持走
+  「汇总建议」路径（committable/inline 模式在本地 provider 下不可用，已显式关死兜底）；输出落
+  独立 `improve.md` 与 `/review` 分流（经 `local.review_path` 原生配置）；关闭 persistent_comment
+  避免本地 provider 翻历史评论刷无意义 traceback。
 
 ## [0.2.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Code Meeseeks（内部开发代号 `meebox`）是命令行工具 [pr-agent](http
 - 🔌 **开箱即用，零外部依赖** —— 安装包内嵌可重定位的 Python 运行时 + 固定版本 pr-agent，**无需自行安装 Python 或 Docker**。
 - 📥 **PR 自动发现** —— 轮询拉取评审者待评审的 Open PR，按仓库分组、状态过滤、搜索。
 - 🔍 **本地 Diff 阅读** —— Monaco 并排 / 内联 diff、文件树、行内评论、blame、跨文件代码搜索。
-- 🤖 **AI 评审** —— `/describe`、`/review`、`/ask` 对话式驱动 pr-agent，结果结构化成可操作的 findings。
+- 🤖 **AI 评审** —— `/describe`、`/review`、`/improve`、`/ask` 对话式驱动 pr-agent，结果结构化成可操作的 findings。
 - 📐 **个性化规则** —— 每位 Reviewer 维护自己的规则目录（markdown + frontmatter），按项目 / 仓库 / 目标分支命中后注入评审。
 - ✍️ **确认 → 发布闭环** —— finding 转草稿，行内编辑，单条 / 批量发布到远端；自己的评论支持回复 / 编辑 / 删除。
 - 🔀 **合并状态** —— 展示远端可合并状态，满足条件时一键合并。

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -813,6 +813,21 @@ export function registerIpcHandlers({
           ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
           CONFIG__RESPONSE_LANGUAGE: bootstrap.config.language,
         };
+        if (req.tool === 'improve') {
+          // /improve 在 local provider 下只有「汇总建议 → publish_comment」一条可用路径
+          // （shim 已强制 gfm_markdown=True）。committable/inline 模式会走
+          // publish_code_suggestions → local provider 直接 NotImplementedError，显式关死兜底
+          // （pr-agent 默认即 false，此处防上游翻默认值）。
+          env['PR_CODE_SUGGESTIONS__COMMITABLE_CODE_SUGGESTIONS'] = 'false';
+          // persistent_comment（默认 true）会走 publish_persistent_comment_with_history →
+          // get_issue_comments() 翻历史评论做增量更新 → local provider 不实现，每次 improve
+          // 都刷一段 NotImplementedError traceback（被上游捕获后兜底 publish_comment，正文
+          // 不丢但日志吵）。local 每次都是全新 worktree、无历史可翻，直接关掉走 publish_comment。
+          env['PR_CODE_SUGGESTIONS__PERSISTENT_COMMENT'] = 'false';
+          // 输出与 /review /ask 的 review.md 分流：pr-agent 原生支持 local.review_path 覆盖
+          // publish_comment 的落盘路径；相对路径按子进程 cwd（= worktree 根）解析。
+          env['LOCAL__REVIEW_PATH'] = 'improve.md';
+        }
 
         // 注给 pr-agent 的 EXTRA_INSTRUCTIONS 由三部分按顺序拼接：
         //   1. 语言指示：CONFIG__RESPONSE_LANGUAGE 对 /describe /review 够用，但
@@ -989,10 +1004,15 @@ export function registerIpcHandlers({
         //   /describe → <wt>/description.md  (走 publish_description)
         //   /review   → <wt>/review.md       (走 publish_comment)
         //   /ask      → <wt>/review.md       ← 共用同一文件 (publish_comment 会覆盖)
-        //   /improve  → <wt>/review.md       ← 同上：local provider 不实现
-        //                                      publish_code_suggestions，汇总走 publish_comment
+        //   /improve  → <wt>/improve.md      ← 汇总建议走 publish_comment，经 LOCAL__REVIEW_PATH
+        //                                      重定向与 review.md 分流（见上方 env 注入）
         // 走 worktree 路径，cleanup 前必须先把文件读出来。
-        const outFile = req.tool === 'describe' ? 'description.md' : 'review.md';
+        const outFile =
+          req.tool === 'describe'
+            ? 'description.md'
+            : req.tool === 'improve'
+              ? 'improve.md'
+              : 'review.md';
         let fileContent = '';
         try {
           fileContent = await fs.readFile(path.join(wt.path, outFile), 'utf8');

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -621,11 +621,10 @@ const COMMANDS: ReadonlyArray<CommandSpec> = [
   // pr-agent
   { kind: 'pragent', name: 'review', label: '/review', desc: '代码评审', insertAs: '/review' },
   { kind: 'pragent', name: 'describe', label: '/describe', desc: '生成 PR 描述', insertAs: '/describe' },
-  // /improve 暂屏蔽：实测 pr-agent 的 improve 工具依赖在线平台 (GitHub / GitLab /
-  // Bitbucket Cloud) 的 inline code suggestion / best practices 集成，跟 meebox
-  // 本地 PR 管理路径不兼容。后端类型 / parser / IPC 仍保留，等策略变化或上游
-  // 支持 local provider 时直接放开
-  // { kind: 'pragent', name: 'improve', label: '/improve', desc: '逐行代码改进建议', insertAs: '/improve' },
+  // /improve：shim 强制 gfm_markdown=True 后，improve 走「汇总建议 → publish_comment →
+  // review.md」路径（非 committable，inline 模式仍不可用），parse-output 按
+  // generate_summarized_suggestions 的 <details> 模板解析出带重要度评分的 finding。
+  { kind: 'pragent', name: 'improve', label: '/improve', desc: '逐行代码改进建议', insertAs: '/improve' },
   { kind: 'pragent', name: 'ask', label: '/ask', desc: '自然语言追问', insertAs: '/ask ' },
   // review 决断 (跟 PR header 按钮共用 prs:setLocalStatus，写 Bitbucket reviewer status)
   {
@@ -1982,6 +1981,9 @@ function ChatEmpty({
         </Bullet>
         <Bullet>
           <code>/review</code> 跑一次 AI review，结果落到 findings 列表
+        </Bullet>
+        <Bullet>
+          <code>/improve</code> 逐行代码改进建议（带重要度评分）
         </Bullet>
         <Bullet>
           <code>/ask &lt;问题&gt;</code> 自然语言追问 (或直接打字，自动当 ask)


### PR DESCRIPTION
## 启用 `/improve` 指令

原屏蔽理由（improve 依赖在线平台的 inline suggestion 集成）已被 shim 的 GFM 支持化解：`gfm_markdown=True` 下 improve 走「汇总建议 → publish_comment」路径，本地 provider 可用。parse-output 既有的 `/improve` 专用解析与 ChatPane 重要度渲染随之生效。

### 改动

- **ChatPane**：放开 `/improve` 命令补全项；空态欢迎列表补 `/improve`。
- **ipc**（improve 专属 env）：
  - `PR_CODE_SUGGESTIONS__COMMITABLE_CODE_SUGGESTIONS=false`——committable/inline 模式在本地 provider 下为 NotImplementedError，显式关死兜底。
  - `PR_CODE_SUGGESTIONS__PERSISTENT_COMMENT=false`——persistent 路径翻历史评论在本地 provider 下每次刷无害但吵闹的 traceback；本地每次都是全新 worktree、无历史可翻，关掉直走 publish_comment。
  - `LOCAL__REVIEW_PATH=improve.md`——输出与 `/review` `/ask` 的 review.md 分流（pr-agent 原生 `local.review_path` 配置）；读取侧按 tool 选 improve.md。
- **README / CHANGELOG**：能力行与 Unreleased 同步。

### 验证

- typecheck / lint / build 全绿。
- 真机：`/improve` 输出落 `improve.md`、建议带 1-10 重要度渲染；persistent traceback 消除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
