### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@
 
 ## [Unreleased]
 
-## [0.4.0-alpha.1] - 2026-06-14
+## [0.4.0] - 2026-06-14
+
+> 第四个正式版（仍属 0.x · 早期预览）。本版重点：**接入 GitLab**（gitlab.com + Self-Managed，
+> CE / EE），评审交互与渲染打磨（拒绝折叠收起、代码建议草稿锚点对齐、评论内嵌附件图片、GitHub /
+> GitLab 评论编辑删除），**连接 Base URL 放宽**，以及 **Windows 升级安装健壮性**（per-machine 提权 +
+> 绕过旧卸载器）。开发期 0.4.0-alpha.1 的变更已并入本版。
+>
+> ⚠️ **Windows 安装说明**：本版为 **per-machine 安装**（所有用户 / Program Files），安装器双击即弹
+> UAC 提权运行；安装后的应用以普通权限启动。从旧版升级会自动清理旧安装，无需手动卸载。
 
 ### Added
 - **GitLab 接入**（gitlab.com + Self-Managed，CE / EE，REST API v4）：新增 `@meebox/platform-gitlab`
@@ -47,6 +55,16 @@
   哨兵统一通过判定，恢复 GitHub / GitLab 评论的编辑与删除；「带 reply 不可删」收敛为 Bitbucket 专属。
 - 评论内嵌图片代理失败时，降级为指向 PR 网页的「浏览器打开」链接（在系统浏览器带 session 渲染评论
   与图片），不再显示破图标；并修正相对图片路径在降级时误跳 localhost。
