### PR TITLE
fix: 评审交互与渲染若干修复（附件图片/拒绝折叠/危险按钮/锚点对齐）

### DIFF
--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -20,6 +20,7 @@ import type { ReviewDraft } from '@meebox/shared';
 import { invoke } from '../api';
 import {
   ChatIcon,
+  ChevronIcon,
   CloseIcon,
   QuestionIcon,
   RetryIcon,
@@ -1846,6 +1847,11 @@ function FindingCard({
   onNavigate?: () => void;
 }) {
   const { t } = useTranslation();
+  // 已拒绝：左色条 + 类别 chip 置灰，卡片默认折叠收起（仅留头部 chip + 锚点行 +
+  // 撤销按钮）。点头部的展开/收起切换可临时回看正文，不影响草稿状态。
+  const isRejected = relatedDraft?.status === 'rejected';
+  const [expanded, setExpanded] = useState(false);
+  const collapsed = isRejected && !expanded;
   // sectionKey 优先（新解析的），fallback 到 category (旧持久化的 run)
   const key: PrDocSectionKey = finding.sectionKey ?? 'general';
   const label = sectionLabel(key, t);
@@ -1870,14 +1876,27 @@ function FindingCard({
       : translatePrAgentLabels(finding.title)
     : undefined;
   return (
-    <li className={`chat-finding chat-finding-${key}`}>
+    <li
+      className={`chat-finding chat-finding-${key}${isRejected ? ' chat-finding-rejected' : ''}${collapsed ? ' chat-finding-collapsed' : ''}`}
+    >
       <header className="chat-finding-head">
         {/* 已知 sectionKey 用中文标签 chip；general / 未知不显示，避免 UI 噪音 */}
         {label && (
           <span className={`chat-finding-cat chat-finding-cat-${key}`}>{label}</span>
         )}
-        {showTitle && translatedTitle && (
+        {showTitle && translatedTitle && !collapsed && (
           <h4 className="chat-finding-title">{translatedTitle}</h4>
+        )}
+        {/* 已拒绝才出现的展开 / 收起切换：chevron 图标，收起态指右、展开态转下，纯图标交互 */}
+        {isRejected && (
+          <button
+            type="button"
+            className={`chat-finding-collapse-toggle${collapsed ? '' : ' is-expanded'}`}
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={!collapsed}
+          >
+            <ChevronIcon />
+          </button>
         )}
       </header>
       {finding.anchor && (
@@ -1935,32 +1954,34 @@ function FindingCard({
             )}
         </div>
       )}
-      {key === 'pr-type' ? (
-        // PR Type 段：拆成胶囊，每个标签按内容 hash 取色
-        <div className="chat-finding-pills">
-          {splitTypeLabels(translatedBody).map((t) => (
-            <span key={t} className="pr-type-pill" style={pillStyle(t)}>
-              {t}
-            </span>
-          ))}
-        </div>
-      ) : (
-        <div className="chat-finding-body markdown">
-          {/* remarkBreaks 把 finding body 里的单换行也当成 <br>。pr-agent 的 trace、
-              或一般段落里 reviewer 习惯按软换行折行，不加 remarkBreaks 会被 markdown
-              合并成长一行。Findings 主要是富文本说明，不存在"故意软换行连接"的场景 */}
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkBreaks]}
-            rehypePlugins={REMOTE_REHYPE_PLUGINS}
-            components={mermaidComponents}
-          >
-            {translatedBody}
-          </ReactMarkdown>
-        </div>
-      )}
+      {/* 已拒绝折叠态隐藏正文与代码对比，只留头部 chip + 锚点行 + 撤销入口 */}
+      {!collapsed &&
+        (key === 'pr-type' ? (
+          // PR Type 段：拆成胶囊，每个标签按内容 hash 取色
+          <div className="chat-finding-pills">
+            {splitTypeLabels(translatedBody).map((t) => (
+              <span key={t} className="pr-type-pill" style={pillStyle(t)}>
+                {t}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className="chat-finding-body markdown">
+            {/* remarkBreaks 把 finding body 里的单换行也当成 <br>。pr-agent 的 trace、
+                或一般段落里 reviewer 习惯按软换行折行，不加 remarkBreaks 会被 markdown
+                合并成长一行。Findings 主要是富文本说明，不存在"故意软换行连接"的场景 */}
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm, remarkBreaks]}
+              rehypePlugins={REMOTE_REHYPE_PLUGINS}
+              components={mermaidComponents}
+            >
+              {translatedBody}
+            </ReactMarkdown>
+          </div>
+        ))}
       {/* /improve 给的 existing → improved 代码对比。两段都是片段，独立 <pre> 块
           + 红/绿背景 模拟 diff 视觉 (不用 Monaco DiffEditor 节省开销) */}
-      {finding.codeChange && (
+      {!collapsed && finding.codeChange && (
         <div className="chat-finding-code-change">
           {finding.codeChange.existing && (
             <pre

--- a/apps/desktop/src/renderer/src/components/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/DiffView.tsx
@@ -422,7 +422,8 @@ export function DiffView({
           )
         : undefined;
     setPendingScroll({
-      line: pendingNav.anchor.startLine,
+      // 取 endLine 跟草稿 zone / 发布锚点对齐（见 zone 行号注释），高亮行与草稿区同位
+      line: pendingNav.anchor.endLine,
       side: 'new',
       draftId: matchingDraft?.id,
     });
@@ -847,12 +848,13 @@ export function DiffView({
     const newByLine = new Map<number, ReviewDraft[]>();
     for (const d of fileDrafts) {
       const target = d.anchor.side === 'old' ? oldByLine : newByLine;
-      // 用 startLine 作为 zone 行号 — finding 跨多行 (startLine=403, endLine=425)
-      // 时 zone 紧贴 startLine 下方，跟 nav reveal 的高亮行视觉一致；之前用 endLine
-      // 让 zone 出现在 finding 段末尾 (425 后)，高亮行在起始 (403)，跨 23 行错位
-      const arr = target.get(d.anchor.startLine) ?? [];
+      // 用 endLine 作为 zone 行号，跟发布锚点对齐 —— publishInlineComment 用
+      // anchor.endLine 发到远端，草稿区也落 endLine 即「预览位置 = 最终发布位置」
+      // (WYSIWYG)。nav reveal 的高亮行同样取 endLine（见下方 pendingScroll），二者
+      // 视觉一致，跨多行 finding (startLine=403, endLine=425) 也不会起止错位。
+      const arr = target.get(d.anchor.endLine) ?? [];
       arr.push(d);
-      target.set(d.anchor.startLine, arr);
+      target.set(d.anchor.endLine, arr);
     }
 
     const originalEditor = diffEditor.getOriginalEditor();

--- a/apps/desktop/src/renderer/src/markdown.ts
+++ b/apps/desktop/src/renderer/src/markdown.ts
@@ -15,6 +15,15 @@ function extend<T>(list: readonly T[] | null | undefined, extra: readonly T[]): 
 // 在 rehype-sanitize 的 GitHub 默认白名单基础上，补齐 Qodo 等机器人常用但默认未必放开的标签/属性。
 const schema = {
   ...defaultSchema,
+  // 放行 Bitbucket 评论的 `attachment:<repoId>/<id>` 内部协议（内嵌图片/附件引用）。
+  // 默认 protocols 白名单 src/href 只许 http/https，会在 react-markdown 的 urlTransform
+  // 之前就把 attachment: 的 src/href 整个剥掉 → img 收不到 src（BitbucketImage 不触发）、
+  // a 收不到 href（渲染成裸文字）。两条附件渲染路径都被卡死，故在此显式放行 attachment 协议。
+  protocols: {
+    ...defaultSchema.protocols,
+    src: extend(defaultSchema.protocols?.src, ['attachment']),
+    href: extend(defaultSchema.protocols?.href, ['attachment']),
+  },
   tagNames: extend(defaultSchema.tagNames, [
     'details',
     'summary',

--- a/apps/desktop/src/renderer/src/styles/base.scss
+++ b/apps/desktop/src/renderer/src/styles/base.scss
@@ -133,13 +133,15 @@ textarea {
 }
 
 .btn-danger {
-  background: $color-danger;
-  border-color: $color-danger;
+  // 实底用饱和的 $color-danger-bg（#c72e0f），而非偏浅鲑红的 $color-danger
+  // （后者是为文案 / 红边框设计的浅色，当实底背景会发灰白、警示力不足）。
+  background: $color-danger-bg;
+  border-color: $color-danger-bg;
   color: $text-on-accent;
 
   &:hover:not(:disabled) {
     filter: brightness(1.1);
-    background: $color-danger;
+    background: $color-danger-bg;
   }
 }
 

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -533,6 +533,11 @@
   &.chat-finding-general {
     border-left-color: $border-default;
   }
+  // 已拒绝：左色条转中性灰（盖过 code-feedback / suggestion 的警示色）、整卡降饱和收起
+  &.chat-finding-rejected {
+    border-left-color: $text-muted;
+    opacity: 0.68;
+  }
 }
 .chat-finding-head {
   display: flex;
@@ -581,6 +586,39 @@
   &.chat-finding-cat-general {
     background: $bg-surface;
     color: $text-muted;
+  }
+}
+// 已拒绝卡片：类别 chip 一并置灰，盖过分类配色（与左色条置灰一致）
+.chat-finding-rejected .chat-finding-cat {
+  background: $bg-surface;
+  color: $text-muted;
+}
+// 已拒绝卡片头部的展开 / 收起切换：chevron 图标，推到头部最右，低调中性样式。
+// 图标在右侧，收起态朝左（◂，旋转 180° 指回内容），展开态朝下（▾，旋转 90°）。
+.chat-finding-collapse-toggle {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 2px;
+  border-radius: $radius-sm;
+  color: $text-muted;
+  cursor: pointer;
+
+  // ChevronIcon 原始朝右（▸）；收起态旋转 180° 朝左
+  svg {
+    transition: transform 0.15s ease;
+    transform: rotate(180deg);
+  }
+  &.is-expanded svg {
+    transform: rotate(90deg);
+  }
+
+  &:hover {
+    color: $text-primary;
+    background: $bg-surface;
   }
 }
 // 概览指标（工作量 / 测试 / 安全 / 评分）：值很短，chip 与值排同一行、紧凑展示，不再各占两行。

--- a/packages/platform-bitbucket-server/src/client.ts
+++ b/packages/platform-bitbucket-server/src/client.ts
@@ -135,7 +135,8 @@ export class BitbucketClient {
         // 相对路径 (e.g., /projects/.../attachments/xxx) 拼当前 baseUrl
         absoluteUrl = new URL(url, `https://${myHost}`).toString();
       }
-    } catch {
+    } catch (e) {
+      console.warn(`[bb-attachment] URL 解析失败 src=${url}:`, e);
       return null;
     }
 
@@ -151,12 +152,21 @@ export class BitbucketClient {
         },
         signal: ctl.signal,
       });
-    } catch {
+    } catch (e) {
       clearTimeout(timer);
+      console.warn(`[bb-attachment] fetch 抛错 src=${url} url=${absoluteUrl}:`, e);
       return null;
     }
     clearTimeout(timer);
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // 非 2xx 不再静默吞掉（原先直接 return null，无任何线索）。记 status / 是否重定向 /
+      // 重定向后最终 URL / content-type —— 跨源重定向会丢 Authorization 头（fetch 规范）、
+      // PAT 未被认可常返回 200 登录页等失败模式，都靠这行定位。
+      console.warn(
+        `[bb-attachment] 取附件失败 src=${url} url=${absoluteUrl} status=${String(res.status)} redirected=${String(res.redirected)} finalUrl=${res.url} contentType=${res.headers.get('content-type') ?? '(none)'}`,
+      );
+      return null;
+    }
     const buf = await res.arrayBuffer();
     return {
       bytes: new Uint8Array(buf),


### PR DESCRIPTION
@
## 概述

本分支收口若干评审体验与渲染相关修复，基于 `dev`（0.4.0 周期）。

## 改动

- **fix(comments): 修复 Bitbucket 评论内嵌附件图片不渲染** (`dd142d3`)
  `rehype-sanitize` 协议白名单 `src`/`href` 仅允许 http/https，会在 `urlTransform` 之前剥掉 `attachment:` 内部协议，导致 img/a 收不到 src/href、图片代理永不触发（该 sanitize 链晚于附件功能引入，属回归）。schema 放行 `attachment` 协议；并让 `getAttachmentBinary` 非 2xx 不再静默吞错（记 status/redirected/finalUrl/content-type）。

- **feat(review): 拒绝代码反馈/改进建议后置灰并折叠收起** (`e73aa61`)
  `/review` code-feedback 与 `/improve` code-suggestion 共用 `FindingCard`。点「拒绝」后左色条转中性灰、类别 chip 置灰、整卡降饱和，正文与代码对比自动折叠，仅留头部 chip + 锚点行（含撤销）。头部加 chevron 图标切换（纯图标，收起朝左 ◂、展开朝下 ▾）可临时回看。

- **fix(ui): 危险按钮实底改用饱和红** (`edcb0b8`)
  `.btn-danger` 实底由浅鲑红 `#f48771` 改为饱和的 `#c72e0f`，提高「清空」「删除」等确认按钮警示力。

- **fix(review): 代码建议草稿区锚定行与发布落点对齐** (`5eed7fd`)
  草稿区原按 `startLine` 渲染，而发布用 `anchor.endLine`，预览行与最终远端评论行不一致。统一以发布落点为准：草稿 zone 行号与 nav 跳转高亮行改用 `endLine`，实现「预览位置 = 发布落点」。**注意：本项改变真实远端评论落点（现统一落在 finding 范围末行）。**

## 验证

本地 CI 门禁全过：lint 11 / typecheck 11 / test 7 / build。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@