### PR TITLE
fix(chat/diff): 行内评论体验统一（/improve 快捷操作 + 单换行渲染 + 删除行评论）

### DIFF
--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -322,11 +322,12 @@ export function ChatPane({
    */
   /**
    * 把 AI finding body 转成草稿初始 body：先 stripFindingMarker 去掉 [file:...]
-   * 末尾 marker，再加 `[AI 建议]` 前缀 — 让远端 reviewer 看到时知道这条评论
-   * 来自 pr-agent
+   * 末尾 marker，再把 pr-agent GFM 里的内联 HTML 标签归一成 markdown（草稿编辑器是
+   * 纯文本，裸 `<code>`/`<br>` 会露馅），最后加 `[AI 建议]` 前缀 — 让远端 reviewer
+   * 看到时知道这条评论来自 pr-agent
    */
   const buildDraftBodyFromFinding = (body: string): string =>
-    `[AI 建议] ${stripFindingMarker(body)}`;
+    `[AI 建议] ${htmlInlineToMarkdown(stripFindingMarker(body))}`;
 
   const handleJumpToDraft = async (finding: Finding, run: ReviewRun): Promise<void> => {
     if (!pr) return;
@@ -677,6 +678,23 @@ const CHAT_HISTORY_MAX = 5;
  */
 function stripFindingMarker(body: string): string {
   return body.replace(/\s*\[\s*file\s*:\s*[^\]]*?\]\s*$/i, '').trimEnd();
+}
+
+/**
+ * 把 pr-agent GFM 输出里的内联 HTML 标签归一成 markdown。finding 卡片走 ReactMarkdown
+ * (允许 HTML) 能正常渲染这些标签，但转成草稿正文落进编辑器 textarea / 发布到远端后，
+ * 裸 `<code>` `<br>` 不一定被渲染，会暴露成字面标签。这里把常见内联标签转成等价
+ * markdown：`<code>x</code>`→`` `x` ``、`<br>`→换行、`<b>/<strong>`→`**`、`<i>/<em>`→`*`。
+ * 空 `<code></code>` 直接丢弃，避免产出孤立的空反引号。
+ */
+function htmlInlineToMarkdown(text: string): string {
+  return text
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\s*code\s*>([\s\S]*?)<\s*\/\s*code\s*>/gi, (_, inner: string) =>
+      inner.trim() ? `\`${inner}\`` : '',
+    )
+    .replace(/<\s*(?:strong|b)\s*>([\s\S]*?)<\s*\/\s*(?:strong|b)\s*>/gi, '**$1**')
+    .replace(/<\s*(?:em|i)\s*>([\s\S]*?)<\s*\/\s*(?:em|i)\s*>/gi, '*$1*');
 }
 
 function loadChatHistory(): string[] {
@@ -1468,7 +1486,8 @@ function RunResultView({
 }
 
 /**
- * Finding card 上的草稿状态 chip + 操作按钮。仅 code-feedback + anchor 完整时出现。
+ * Finding card 上的草稿状态 chip + 操作按钮。仅代码类 finding（/review code-feedback
+ * 与 /improve code-suggestion）+ anchor 完整时出现。
  *
  * 状态可视化：
  * - 无 relatedDraft（用户从未交互）→ 不显示 status chip，只展示"→ 编辑 / ✗ 拒绝"按钮
@@ -1860,11 +1879,13 @@ function FindingCard({
               {finding.score}/10
             </span>
           )}
-          {/* M4 草稿状态 chip + 操作按钮：仅锚到具体行的 code-feedback 才展示
-              (其它如 summary / description / score 没法变 inline 评论) */}
+          {/* M4 草稿状态 chip + 操作按钮：锚到具体行的代码类 finding 才展示——
+              /review 的 code-feedback 与 /improve 的 code-suggestion 同享这套
+              「编辑转草稿 → 发布行内评论」交互（其它如 summary / description /
+              score 没法变 inline 评论） */}
           {finding.anchor.startLine !== undefined &&
             (onJump || onReject) &&
-            key === 'code-feedback' && (
+            (key === 'code-feedback' || key === 'code-suggestion') && (
               <FindingDraftActions
                 relatedDraft={relatedDraft}
                 onJump={onJump}

--- a/apps/desktop/src/renderer/src/components/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/DiffView.tsx
@@ -7,6 +7,7 @@ import { DiffEditor } from '@monaco-editor/react';
 import { editor as MonacoEditorNs, type editor as MonacoEditor } from 'monaco-editor';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import type {
   DiffBlameLine,
   DiffChangedFile,
@@ -133,6 +134,60 @@ function groupBlameByCommit(blame: DiffBlameLine[]): BlameBlock[] {
     }
   }
   return blocks;
+}
+
+/**
+ * 统一(inline)视图下原始编辑器隐藏、删除行由 modified 编辑器以 view zone 呈现，故 old 侧评论/草稿
+ * 不能再挂原始编辑器（会出现「大段空白、无内容」），须改挂 modified 编辑器。这里按 diff 行变更把
+ * 「原始行号」映射成 modified 的 afterLineNumber：
+ *  - 纯删除：删除块落在 modifiedStartLineNumber 之后 → 评论挂该行后；
+ *  - 修改：对齐到 modified 块内对应行；
+ *  - 上下文行（不在任何变更内）：按之前各变更的累计行数差平移。
+ * diff 尚未计算（getLineChanges 为空）时退化为原行号 + 累计平移。
+ */
+function mapOriginalLineToModified(
+  changes: readonly MonacoEditor.ILineChange[],
+  origLine: number,
+): number {
+  let delta = 0;
+  for (const ch of changes) {
+    const oS = ch.originalStartLineNumber;
+    const oE = ch.originalEndLineNumber;
+    const mS = ch.modifiedStartLineNumber;
+    const mE = ch.modifiedEndLineNumber;
+    if (oE === 0) {
+      // 纯插入（原始侧无行）：仅当插入点在 origLine 之前才计入偏移
+      if (oS < origLine) delta += mE - mS + 1;
+      continue;
+    }
+    if (oE < origLine) {
+      // 变更整体在 origLine 之前：累计 modified 与 original 的行数差
+      const oCount = oE - oS + 1;
+      const mCount = mE === 0 ? 0 : mE - mS + 1;
+      delta += mCount - oCount;
+      continue;
+    }
+    if (oS <= origLine && origLine <= oE) {
+      // origLine 落在本变更内
+      if (mE === 0) return mS; // 纯删除：删除块在 modified 行 mS 之后
+      return Math.min(mS + (origLine - oS), mE); // 修改：对齐 modified 块
+    }
+    break; // changes 有序，后续都在 origLine 之后
+  }
+  return origLine + delta;
+}
+
+/** 把 old 侧分桶按 diff 重映射到 modified 行号（统一视图用）。 */
+function remapOldByLineToModified<T>(
+  changes: readonly MonacoEditor.ILineChange[],
+  oldByLine: Map<number, T[]>,
+): Map<number, T[]> {
+  const remapped = new Map<number, T[]>();
+  for (const [origLine, items] of oldByLine) {
+    const modLine = mapOriginalLineToModified(changes, origLine);
+    remapped.set(modLine, [...(remapped.get(modLine) ?? []), ...items]);
+  }
+  return remapped;
 }
 
 export function DiffView({
@@ -695,7 +750,12 @@ export function DiffView({
       });
     };
 
-    addZonesFor(originalEditor, oldByLine);
+    // 并排视图：old 侧挂原始编辑器；统一视图：原始编辑器隐藏，old 侧改挂 modified 编辑器对应行。
+    if (renderSideBySide) {
+      addZonesFor(originalEditor, oldByLine);
+    } else if (oldByLine.size > 0) {
+      addZonesFor(modifiedEditor, remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine));
+    }
     addZonesFor(modifiedEditor, newByLine);
 
     return () => {
@@ -751,7 +811,16 @@ export function DiffView({
         }
       });
     };
-  }, [diffEditor, comments, content, selected, pr.connectionId, attachmentBase, pr.localId]);
+  }, [
+    diffEditor,
+    comments,
+    content,
+    selected,
+    pr.connectionId,
+    attachmentBase,
+    pr.localId,
+    renderSideBySide,
+  ]);
 
   // M4: 内联草稿 view zones (蓝底，editable)。跟 comments 同套机制：
   // - filter drafts by selected.path / oldPath
