### PR TITLE
feat(desktop): 无边框窗口 + 自绘标题栏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### Added
 - 设置页「运行环境」新增「关于 & 反馈」入口：GitHub 仓库（Star）/ 提交 Issue / Releases 三个外链
   （各带专属图标，点击经系统浏览器打开），低频社区入口集中于「关于」区、不进状态栏。
+- **无边框窗口 + 自绘标题栏**（VS Code 风）：主窗口去掉系统原生标题栏，渲染层自绘 36px 标题栏，
+  深色主题从顶贯通到底。窗控按钮交由系统绘制以保留原生行为——macOS 保留红绿灯（下移到标题栏内）、
+  Windows/Linux 用 `titleBarOverlay` 在右上画最小化/最大化/关闭。标题栏展示品牌名与当前 PR 标题，
+  Windows/Linux 开头另显应用图标（macOS 因红绿灯占位不显）。设计见
+  [`docs/arch/09-ui-interaction.md`](docs/arch/09-ui-interaction.md)。
 
 ### Changed
 - **移除独立 `ollama` provider**，统一经 `openai-compatible` 接入本地 Ollama（Base URL 填

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
   },
   renderer: {
     root: resolve('src/renderer'),
+    // 渲染层引用仓库根 assets/（品牌图标等单一来源，避免拷贝重复二进制）
+    resolve: {
+      alias: { '@assets': resolve('../../assets') },
+    },
     plugins: [react()],
     build: {
       rollupOptions: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -518,6 +518,13 @@ function createWindow(splash?: BrowserWindow): void {
     show: false,
     // 首帧前的窗口底色与 app 一致，避免显示瞬间白闪
     backgroundColor: '#1e1e1e',
+    // 无边框 + 自绘标题栏（VS Code 风）：macOS 保留红绿灯并下移到自绘标题栏内；
+    // Windows/Linux 用 titleBarOverlay 让系统继续画窗控按钮（最小化/最大化/关闭），
+    // 渲染层只接管中间标题区。高度需与渲染层 .app-titlebar 一致（36px）。
+    titleBarStyle: 'hidden',
+    ...(process.platform === 'darwin'
+      ? { trafficLightPosition: { x: 12, y: 11 } }
+      : { titleBarOverlay: { color: '#1e1e1e', symbolColor: '#cccccc', height: 36 } }),
     // dev 下显式给窗口图标（assets/icons/icon.ico）；打包态窗口/任务栏图标走 exe
     // 内嵌（electron-builder），且 assets 不进 asar，故仅 dev 设置
     icon: app.isPackaged ? undefined : path.join(app.getAppPath(), '../../assets/icons/icon.ico'),

--- a/apps/desktop/src/renderer/src/App.scss
+++ b/apps/desktop/src/renderer/src/App.scss
@@ -15,6 +15,7 @@
 //   drafts-panel "草稿" tab 列表页 (.drafts-panel / -filter / -item / -anchor)
 //   modal        SettingsModal + LlmEditorModal 子模态 + LLM profile 列表
 @use './styles/base';
+@use './styles/titlebar';
 @use './styles/statusbar';
 @use './styles/sidebar';
 @use './styles/main-pane';

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -22,6 +22,7 @@ import { OnboardingWizard, type OnboardingResult } from './components/onboarding
 import { SettingsModal } from './components/SettingsModal';
 import { Sidebar, SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_WIDTH } from './components/Sidebar';
 import { StatusBar } from './components/StatusBar';
+import { TitleBar } from './components/TitleBar';
 
 interface BootstrapState {
   info: AppInfo;
@@ -408,6 +409,7 @@ export default function App() {
 
   return (
     <div className="app">
+      <TitleBar platform={boot.info.platform} title={selected?.title} />
       <div className="app-body">
         {!sidebarCollapsed && (
           <Sidebar

--- a/apps/desktop/src/renderer/src/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TitleBar.tsx
@@ -1,0 +1,30 @@
+import type { Platform } from '@meebox/shared';
+import brandIcon from '@assets/icons/icon.png';
+
+interface TitleBarProps {
+  /** 运行平台：macOS 需为红绿灯留出左侧占位；Windows/Linux 窗控由系统 overlay 画在右上。 */
+  platform: Platform;
+  /** 标题区中间展示的上下文文案（如当前 PR 标题）；缺省仅显示品牌名。 */
+  title?: string;
+}
+
+/**
+ * 无边框窗口的自绘标题栏（VS Code 风）。整条 `-webkit-app-region: drag` 可拖拽窗口，
+ * 其中的交互元素需各自标 `no-drag`（见 styles/titlebar.scss）。
+ *
+ * 平台差异：
+ * - macOS：`titleBarStyle: hidden` 保留红绿灯，左侧留 72px 占位避免与品牌名重叠；
+ *   左上空间被红绿灯占据，**不展示**应用图标，仅品牌名。
+ * - Windows/Linux：`titleBarOverlay` 让系统在右上画最小化/最大化/关闭，故右侧留白，
+ *   勿在右上角放可点元素（会被 overlay 覆盖）；左侧空闲，开头展示应用图标。
+ */
+export function TitleBar({ platform, title }: TitleBarProps) {
+  const isMac = platform === 'darwin';
+  return (
+    <header className={`app-titlebar${isMac ? ' app-titlebar--mac' : ''}`}>
+      {!isMac && <img className="app-titlebar-icon" src={brandIcon} alt="" />}
+      <div className="app-titlebar-brand">Code Meeseeks</div>
+      {title && <div className="app-titlebar-title">{title}</div>}
+    </header>
+  );
+}

--- a/apps/desktop/src/renderer/src/styles/titlebar.scss
+++ b/apps/desktop/src/renderer/src/styles/titlebar.scss
@@ -1,0 +1,52 @@
+@use './tokens' as *;
+
+// 无边框窗口的自绘标题栏。高度必须与 main 进程 titleBarOverlay.height 一致（36px）。
+.app-titlebar {
+  flex: 0 0 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  gap: $space-4;
+  padding: 0 $space-6;
+  background: $bg-app;
+  border-bottom: 1px solid $border-muted;
+  user-select: none;
+  // 整条作为拖拽区；内部交互元素需各自 no-drag
+  -webkit-app-region: drag;
+
+  // macOS：为左上角红绿灯留位（trafficLightPosition x=12 起，约 3 颗 + 间距）
+  &--mac {
+    padding-left: 72px;
+  }
+}
+
+.app-titlebar-icon {
+  width: 18px;
+  height: 18px;
+  border-radius: $radius-md;
+  flex: 0 0 auto;
+  // 拖拽区内的图片默认可被拖出，禁掉以免误触发原生图片拖拽
+  -webkit-user-drag: none;
+}
+
+.app-titlebar-brand {
+  font-size: $fs-md;
+  font-weight: 600;
+  color: $text-primary;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+}
+
+.app-titlebar-title {
+  font-size: $fs-sm;
+  color: $text-muted;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+// 标题栏内的可点元素需关闭拖拽，否则点击会被当成拖窗
+.app-titlebar :is(button, a, input, select) {
+  -webkit-app-region: no-drag;
+}

--- a/docs/arch/09-ui-interaction.md
+++ b/docs/arch/09-ui-interaction.md
@@ -12,8 +12,9 @@
 ### 布局
 
 根组件挂载后做一次 bootstrap（并行拉 app 信息 / 配置 / PR 列表 / pr-agent 状态 / 连接 / 上次同步），
-之后是三栏 + 状态栏的主界面，外加按需浮层：
+之后是自绘标题栏 + 三栏 + 状态栏的主界面，外加按需浮层：
 
+- **TitleBar（顶）**：无边框窗口的自绘标题栏（见下「无边框窗口」），展示品牌名 + 选中 PR 标题，整条可拖拽窗口。
 - **Sidebar（左）**：待评审 PR 列表，按 `项目/仓库` 分组 + 手风琴折叠，updatedAt 倒序，状态过滤 + 搜索；
   宽度可拖拽、可整体收起。
 - **MainPane（中）**：选中 PR 的详情，分「变更 / 评论 / 提交 / 详情」标签页。变更页即 **DiffView**。
@@ -38,6 +39,19 @@ pr-agent run 的实时状态、仓库同步、草稿都用**模块级 store**（
 启动时把主进程的事件流（run 进度 / 队列变化 / 同步进度 / 草稿变化）接入。这样切换 PR 时运行中的状态、
 实时 stdout、草稿列表不随组件卸载丢失。
 
+### 无边框窗口
+
+主窗口去掉系统原生标题栏（`titleBarStyle: 'hidden'`），由渲染层自绘一条 36px 标题栏（VS Code 风），
+让深色主题从顶贯通到底。窗控按钮**不自绘**，交由系统画以保留原生行为（Snap Layouts / 双击最大化 / 吸附）：
+
+- **macOS**：保留红绿灯，`trafficLightPosition` 下移到自绘标题栏内；标题栏左侧留 72px 占位避让。
+- **Windows / Linux**：`titleBarOverlay` 让系统在右上画最小化/最大化/关闭，渲染层只接管中间标题区，
+  **勿在右上角放可点元素**（会被 overlay 覆盖）。`titleBarOverlay.height` 必须与渲染层 `.app-titlebar` 高度（36px）一致。
+
+拖拽实现：整条标题栏 `-webkit-app-region: drag`，其中的按钮/链接/输入等交互元素各自 `no-drag`，否则点击被当成拖窗。
+
+平台差异经 `AppInfo.platform`（bootstrap 时由主进程下发）判定，渲染层不直接读 `process`。
+
 ### 交互约定
 
 - **外链统一外开**：所有 UGC（评论 / PR 描述 / finding / chat）里的 `http(s)` 链接点击都走系统默认浏览器
@@ -60,4 +74,5 @@ pr-agent run 的实时状态、仓库同步、草稿都用**模块级 store**（
 - **跨 PR 需存活的状态进模块级 store**，不要塞组件 useState（切 PR 即丢）。
 - **安全基线**：`contextIsolation` 开、无 `nodeIntegration`、CSP；preload 只暴露白名单能力。
 - **二层模态**新增时记得 backdrop `stopPropagation`，否则会连带关掉外层。
+- **无边框标题栏高度**改动时，渲染层 `.app-titlebar` 与主进程 `titleBarOverlay.height` 两处须同步，否则 Windows 窗控与标题区错位；标题栏内新增交互元素记得标 `no-drag`。
 - Monaco 的 worker、view zone（行内评论/草稿）渲染较重，注意大 PR 下的懒加载与销毁。


### PR DESCRIPTION
## 概述

主窗口改为**无边框 + 自绘标题栏**（VS Code 风），深色主题从顶贯通到底，提升 IDE 沉浸感。窗控按钮**交由系统绘制**以保留原生行为（Snap Layouts / 双击最大化 / 吸附等），不自绘。

## 改动

**主进程**（`apps/desktop/src/main/index.ts`）
- 主窗口加 `titleBarStyle: 'hidden'`
- macOS → `trafficLightPosition`（红绿灯下移到自绘标题栏内）
- Windows/Linux → `titleBarOverlay`（系统在右上画最小化/最大化/关闭，色 `#1e1e1e`/`#cccccc`，高 36px）

**渲染层**
- 新增 `TitleBar.tsx`：36px 可拖拽标题栏，展示品牌名 + 当前 PR 标题；Windows/Linux 开头另显应用图标（macOS 因红绿灯占位不显）
- 新增 `titlebar.scss`：整条 `-webkit-app-region: drag`，内部交互元素 `no-drag`
- `App.tsx` / `App.scss` 接入；平台经 `AppInfo.platform` 判定
- `electron.vite.config.ts` 新增 `@assets` 别名 → 仓库根 `assets/`，应用图标复用单一来源（`assets/icons/icon.png`），不拷贝重复二进制

**文档**：`docs/arch/09-ui-interaction.md` 补充「无边框窗口」设计；CHANGELOG 记入 Unreleased。

## 平台差异

| | macOS | Windows / Linux |
|---|---|---|
| 窗控 | 原生红绿灯（位置下移） | 系统 `titleBarOverlay` 右上 |
| 应用图标 | 不显（红绿灯占位） | 标题栏开头显示 |

## 已知割舍（后续可跟进）

- 标题栏仅在主界面渲染；**加载 / 首启向导**页暂未配置（系统窗控仍在，但无自绘拖拽区）
- **双击标题栏最大化**：macOS 由系统处理，Windows 暂未自绘实现

## 验证

- `lint` / `typecheck` / `build` 均通过；`build` 确认 `@assets` 图标正确产出（`out/renderer/assets/icon-*.png`）
- dev 实机起动、首帧正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)