### PR TITLE
fix(pragent): /review YAML 解析健壮化 + 消除 marker 误导日志与 labels 噪音

### DIFF
--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/load_yaml.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/load_yaml.py
@@ -70,36 +70,69 @@ def patch(module) -> None:
 
     import re as _re
 
+    # loguru 全局单例（pr_agent.log 用的同一个）。用于在「首探+修复」阶段临时压制
+    # pr_agent.algo.utils 的失败日志；import 失败则降级为不压制（不致命）。
+    try:
+        from loguru import logger as _loguru_logger
+    except Exception:  # noqa: BLE001
+        _loguru_logger = None
+
     orig_load_yaml = module.load_yaml
     # 整行仅为 `[file: ...]`（含缩进/path-only 形式），吃掉行尾换行
     marker_line_re = _re.compile(r"(?m)^[ \t]*\[file:[^\]\n]*\][ \t]*$\n?")
+    # 激进兜底：`[file:` 起、吃到 `]` 或行尾（闭合 `]` 可选），出现在**任意位置**都抹掉。
+    # 统一覆盖：独占整行、行内（`issue text [file:...]`）、值位、以及模型截断漏 `]` 的未闭合
+    # marker。marker_line_re（仅独占整行的闭合形式）漏掉的破格全归它收。
+    marker_any_re = _re.compile(r"\[file:[^\]\n]*\]?")
 
-    def load_yaml(response_text, *args, **kwargs):
-        data = orig_load_yaml(response_text, *args, **kwargs)
-        if data:
-            return data
-        if not isinstance(response_text, str):
-            return data
-        # 候选修复，按代价从小到大；每个交回原 load_yaml（其内部还会再跑 try_fix_yaml）
+    def _repair_candidates(response_text):
+        """生成修复候选，按代价从小到大；每个交回原 load_yaml（其内部还会再跑 try_fix_yaml）。
+        marker 仅是行号兜底（anchor 主源是 get_line_link 的 meebox:/// 链接），recovery 路径剥掉
+        它不影响主锚点，优先保证整个 /review 不因一条破格 marker 整体失败。"""
         stripped = marker_line_re.sub("", response_text)
+        # 更激进：任意位置 / 未闭合 marker 全清（marker_line_re 只清独占整行的闭合形式）
+        aggressive = marker_any_re.sub("", response_text)
         attempts = []
         if stripped != response_text:
             attempts.append(stripped)
         reflowed = _reflow_unindented_multiline(response_text)
-        if reflowed != response_text:
+        if reflowed != response_text and reflowed not in attempts:
             attempts.append(reflowed)
         if stripped != response_text:
             r2 = _reflow_unindented_multiline(stripped)
-            if r2 != stripped and r2 != response_text:
+            if r2 != stripped and r2 not in attempts:
                 attempts.append(r2)
-        for cand in attempts:
-            try:
-                d = orig_load_yaml(cand, *args, **kwargs)
-            except Exception:  # noqa: BLE001 - 修复尝试失败不致命，继续下一个
-                d = None
-            if d:
-                _debug("load_yaml recovered via meebox repair")
-                return d
-        return data
+        if aggressive != response_text and aggressive not in attempts:
+            attempts.append(aggressive)
+            ra = _reflow_unindented_multiline(aggressive)
+            if ra != aggressive and ra not in attempts:
+                attempts.append(ra)
+        return attempts
+
+    def load_yaml(response_text, *args, **kwargs):
+        # 「首探 + 修复」阶段静默：orig 对带 marker 的原文必然解析失败并打 WARNING+ERROR，但这些
+        # 破格我们随后能修复，那两条日志是误导噪音（让用户以为 /review 挂了）。故临时压制
+        # pr_agent.algo.utils 的日志；仅当所有修复都失败，才放**原始报错**出来（真失败应可见）。
+        # 本 shim 跑在单次 review 的独立 python 子进程、无并发，disable/enable 全局开关安全。
+        if _loguru_logger is not None:
+            _loguru_logger.disable("pr_agent.algo.utils")
+        try:
+            data = orig_load_yaml(response_text, *args, **kwargs)
+            if data:
+                return data
+            if isinstance(response_text, str):
+                for cand in _repair_candidates(response_text):
+                    try:
+                        d = orig_load_yaml(cand, *args, **kwargs)
+                    except Exception:  # noqa: BLE001 - 修复尝试失败不致命，继续下一个
+                        d = None
+                    if d:
+                        _debug("load_yaml recovered via meebox repair")
+                        return d
+        finally:
+            if _loguru_logger is not None:
+                _loguru_logger.enable("pr_agent.algo.utils")
+        # 全部修复失败 → 日志已恢复，重跑一次 orig 让真实报错可见，并返回其结果（None/空）
+        return orig_load_yaml(response_text, *args, **kwargs)
 
     module.load_yaml = load_yaml

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/local_git_provider.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/local_git_provider.py
@@ -100,3 +100,13 @@ def patch(module) -> None:
         return _orig_is_supported(self, capability)
 
     module.LocalGitProvider.is_supported = is_supported