@@ -985,7 +1054,12 @@ export function DiffView({
       });
     };
 
-    addZonesFor(originalEditor, oldByLine);
+    // 并排视图：old 侧挂原始编辑器；统一视图：原始编辑器隐藏，old 侧改挂 modified 编辑器对应行。
+    if (renderSideBySide) {
+      addZonesFor(originalEditor, oldByLine);
+    } else if (oldByLine.size > 0) {
+      addZonesFor(modifiedEditor, remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine));
+    }
     addZonesFor(modifiedEditor, newByLine);
 
     return () => {
@@ -1039,7 +1113,7 @@ export function DiffView({
     // 不依赖 autoEditTokens (已移除 state) / registerEditTrigger (稳定的 useCallback)
     // — 避免 trigger 引发 zone 重建带来的 DraftZone unmount/mount，根除取消后重入
     // edit 模式的 race
-  }, [diffEditor, drafts, content, selected, pr.localId, registerEditTrigger]);
+  }, [diffEditor, drafts, content, selected, pr.localId, registerEditTrigger, renderSideBySide]);
 
   // M4 行 hover '+' 新建 manual 草稿：modifiedEditor (head 侧) 上加 mousemove +
   // mousedown 监听。已有评论 / 草稿的行不重复出 + glyph，避免误触。
@@ -1614,8 +1688,10 @@ function CommentNode({
           />
         ) : (
           <div className="comment-zone-body markdown">
+            {/* remarkBreaks：单换行即渲染成 <br>，与 Bitbucket/GitHub 评论上下文一致
+                （评论场景按 hard-break，单 \n 就换行），也跟草稿预览/评论列表保持统一 */}
             <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
+              remarkPlugins={[remarkGfm, remarkBreaks]}
               rehypePlugins={REMOTE_REHYPE_PLUGINS}
               components={components}
               urlTransform={transformBitbucketUrl}


### PR DESCRIPTION
@
## 背景

围绕「行内评论」体验的一组一致性修复，分支累计两条逻辑改动。

## 改动

### feat(chat): /improve 与 /review 行内评论操作一致（8556b45）
- 放开草稿操作按钮 gate：`code-suggestion`（/improve）与 `code-feedback`（/review）同享「编辑转草稿 → 发布行内评论」及锚点跳转。/improve finding 早已带 anchor/codeChange/score，handler 也是按 anchor 通用判断，此前仅被可见性条件挡住。
- 转草稿时把 pr-agent GFM 内联 HTML（`<code>`/`<br>`/`<b>`/`<i>`）归一成 markdown，避免草稿编辑器（纯文本 textarea）与远端评论露出裸标签。

### fix(diff): 统一视图删除行评论 + 单换行渲染（f124eb4）
- 统一视图下删除行的行内评论改挂 modified 编辑器，修复大段空白。
- DiffView 行内评论渲染补 `remarkBreaks`，单换行即换行——与 Bitbucket/GitHub 评论上下文（hard-break）及草稿预览/评论列表保持一致。

## 验证

`npx nx typecheck desktop` / `npx nx lint desktop`（--max-warnings=0）/ `npx nx build desktop` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@