### PR TITLE
fix(mac): 修复 GUI 启动本地 CLI provider 失效（0.3.1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-11
+
 ### Fixed
 - **macOS 分发版「本地 CLI」provider（claude / codex）失效**（Finder/Dock 启动）：macOS GUI 应用
   只继承 launchd 的最小 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），读不到 shell 配置，故找不到装在

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- **macOS 分发版「本地 CLI」provider（claude / codex）失效**（Finder/Dock 启动）：macOS GUI 应用
+  只继承 launchd 的最小 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），读不到 shell 配置，故找不到装在
+  `~/.local/bin` / homebrew 等目录的 CLI，评审报错（`litellm ... LLM Provider NOT provided` 或
+  "找不到命令"）。启动期把常见 CLI 安装目录（`~/.local/bin` / `/usr/local/bin` /
+  `/opt/homebrew/bin` 等）前置进 `PATH`，使嵌入式 python 及其 CLI 子进程都能定位命令。仅 macOS
+  受影响；终端启动（dev）与 Windows 不受影响。(#21)
+
 ## [0.3.0] - 2026-06-11
 
 > 第三个正式版（仍属 0.x · 早期预览）。本版重点：**界面国际化（四语 + 即时切换）**、Mermaid 架构图

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meebox/desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "meebox Electron desktop app",
   "author": {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,6 +15,7 @@ import { buildAdapters, type ConnectionRuntime } from './adapters.js';
 import { initMainI18n } from './i18n/index.js';
 import { registerIpcHandlers } from './ipc.js';
 import { buildProxyEnv } from './utils/proxy.js';
+import { fixMacPath } from './utils/mac-path.js';
 import {
   readConnectionStates,
   writeConnectionStates,
@@ -105,6 +106,14 @@ async function start(): Promise<void> {
     { firstRun: bootstrap.firstRun, appDir: bootstrap.paths.appDir },
     'meebox main process started',
   );
+
+  // macOS GUI 启动（Finder/Dock）只有 launchd 最小 PATH，找不到本机 CLI（claude/codex，常在
+  // ~/.local/bin / homebrew）。启动期前置常见目录到 process.env.PATH，使后续 spawn 的嵌入式
+  // python 及其 CLI 子进程（经 {...process.env} 继承）都能定位到命令。须在 pr-agent 探测/运行前。
+  const macPath = fixMacPath();
+  if (macPath.applied) {
+    logger.info({ added: macPath.added }, 'macOS PATH 已补全');
+  }
 
   // main 进程全局兜底：未捕获异常 / 未处理 rejection 至少留一条日志，不静默崩溃。
   process.on('uncaughtException', (err) => {

--- a/apps/desktop/src/main/utils/mac-path.ts
+++ b/apps/desktop/src/main/utils/mac-path.ts
@@ -1,0 +1,46 @@
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * macOS GUI（Finder / Dock / LaunchServices）启动的 app 由 launchd 给出**最小 PATH**
+ * （`/usr/bin:/bin:/usr/sbin:/sbin`），**不读用户 shell 配置**（`.zshrc` / `.zprofile`）。
+ * 而本机 CLI（claude / codex）常装在 `~/.local/bin`、homebrew 等**只由 shell 往 PATH 里加**的
+ * 目录——于是嵌入式 python 的 `shutil.which(...)` 找不到命令、本地 CLI provider 失效，但从终端
+ * `npm run dev` 启动却正常（继承了已加载配置的终端 PATH）。Windows 不受影响（GUI 进程继承用户 PATH）。
+ *
+ * 这里在启动期把常见 CLI 安装目录前置进 `process.env.PATH`（仅 darwin），之后所有子进程
+ * （嵌入式 python 及其 spawn 的 CLI）都经 `{ ...process.env }` 继承到。静态目录已覆盖最常见的
+ * 安装位置；不跑登录 shell 解析（避免启动期子进程 / 超时 / 噪声）。
+ */
+
+// 常见 CLI 安装目录：覆盖 pip --user / npm global / homebrew(Apple Silicon + Intel)。
+const COMMON_DIRS = [
+  path.join(os.homedir(), '.local', 'bin'),
+  '/usr/local/bin',
+  '/opt/homebrew/bin',
+  '/opt/homebrew/sbin',
+];
+
+export interface MacPathResult {
+  /** 是否实际改写了 PATH（仅 darwin 且确有目录新增时为 true）。 */
+  applied: boolean;
+  /** 本次新前置、原 PATH 中没有的目录（供日志诊断）。 */
+  added: string[];
+}
+
+/**
+ * 仅 darwin：把常见目录前置进 `process.env.PATH`（去重，只补原 PATH 缺失的，保持原有顺序在后）。
+ * 非 darwin 直接 no-op。返回补全详情供日志。
+ */
+export function fixMacPath(): MacPathResult {
+  if (process.platform !== 'darwin') {
+    return { applied: false, added: [] };
+  }
+  const existing = (process.env.PATH ?? '').split(':').filter(Boolean);
+  const existingSet = new Set(existing);
+  const added = COMMON_DIRS.filter((d) => !existingSet.has(d));
+  if (added.length > 0) {
+    process.env.PATH = [...added, ...existing].join(':');
+  }
+  return { applied: added.length > 0, added };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/desktop": {
       "name": "@meebox/desktop",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.1",
       "dependencies": {
         "@iconify-json/material-icon-theme": "^1.2.66",
         "@iconify/react": "^5.2.1",


### PR DESCRIPTION
0.3.1 hotfix（基于 `v0.3.0`）。Closes #21。

## 问题

macOS 从 Finder/Dock 启动的分发版，使用「本地 CLI」provider（claude / codex）评审失败：
`litellm ... LLM Provider NOT provided`（或新版 shim 下"找不到命令"）。Windows 与 dev 终端启动正常。

## 根因

macOS GUI 应用由 launchd 给出最小 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），**不读 shell 配置**，
故找不到装在 `~/.local/bin` / homebrew 等目录的 CLI；嵌入式 python 及其 spawn 的 CLI 子进程
（经 `{ ...process.env }` 继承）只见到最小 PATH → `shutil.which(...)` 失败。

## 修复

- 新增 `apps/desktop/src/main/utils/mac-path.ts`：仅 darwin，启动期把常见 CLI 安装目录
  （`~/.local/bin` / `/usr/local/bin` / `/opt/homebrew/bin` / `/opt/homebrew/sbin`）前置进
  `process.env.PATH`（去重保序、纯静态、不跑登录 shell）。
- `main/index.ts` 在 logger 后、pr-agent 探测前调用，使后续所有子进程继承。
- 仅影响 macOS；终端启动 / Windows 行为不变。

## 发布准备

- bump `@meebox/desktop` 0.3.0 → 0.3.1；`package-lock` 经 `npm install` 对齐（顺带修正遗留的
  `0.3.0-alpha.1` 漂移）。
- CHANGELOG 收口 `[0.3.1]`。

## 验证

- `lint` / `typecheck` / `build` 全绿。
- 端到端实测：最小 PATH 下 `which claude = None`；前置常见目录后 `which claude = ~/.local/bin/claude`、
  CLI 接管激活（`installed CLI chat_completion`）。

> 合并打 `v0.3.1` 后，此修复也需回合到 `dev`（0.4.x）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)