+
+    # get_pr_labels: 基类未实现，LocalGitProvider 直接抛 NotImplementedError('Getting labels
+    # is not implemented for the local git provider')。/review 跑完会调 set_review_labels →
+    # get_pr_labels(update=True) 读现有标签做 merge，本地仓库无"标签"概念，异常被 pr_reviewer
+    # catch 后打成 ERROR 噪音（review 结果不受影响）。本地无远端标签，返回空列表即可：
+    # set_review_labels 据此走 publish_labels（LocalGitProvider 本就是 no-op），全程静默。
+    def get_pr_labels(self, update=False):
+        return []
+
+    module.LocalGitProvider.get_pr_labels = get_pr_labels


### PR DESCRIPTION
@
## 背景

`/review` 跑完日志里出现 `load_yaml` 的 WARNING/ERROR + `set_review_labels` 的 ERROR，看起来像 review 挂了。实际功能未挂（labels 仍能 set，证明 YAML 已解析成功），但成因是锚点 marker 破格 + 误导性日志。

## 根因

`/review` 的 EXTRA_INSTRUCTIONS 要求模型在每条 key_issue 末尾追加锚点 marker `[file: <path>, lines: <s>-<e>]`。`[` 是 YAML flow 序列起始符，落在 key_issues mapping 上下文就破格（`could not find expected ":"`）。该 marker 仅为**行号兜底**——anchor 主源是 `get_line_link` 注入的 `meebox:///` 链接，recovery 路径剥掉它不影响主锚点。

旧 load_yaml 包装「先调原版（必失败并打 WARNING+ERROR）→ 再静默修复」，把首探失败的吓人日志暴露了出来；且修复正则只覆盖「独占整行的闭合 marker」，漏掉行内 / 键层级 / 未闭合等形态。

## 改动

### load_yaml.py
- 统一正则 `\[file:[^\]\n]*\]?` 覆盖 marker **所有位置/闭合形态**（独占行、行内、值位、键层级、未闭合截断），叠加多行块标量 reflow 重试。
- 「首探 + 修复」阶段临时压制 `pr_agent.algo.utils` 的 loguru 日志；仅当所有修复都失败，才放**原始报错**出来（真失败仍可见）。单次 review 独立子进程、无并发，全局 disable/enable 安全；loguru import 失败则降级不压制。

### local_git_provider.py
- `get_pr_labels` 返回 `[]`（本地仓库无远端标签概念），消除 `set_review_labels` 调用时抛 `NotImplementedError` 被 catch 后的 ERROR 噪音。

## 验证

用 vendored pr-agent 真实 `load_yaml` 验证四场景：marker 破格能恢复（2 条 finding 完整）、恢复路径无 WARNING/ERROR 噪音、合法 YAML 不受影响、真正损坏的 YAML 仍返回 None 并正常打日志。`get_pr_labels` 运行时返回 `[]`。已 `prepare:pragent` 同步进 vendor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@