+- **Windows 升级安装卡死 /「无法关闭」**：① 改为 per-machine 提权安装（清单 requireAdministrator，
+  双击即弹 UAC、提权运行），取代 perMachine:false 在已存在 per-machine 安装时「按需提权失败 → 静默
+  退出 → 双击打不开」的半吊子路径；② 升级时绕过 electron-builder 旧卸载器——在 customInit（早于
+  uninstallOldVersion 执行）清掉旧版卸载注册表项使其读空值直接 no-op、改由安装器自行强删旧目录，
+  规避旧卸载器原位 `_?=` 模式下「数万文件原子 rename、瞬时占用即整批回滚 → 重试 5 次后『无法关闭』」
+  的死结。
+
+## [0.4.0-alpha.1] - 2026-06-14
+
+> 开发期预览版。其全部变更内容已并入正式版 **[0.4.0](#040---2026-06-14)**，此处不再展开。
 
 ## [0.3.1] - 2026-06-11
 
@@ -249,7 +267,10 @@
 
 许可证：[Apache-2.0](LICENSE)。打包内含第三方组件（pr-agent、Electron 等），各按其许可证分发，见 [NOTICE](NOTICE)。
 
-[Unreleased]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/huhamhire/code-meeseeks/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.1...v0.4.0
+[0.4.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.1...v0.4.0-alpha.1
+[0.3.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.2.0...v0.3.0
 [0.3.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.2.0...v0.3.0-alpha.1
 [0.2.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.1.0...v0.2.0

--- a/apps/desktop/build-resources/installer.nsh
+++ b/apps/desktop/build-resources/installer.nsh
@@ -1,45 +1,47 @@
-; meebox 自定义 NSIS 注入（由 electron-builder.yml 的 nsis.include 引入）。
+; meebox 自定义 NSIS 注入（由 electron-builder.yml 的 buildResources 自动收录）。
 ;
-; 解决升级安装时的卸载失败（见各宏内排查结论）：
-;   1. customCheckAppRunning：强制结束残留进程；并在触发旧卸载器前**前置强删** pr-agent 运行时目录，
-;      绕开旧卸载器「数万文件原子 rename + 瞬时锁整批回滚」的死结（当前从旧版升级即生效）。
-;   2. customRemoveFiles：新卸载器改为直接强删、不回滚（数据在 ~/.code-meeseeks、安装目录可重建）。
-;   3. customHeader：卸载展开文件明细，慢删时给进度感知。
+; 解决升级安装时旧卸载器卡死/回滚（根因已定位、实测验证）：
 ;
-; electron-builder 在生成的 installer.nsi 里按名 !insertmacro 调用下列宏（定义即覆盖其默认行为）。
-; 可用变量由 electron-builder 注入：APP_EXECUTABLE_FILENAME（产物 exe 名，含空格）、PRODUCT_NAME 等。
+; 旧卸载器在被 uninstallOldVersion 以 `_?=$INSTDIR` 原位模式静默调起时，即便无任何文件锁也会做
+; 「数万文件原子 rename → 任一瞬时占用即整批回滚」并返回非 0，安装器重试 5 次后弹「无法关闭」。
+; 该行为固化在旧版卸载器、无法从新安装器修改。本应用为 per-machine 安装（C:\Program Files），
+; 升级需 UAC 提权 → 安装 Section 在**内层(提权)实例**执行；electron-builder 的 customCheckAppRunning
+; 被 `${ifNot} ${UAC_IsInnerInstance}` 守卫挡在内层之外，放那里的清理逻辑在升级时根本不执行。
+;
+; 解法（绕过旧卸载器）：改用 customInit —— 位于 .onInit 的 check64BitAndSetRegView 与 initMultiUser
+; 之后、且不在 UAC 守卫内 → 内外层实例都执行、且早于 Section 的 uninstallOldVersion，此时 RegView 已 64、
+; $INSTDIR 与 SHELL_CONTEXT 已解析。在此清掉旧版卸载注册表项 → uninstallOldVersion 读到空 UninstallString
+; 即直接 Return（installUtil.nsh:155-163），**根本不调用旧卸载器** → 无回滚；再自行强删旧安装目录。
+; 数据在 ~/.code-meeseeks、安装目录可重建，强删安全；新安装随后写入全新文件与注册表项。
+;
+; 注入变量/宏：APP_EXECUTABLE_FILENAME、PRODUCT_NAME、UNINSTALL_REGISTRY_KEY、UAC_IsInnerInstance 等。
 
-; 顶层属性：仅卸载展开详细文件日志（卸载走逐文件 Delete/RMDir，会打印进度，慢删时有感知）。
-; 安装侧 electron-builder 用 Nsis7z::Extract 单包解包 + CopyFiles /SILENT，不产生逐文件日志行，
-; 展开只会显示一个空白框、反而像卡住——故安装页保持默认（只显示进度条），不强制展开。
+; 仅卸载展开文件明细（慢删时给进度感知）。安装侧 electron-builder 整包解包不产生逐文件日志，
+; 展开只会是空白框，故不开 ShowInstDetails。
 !macro customHeader
   ShowUninstDetails show
 !macroend
 
-; 覆盖默认「检测应用在运行 → 提示手动关闭并重试」：改为强制结束残留进程（含无窗口的辅助进程
-; 及其子进程树 /T），不弹阻塞对话框。本应用数据在 ~/.code-meeseeks，强杀不丢数据；升级期这是期望行为。
-;
-; 升级卸载根因（已定位）：electron-builder 旧卸载器对 ${INSTDIR} 走「原子卸载」——把数万个文件
-; 逐个 Rename 到暂存区，任一文件在 rename 瞬间被占用（AV/索引/句柄）即 `un.restoreFiles` 整批移回
-; （= 用户看到的「删了又还原」），返回非 0；安装器侧仅重试 5 次后弹「文件被占用」。嵌入式 pr-agent
-; 运行时（数万小文件）使「某次 rename 撞上瞬时锁」几乎必然发生。
-;
-; 解法（前置强删）：CHECK_APP_RUNNING 早于 uninstallOldVersion 执行（见 installSection.nsh），且本宏
-; 在「新安装器」里跑——故在触发旧卸载器之前，用原生 `rd /s /q` 直接递归强删 pr-agent 目录，旧卸载器
-; 随后只剩应用壳层、原子 rename 轻松完成。此举对「当前从旧版升级」即生效，不必等下一版。
-!macro customCheckAppRunning
-  DetailPrint "正在结束可能残留的 ${PRODUCT_NAME} 进程…"
-  nsExec::Exec `taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}"`
-  Pop $0
-  Sleep 500
-  DetailPrint "正在清理旧的嵌入式运行时（pr-agent）…"
-  nsExec::Exec `cmd /c rd /s /q "$INSTDIR\resources\pragent"`
-  Pop $0
+; 绕过旧卸载器 + 清理旧目录。内外层实例都会进来；幂等，重复执行无害（per-machine 升级靠外层清 HKLM
+; 即可让内层 uninstallOldVersion 读到空值）。仅在检测到旧版本（UninstallString 非空）时动作。
+!macro customInit
+  ReadRegStr $R7 SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+  ${If} $R7 != ""
+    ; 结束可能残留的进程，避免占用安装目录文件
+    nsExec::Exec `taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}"`
+    Pop $0
+    ; 清掉旧版卸载注册表项 → uninstallOldVersion no-op，不触发易卡死的旧卸载器
+    DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}"
+    DeleteRegKey HKCU "${UNINSTALL_REGISTRY_KEY}"
+    DeleteRegKey HKLM "${UNINSTALL_REGISTRY_KEY}"
+    ; 自行递归强删旧安装目录（数据在 ~/.code-meeseeks，可重建）
+    SetOutPath $TEMP
+    nsExec::Exec `cmd /c rd /s /q "$INSTDIR"`
+    Pop $0
+  ${EndIf}
 !macroend
 
-; 覆盖默认「原子 rename 到暂存区 + 失败整批回滚」的文件删除（仅卸载/升级时）：不需要回滚——
-; 数据在 ~/.code-meeseeks、安装目录可重建。改为直接强删：大头 pr-agent 运行时先原生递归删，其余
-; RMDir /r；个别顽固锁走 /REBOOTOK 留待重启删，绝不整批回滚、绝不因瞬时锁返回非 0 触发安装器重试。
+; 新卸载器自身的卸载/升级删除：直接强删、不做原子 rename + 回滚（数据在 ~/.code-meeseeks、目录可重建）。
 !macro customRemoveFiles
   SetOutPath $TEMP
   nsExec::Exec `cmd /c rd /s /q "$INSTDIR\resources\pragent"`

--- a/apps/desktop/build-resources/installer.nsh
+++ b/apps/desktop/build-resources/installer.nsh
@@ -1,8 +1,10 @@
 ; meebox 自定义 NSIS 注入（由 electron-builder.yml 的 nsis.include 引入）。
 ;
-; 解决两件事（见排查结论）：
-;   1. 升级安装时不被「Code Meeseeks 无法关闭」对话框阻塞 —— 直接强制结束残留进程，不弹手动关闭框；
-;   2. 展开卸载的文件处理明细，让用户对「正在删除大量文件」有进度感知（嵌入式 python 文件多、慢）。
+; 解决升级安装时的卸载失败（见各宏内排查结论）：
+;   1. customCheckAppRunning：强制结束残留进程；并在触发旧卸载器前**前置强删** pr-agent 运行时目录，
+;      绕开旧卸载器「数万文件原子 rename + 瞬时锁整批回滚」的死结（当前从旧版升级即生效）。
+;   2. customRemoveFiles：新卸载器改为直接强删、不回滚（数据在 ~/.code-meeseeks、安装目录可重建）。
+;   3. customHeader：卸载展开文件明细，慢删时给进度感知。
 ;
 ; electron-builder 在生成的 installer.nsi 里按名 !insertmacro 调用下列宏（定义即覆盖其默认行为）。
 ; 可用变量由 electron-builder 注入：APP_EXECUTABLE_FILENAME（产物 exe 名，含空格）、PRODUCT_NAME 等。
@@ -16,10 +18,31 @@
 
 ; 覆盖默认「检测应用在运行 → 提示手动关闭并重试」：改为强制结束残留进程（含无窗口的辅助进程
 ; 及其子进程树 /T），不弹阻塞对话框。本应用数据在 ~/.code-meeseeks，强杀不丢数据；升级期这是期望行为。
-; 经排查：目标机常无进程持有安装目录，阻塞多由检测/慢删误判触发；此宏直接清场、让安装继续。
+;
+; 升级卸载根因（已定位）：electron-builder 旧卸载器对 ${INSTDIR} 走「原子卸载」——把数万个文件
+; 逐个 Rename 到暂存区，任一文件在 rename 瞬间被占用（AV/索引/句柄）即 `un.restoreFiles` 整批移回
+; （= 用户看到的「删了又还原」），返回非 0；安装器侧仅重试 5 次后弹「文件被占用」。嵌入式 pr-agent
+; 运行时（数万小文件）使「某次 rename 撞上瞬时锁」几乎必然发生。
+;
+; 解法（前置强删）：CHECK_APP_RUNNING 早于 uninstallOldVersion 执行（见 installSection.nsh），且本宏
+; 在「新安装器」里跑——故在触发旧卸载器之前，用原生 `rd /s /q` 直接递归强删 pr-agent 目录，旧卸载器
+; 随后只剩应用壳层、原子 rename 轻松完成。此举对「当前从旧版升级」即生效，不必等下一版。
 !macro customCheckAppRunning
   DetailPrint "正在结束可能残留的 ${PRODUCT_NAME} 进程…"
   nsExec::Exec `taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}"`
   Pop $0
   Sleep 500
+  DetailPrint "正在清理旧的嵌入式运行时（pr-agent）…"
+  nsExec::Exec `cmd /c rd /s /q "$INSTDIR\resources\pragent"`
+  Pop $0
+!macroend
+
+; 覆盖默认「原子 rename 到暂存区 + 失败整批回滚」的文件删除（仅卸载/升级时）：不需要回滚——
+; 数据在 ~/.code-meeseeks、安装目录可重建。改为直接强删：大头 pr-agent 运行时先原生递归删，其余
+; RMDir /r；个别顽固锁走 /REBOOTOK 留待重启删，绝不整批回滚、绝不因瞬时锁返回非 0 触发安装器重试。
+!macro customRemoveFiles
+  SetOutPath $TEMP
+  nsExec::Exec `cmd /c rd /s /q "$INSTDIR\resources\pragent"`
+  Pop $0
+  RMDir /r /REBOOTOK "$INSTDIR"
 !macroend

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -101,6 +101,10 @@ linux:
 
 nsis:
   oneClick: false
-  perMachine: false
+  # per-machine 安装（所有用户 / Program Files）。electron-builder 据此定义 INSTALL_MODE_PER_ALL_USERS
+  # → 安装器清单 RequestExecutionLevel admin（installer.nsi:20-25）→ 双击即弹 UAC、提权运行，
+  # 避免 perMachine:false(asInvoker) 在已有 per-machine 安装时"按需提权失败→静默退出→打不开"。
+  # 升级也变成单一提权实例，customInit 绕过旧卸载器更稳。安装后的应用本体仍 asInvoker、普通启动。
+  perMachine: true
   allowToChangeInstallationDirectory: true
   # 自定义注入见 build-resources/installer.nsh —— 由 buildResources auto-include 自动收录，无需显式 include。

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meebox/desktop",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0",
   "private": true,
   "description": "meebox Electron desktop app",
   "author": {


### PR DESCRIPTION
@
## 0.4.0 正式发布

本版重点（完整条目见 [CHANGELOG `[0.4.0]`](CHANGELOG.md)）：

- **接入 GitLab**（gitlab.com + Self-Managed，CE / EE，REST API v4）：`@meebox/platform-gitlab` 适配器，MR 发现 / 评论读写改删回复 / 合并 / clone / 附件，CE·EE 审批能力按 edition 降级。
- **评审交互与渲染打磨**：拒绝代码反馈/改进建议后折叠收起并置灰；代码建议草稿锚点与发布落点对齐；Bitbucket 评论内嵌附件图片修复；GitHub / GitLab 评论编辑/删除恢复；图片代理失败降级为浏览器打开。
- **连接 Base URL 放宽**：GHE / GitLab 自建可直填实例地址，`/api/v3`·`/api/v4` 自动补全。
- **Windows 升级安装健壮性**：改为 **per-machine 提权安装**（清单 `requireAdministrator`，双击即弹 UAC），并在升级时**绕过 electron-builder 旧卸载器**（customInit 清掉旧版卸载注册表项使 `uninstallOldVersion` no-op + 自行强删旧目录），修复「双击打不开」与「升级卡死 / 无法关闭」。

开发期 `0.4.0-alpha.1` 的变更已并入本版；本 PR 相对 alpha.1 的增量为上面的 **Windows 升级安装健壮性**修复 + 版本/CHANGELOG 收口。

### 验证
本地 CI 门禁全过：lint 12 / typecheck 12 / test 8 / build；Windows 安装包实测：双击弹 UAC 提权安装、应用普通启动正常、从旧版升级不再卡死。

> ⚠️ Windows 为 per-machine 安装（所有用户 / Program Files），安装器双击即弹 UAC；安装后应用普通权限启动；从旧版升级自动清理旧安装、无需手动卸载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@