### PR TITLE
feat(pragent): /describe 增加「思路建议」段（替代方案 + 推荐）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   「汇总建议」路径（committable/inline 模式在本地 provider 下不可用，已显式关死兜底）；输出落
   独立 `improve.md` 与 `/review` 分流（经 `local.review_path` 原生配置）；关闭 persistent_comment
   避免本地 provider 翻历史评论刷无意义 traceback。
+- **/describe 思路建议段**：shim 往 describe prompt 注入 `assessment` 字段，让社区版 `/describe`
+  额外产出「思路建议」段——2-4 个替代实现方案（各自折叠）+ 倾向性推荐，对齐 Qodo Merge 的
+  High-Level Assessment（社区版原生无此字段）。pr-agent 通用渲染成段、parse-output 映射 sectionKey，
+  英文结构串经渲染期翻译表中文化，chip 配主蓝（信息性）色。
 
 ## [0.2.0] - 2026-06-09
 

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/__init__.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/__init__.py
@@ -7,6 +7,7 @@
 所有对 pr-agent 行为的改造集中在本包，上游源码保持原封。每个补丁用 try/except 包裹（见
 runtime._register_post_import），打不上则静默降级，绝不让 shim 异常阻断流程。
 """
+from .patches.describe_assessment import patch as _patch_describe_assessment
 from .patches.litellm_handler import patch as _patch_litellm_handler
 from .patches.load_yaml import patch as _patch_load_yaml
 from .patches.local_git_provider import patch as _patch_local_git_provider
@@ -29,5 +30,10 @@ def apply() -> None:
     _register_post_import(
         "pr_agent.algo.utils",
         _patch_load_yaml,
+    )
+    # /describe 思路建议：往 describe prompt 注入 assessment 字段，产出「替代方案 + 倾向性建议」段。
+    _register_post_import(
+        "pr_agent.tools.pr_description",
+        _patch_describe_assessment,
     )
     _debug("meebox shim loaded")

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/describe_assessment.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/describe_assessment.py
@@ -1,0 +1,60 @@
+"""describe 增强（受版本守卫）：往 /describe 的 prompt schema 注入一个 assessment 字段，
+让社区版 /describe 产出「思路建议（替代实现方案 + 倾向性建议）」段——对齐 Qodo Merge 的
+High-Level Assessment（社区版原生无此字段）。
+
+无需改渲染：pr_description._prepare_pr_answer 对未知 key 走通用 `### **Key**` 分支，
+assessment 会自动渲染成 `### **Assessment**` 段进 description.md，由 app 的 parse-output
+按表头映射为 sectionKey='assessment'。
+
+注入方式：运行期改写 get_settings().pr_description_prompt.system（dynaconf set）。锚点是
+schema 里 title 字段尾 + 示例输出 title 之后；锚点缺失则跳过（版本漂移安全降级）。
+"""
+from ..runtime import _EXPECTED_PRAGENT_VERSION, _debug, _pragent_version
+
+# 紧跟 PRDescription schema 的 title 字段之后插入（锚定 title 字段行尾的唯一子串）
+_SCHEMA_ANCHOR = 'that captures the PR\'s main theme")'
+_SCHEMA_FIELD = (
+    '\n    assessment: str = Field(description="A high-level assessment in GFM markdown, mirroring '
+    "this exact structure: (1) the intro line \\'The following are alternative approaches to this PR:\\'; "
+    "(2) then 2-4 plausible ALTERNATIVE implementation approaches, EACH formatted as a <details> block "
+    "with BLANK LINES inside so the body is parsed as markdown (this exact layout, blank lines required): "
+    "a line '<details><summary>N. concise PLAIN-TEXT approach title (NO backticks or markdown inside the "
+    "summary)</summary>', then a blank line, then 1-3 sentences explaining the approach and its main "
+    "trade-off (you MAY use `inline code` for identifiers in this body), then a blank line, then the line "
+    "'</details>'; (3) after the last </details> leave ONE blank line, then a paragraph starting with "
+    "**Recommendation:** that compares the current approach against the alternatives and recommends one. "
+    'Be objective and specific to this PR. Leave empty for trivial changes.")'
+)
+
+# 紧跟示例输出的 title 之后插入（best-effort，缺失不致命）
+_EXAMPLE_ANCHOR = "title: |\n  ...\n"
+_EXAMPLE_FIELD = "assessment: |\n  ...\n"
+
+
+def patch(module) -> None:
+    installed = _pragent_version()
+    if installed != _EXPECTED_PRAGENT_VERSION:
+        _debug(f"skip describe assessment patch: pr-agent {installed} != {_EXPECTED_PRAGENT_VERSION}")
+        return
+    from pr_agent.config_loader import get_settings
+
+    try:
+        settings = get_settings()
+        prompt = settings.pr_description_prompt.system
+    except Exception as exc:  # noqa: BLE001
+        _debug(f"describe assessment: 读取 prompt 失败（跳过）: {exc}")
+        return
+    if not isinstance(prompt, str) or "assessment:" in prompt or "assessment: str" in prompt:
+        return  # 已注入 / 形态异常 → 幂等跳过
+    if _SCHEMA_ANCHOR not in prompt:
+        _debug("describe assessment: schema 锚点未命中（版本漂移），跳过")
+        return
+    new = prompt.replace(_SCHEMA_ANCHOR, _SCHEMA_ANCHOR + _SCHEMA_FIELD, 1)
+    if _EXAMPLE_ANCHOR in new:
+        new = new.replace(_EXAMPLE_ANCHOR, _EXAMPLE_ANCHOR + _EXAMPLE_FIELD, 1)
+    try:
+        settings.set("pr_description_prompt.system", new)
+    except Exception as exc:  # noqa: BLE001
+        _debug(f"describe assessment: 写回 prompt 失败（跳过）: {exc}")
+        return
+    _debug("describe assessment field injected into /describe prompt")

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -1691,14 +1691,15 @@ const SECTION_ORDER: Record<PrDocSectionKey, number> = {
   summary: 2,
   description: 3,
   diagram: 4,
-  walkthrough: 5,
-  'relevant-tests': 6,
-  security: 7,
-  'code-feedback': 8,
-  'code-suggestion': 8, // 跟 code-feedback 一组，UI 顺序无优先关系
-  effort: 9,
-  score: 10,
-  general: 11,
+  assessment: 5, // 思路建议紧随架构图（对齐 Qodo：Description → Diagram → Assessment）
+  walkthrough: 6,
+  'relevant-tests': 7,
+  security: 8,
+  'code-feedback': 9,
+  'code-suggestion': 9, // 跟 code-feedback 一组，UI 顺序无优先关系
+  effort: 10,
+  score: 11,
+  general: 12,
 };
 const SECTION_LABEL: Record<PrDocSectionKey, string> = {
   title: '建议标题',
@@ -1706,6 +1707,7 @@ const SECTION_LABEL: Record<PrDocSectionKey, string> = {
   summary: '总结',
   description: '描述',
   diagram: '架构图',
+  assessment: '思路建议',
   walkthrough: '文件变更',
   'relevant-tests': '相关测试',
   security: '安全',

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -512,6 +512,7 @@
   &.chat-finding-title,
   &.chat-finding-pr-type,
   &.chat-finding-diagram,
+  &.chat-finding-assessment,
   &.chat-finding-effort {
     border-left-color: $color-info;
   }
@@ -551,6 +552,7 @@
   &.chat-finding-cat-title,
   &.chat-finding-cat-pr-type,
   &.chat-finding-cat-diagram,
+  &.chat-finding-cat-assessment,
   &.chat-finding-cat-effort {
     background: $color-accent-bg-fade;
     color: $color-info;

--- a/apps/desktop/src/renderer/src/utils/translate-pr-agent.ts
+++ b/apps/desktop/src/renderer/src/utils/translate-pr-agent.ts
@@ -83,6 +83,12 @@ export const PR_AGENT_TRANSLATIONS_ZH: ReadonlyMap<string, string> = new Map([
   ['Lines:', '行号：'],
   ['Relevant file:', '相关文件：'],
   ['Relevant lines:', '相关行号：'],
+  // /describe 思路建议段（shim 注入的固定英文结构串，内容值已随 response language 中文化，
+  // 这里把结构串也翻成中文，与其余 pr-agent 模板词同一套渲染期替换）
+  ['The following are alternative approaches to this PR:', '可考虑的其他实现思路：'],
+  ['The following are alternative approaches to this PR', '可考虑的其他实现思路'],
+  ['Recommendation:', '推荐方案：'],
+  ['Recommendation', '推荐方案'],
   // /describe 结构化标签
   ['PR Type', '类型'],
   ['Description', '描述'],

--- a/packages/poller/src/parse-output.ts
+++ b/packages/poller/src/parse-output.ts
@@ -146,6 +146,8 @@ const SECTION_KEY_PATTERNS: ReadonlyArray<readonly [RegExp, PrDocSectionKey]> = 
   [/^description$/i, 'description'],
   // "Diagram Walkthrough" → diagram（含 walkthrough 子串，故须排在 walkthrough 之前）
   [/diagram/i, 'diagram'],
+  // 注入的高层评估段（shim 给 describe schema 加 assessment 字段 → 渲染为 `### **Assessment**`）
+  [/^(?:high[\s_-]+level[\s_-]+)?assessment$/i, 'assessment'],
   [/^walkthrough$/i, 'walkthrough'],
   // 测试/安全段的 <strong> 文案随结论变化（pr-agent 模板硬编码，恒英文）：
   //   测试：Relevant tests / PR contains tests / No relevant tests[ found]

--- a/packages/shared/src/poller-contract.ts
+++ b/packages/shared/src/poller-contract.ts
@@ -64,6 +64,7 @@ export type PrDocSectionKey =
   | 'summary'           // /review 顶部总结
   | 'description'       // 主描述段
   | 'diagram'           // 架构图（changes_diagram，mermaid）
+  | 'assessment'        // 思路建议（注入字段：替代方案 + 倾向性建议，对齐 Qodo High-Level Assessment）
   | 'walkthrough'       // 文件级走查
   | 'relevant-tests'    // 相关测试
   | 'security'          // 安全发现


### PR DESCRIPTION
## /describe 增加「思路建议」段

对齐 Qodo Merge 的 **High-Level Assessment**(社区版 `/describe` 原生无此字段):shim 往 describe prompt 注入 `assessment` 字段,模型产出 **2-4 个替代实现方案**(各自 `<details>` 折叠)+ 一段**倾向性推荐**。借鉴的是 Qodo 的输出形态,非其专有 prompt。

### 改动

- **shim**(新 patch `describe_assessment`):运行期改写 `pr_description_prompt.system` 注入 `assessment` 字段(schema + 示例),受版本守卫、锚点缺失/已注入则安全跳过。`_prepare_pr_answer` 对未知 key 走通用 `### **Key**` 分支 → **无需改 pr-agent 渲染**,assessment 自动成段进 description.md。
- **parse-output**:表头 `Assessment` → `sectionKey='assessment'`。
- **shared**:`PrDocSectionKey` 增 `'assessment'`。
- **ChatPane**:`SECTION_ORDER`(紧随架构图)+ `SECTION_LABEL`「思路建议」(平和措辞,不与 `/improve` 的「改进建议」重名)。
- **i18n**:注入的固定英文结构串(intro / `Recommendation:`)经渲染期翻译表中文化。
- **样式**:`assessment` chip 归主蓝(信息性)色组。
- **prompt 排版**:`<details>` 内用空行包裹正文,使行内代码等 markdown 正常解析;末个 `</details>` 后空行再写推荐段,使粗体正常渲染。

### 验证

- embedded 冒烟确认字段注入进 prompt;typecheck / lint / build 全绿。
- 真机 `/describe`:已确认段出现、中文化、折叠 + chip 配色(见迭代截图)。

> 备注:格式依赖模型遵循空行排版指令;若后续偶发不规范,可加 parse-output 侧对 `assessment` 段的空行规整兜底(本 PR 暂未做)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
