### PR TITLE
feat(agent): 编排器基座 — §2 上下文装配 + 独立 LLM 通道

### DIFF
--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/chat.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/chat.py
@@ -1,0 +1,56 @@
+"""编排器「独立 LLM 对话通道」的运行入口（见 docs/arch/06-agent.md §3 + packages/pr-agent-bridge）。
+
+由嵌入式运行时以 `python -m meebox_pragent_shim.chat` 启动：复用 pr-agent **已被本 shim 补丁**的
+`LiteLLMAIHandler.chat_completion`——provider 路由、CLI 模式（MEEBOX_CLI_MODE）、Anthropic 去
+temperature、token usage 哨兵全部继承，无需在此重复实现。
+
+约定：stdin 收一段 JSON `{"system": ..., "user": ..., "temperature"?: ...}`，回复正文写 stdout，
+token 用量经 `@@MEEBOX_USAGE@@` 哨兵打到 stderr（主进程与 pr-agent run 同一套累加，见 ipc.ts）。
+"""
+import asyncio
+import json
+import sys
+
+
+def _read_payload() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {"system": "", "user": "", "temperature": None}
+    data = json.loads(raw)
+    return {
+        "system": data.get("system") or "",
+        "user": data.get("user") or "",
+        "temperature": data.get("temperature"),
+    }
+
+
+async def _run(payload: dict) -> str:
+    # 惰性 import：触发 shim 注册的 post-import 补丁（CLI 模式替换 / _get_completion usage 包装）。
+    from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
+    from pr_agent.config_loader import get_settings
+
+    model = get_settings().config.model
+    handler = LiteLLMAIHandler()
+    kwargs = {"model": model, "system": payload["system"], "user": payload["user"]}
+    if payload["temperature"] is not None:
+        kwargs["temperature"] = payload["temperature"]
+    result = await handler.chat_completion(**kwargs)
+    # chat_completion 返回 (resp_text, finish_reason)
+    if isinstance(result, tuple):
+        return result[0] or ""
+    return result or ""
+
+
+def main() -> int:
+    try:
+        text = asyncio.run(_run(_read_payload()))
+        sys.stdout.write(text)
+        sys.stdout.flush()
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"meebox_chat error: {exc}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/agent/src/assemble.ts
+++ b/packages/agent/src/assemble.ts
@@ -1,0 +1,98 @@
+import type { Rule } from '@meebox/rules';
+import type { AgentContext } from './types.js';
+import type { AgentTodoItem, ToolCatalogEntry } from './session.js';
+
+/** 当前 PR 的最小元数据（装配进上下文）。 */
+export interface AssemblePrMeta {
+  title: string;
+  description?: string;
+  targetBranch: string;
+  /** 变更概况，如「12 files, +340/-58」。 */
+  changeSummary?: string;
+}
+
+/** 当前会话快照：让 Agent 续上未完成的规划。 */
+export interface AssembleSessionSnapshot {
+  todo: AgentTodoItem[];
+  progressNote?: string;
+}
+
+export interface AssembleInput {
+  context: AgentContext;
+  pr: AssemblePrMeta;
+  toolCatalog: ToolCatalogEntry[];
+  /** 命中的规则（按 §2 第 4 项注入正文）；无命中传 null。 */
+  matchedRule?: Rule | null;
+  /** 输出 / 记忆写入语言（解析后的 locale code；空 = 默认 en-US，见 §2 第 8 项）。 */
+  language?: string;
+  session?: AssembleSessionSnapshot;
+}
+
+function section(title: string, body: string | undefined): string | null {
+  const trimmed = (body ?? '').trim();
+  return trimmed ? `# ${title}\n\n${trimmed}` : null;
+}
+
+function renderToolCatalog(tools: ToolCatalogEntry[]): string | null {
+  if (tools.length === 0) return null;
+  const lines = tools.map((t) => {
+    const flags: string[] = [];
+    if (t.mutating) flags.push('mutating');
+    if (!t.enabled) flags.push('disabled — requires explicit authorization');
+    const suffix = flags.length ? ` _(${flags.join('; ')})_` : '';
+    return `- \`${t.name}\` — ${t.summary}${suffix}`;
+  });
+  return `# Available tools\n\n${lines.join('\n')}`;
+}
+
+function renderPr(pr: AssemblePrMeta): string {
+  const parts = [`Title: ${pr.title}`, `Target branch: ${pr.targetBranch}`];
+  if (pr.changeSummary) parts.push(`Changes: ${pr.changeSummary}`);
+  if (pr.description?.trim()) parts.push(`\nDescription:\n${pr.description.trim()}`);
+  return `# Current PR\n\n${parts.join('\n')}`;
+}
+
+function renderSession(snap: AssembleSessionSnapshot): string | null {
+  const todoLines = snap.todo.map((it) => `- [${it.done ? 'x' : ' '}] ${it.text}`);
+  const body = [
+    todoLines.length ? `Tasks:\n${todoLines.join('\n')}` : '',
+    snap.progressNote?.trim() ? `Progress:\n${snap.progressNote.trim()}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+  return body ? `# Current session\n\n${body}` : null;
+}
+
+function renderLanguage(language: string | undefined): string {
+  const lang = (language ?? '').trim() || 'en-US';
+  return [
+    '# Output & memory language',
+    '',
+    `Respond to the user in ${lang}.`,
+    `When appending new entries to MEMORY.md / USER.md, also write them in ${lang}.`,
+  ].join('\n');
+}
+
+/**
+ * 现读现装配：按 §2 固定次序拼接系统上下文。空段跳过。
+ * 次序：SOUL → AGENTS → 工具目录 → 命中规则 → MEMORY + USER → PR 元数据
+ *      → 会话快照 → 语言行为指令。
+ */
+export function assembleSystemContext(input: AssembleInput): string {
+  const { context, pr, toolCatalog, matchedRule, language, session } = input;
+  const { files } = context;
+
+  const blocks: Array<string | null> = [
+    section('Soul', files.soul),
+    section('Working agreement', files.agents),
+    renderToolCatalog(toolCatalog),
+    matchedRule ? section('Matched rule', matchedRule.instructions) : null,
+    section('Memory', files.memory),
+    section('User profile', files.user),
+    renderPr(pr),
+    session ? renderSession(session) : null,
+    renderLanguage(language),
+  ];
+
+  return blocks.filter((b): b is string => b !== null).join('\n\n---\n\n');
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,3 +5,20 @@ export { scaffoldAgentDir } from './scaffold.js';
 export { AGENT_TEMPLATES } from './templates.js';
 export type { AgentTemplate } from './templates.js';
 export type { AgentContext, AgentContextFiles, LoadAgentContextOptions } from './types.js';
+export { assembleSystemContext } from './assemble.js';
+export type {
+  AssembleInput,
+  AssemblePrMeta,
+  AssembleSessionSnapshot,
+} from './assemble.js';
+export type {
+  AgentRecommendation,
+  AgentRecommendationVerdict,
+  AgentSession,
+  AgentSessionStatus,
+  AgentStep,
+  AgentStepKind,
+  AgentTodoItem,
+  AgentToolCall,
+  ToolCatalogEntry,
+} from './session.js';

--- a/packages/agent/src/session.ts
+++ b/packages/agent/src/session.ts
@@ -1,0 +1,70 @@
+/**
+ * Agent 会话与工具目录的领域类型（见 docs/arch/06-agent.md §3 / 数据契约）。
+ * 纯类型 + 不依赖运行时；编排器、持久化、IPC 后续接入。
+ */
+
+/** 工具的副作用分类与可用性（红线落地的依据，见 §4）。 */
+export interface ToolCatalogEntry {
+  /** 工具指令名，如 `/describe`。 */
+  name: string;
+  /** 语义说明，注入提示词供 Agent 理解何时调用。 */
+  summary: string;
+  /** 是否修改类（对远端有副作用）。读/分析类 = false。 */
+  mutating: boolean;
+  /** 是否可被 Agent 自主调用：修改类在未授权时为 false（禁用态注入）。 */
+  enabled: boolean;
+}
+
+export type AgentSessionStatus = 'running' | 'paused' | 'done' | 'failed' | 'cancelled';
+
+/** 编排步骤的种类：规划 / 工具分发 / 判读（见 §3 计量边界）。 */
+export type AgentStepKind = 'plan' | 'tool' | 'judge';
+
+export interface AgentTodoItem {
+  id: string;
+  text: string;
+  done: boolean;
+}
+
+export interface AgentToolCall {
+  /** 被分发的工具名（如 `/review`）。 */
+  tool: string;
+  args?: Record<string, unknown>;
+}
+
+/** 一个编排级步骤（编排 agent 的一次决策回合，不含 pr-agent run 内部开销）。 */
+export interface AgentStep {
+  kind: AgentStepKind;
+  /** 思考摘要（留档 + 流式推送）。 */
+  thought?: string;
+  /** kind='tool' 时的工具调用。 */
+  toolCall?: AgentToolCall;
+  /** 工具结果 / 判读结论的摘要。 */
+  result?: string;
+}
+
+export type AgentRecommendationVerdict = 'approve' | 'needs_work' | 'manual_review';
+
+/** 收尾建议（非约束性，不触发任何写操作，见 §6）。 */
+export interface AgentRecommendation {
+  verdict: AgentRecommendationVerdict;
+  reason: string;
+}
+
+/** 每个 PR 一份、由子 agent 所有的会话记录（见数据契约）。 */
+export interface AgentSession {
+  id: string;
+  prLocalId: string;
+  status: AgentSessionStatus;
+  todo: AgentTodoItem[];
+  stepCount: number;
+  maxSteps: number;
+  /** 本 PR 收尾总结正文（受 summary_max_chars 限长）。 */
+  summary?: string;
+  /** 收尾建议（非约束性）。 */
+  recommendation?: AgentRecommendation;
+  startedAt: string;
+  finishedAt?: string;
+  /** 终止原因（如「步数上限中止」「用户暂停」）。 */
+  terminationReason?: string;
+}

--- a/packages/agent/tests/assemble.test.ts
+++ b/packages/agent/tests/assemble.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { assembleSystemContext } from '../src/assemble.js';
+import type { AgentContext } from '../src/types.js';
+import type { ToolCatalogEntry } from '../src/session.js';
+
+const emptyContext: AgentContext = {
+  files: { soul: '', agents: '', memory: '', user: '' },
+  rules: [],
+};
+
+const tools: ToolCatalogEntry[] = [
+  { name: '/review', summary: 'Generate review findings', mutating: false, enabled: true },
+  { name: '/approve', summary: 'Approve the PR', mutating: true, enabled: false },
+];
+
+const pr = { title: 'Fix login bug', targetBranch: 'main', changeSummary: '3 files, +20/-5' };
+
+describe('assembleSystemContext', () => {
+  it('orders sections per §2 and skips empty ones', () => {
+    const out = assembleSystemContext({
+      context: {
+        files: { soul: 'I am soul', agents: 'work rules', memory: '', user: 'prefers terse' },
+        rules: [],
+      },
+      pr,
+      toolCatalog: tools,
+      language: 'zh-CN',
+    });
+
+    // SOUL before AGENTS before tools before PR before language
+    expect(out.indexOf('# Soul')).toBeLessThan(out.indexOf('# Working agreement'));
+    expect(out.indexOf('# Working agreement')).toBeLessThan(out.indexOf('# Available tools'));
+    expect(out.indexOf('# Available tools')).toBeLessThan(out.indexOf('# Current PR'));
+    expect(out.indexOf('# Current PR')).toBeLessThan(out.indexOf('# Output & memory language'));
+    // empty memory section is skipped, present user section is kept
+    expect(out).not.toContain('# Memory');
+    expect(out).toContain('# User profile');
+  });
+
+  it('marks mutating/disabled tools in the catalog', () => {
+    const out = assembleSystemContext({ context: emptyContext, pr, toolCatalog: tools });
+    expect(out).toContain('`/review` — Generate review findings');
+    expect(out).toContain('`/approve`');
+    expect(out).toContain('mutating');
+    expect(out).toContain('requires explicit authorization');
+  });
+
+  it('emits the language directive for output and memory writes; defaults to en-US', () => {
+    const zh = assembleSystemContext({ context: emptyContext, pr, toolCatalog: [], language: 'zh-CN' });
+    expect(zh).toContain('Respond to the user in zh-CN');
+    expect(zh).toContain('MEMORY.md / USER.md');
+
+    const def = assembleSystemContext({ context: emptyContext, pr, toolCatalog: [] });
+    expect(def).toContain('Respond to the user in en-US');
+  });
+
+  it('renders the session snapshot when provided', () => {
+    const out = assembleSystemContext({
+      context: emptyContext,
+      pr,
+      toolCatalog: [],
+      session: { todo: [{ id: '1', text: 'run review', done: false }], progressNote: 'started' },
+    });
+    expect(out).toContain('# Current session');
+    expect(out).toContain('- [ ] run review');
+    expect(out).toContain('started');
+  });
+});

--- a/packages/pr-agent-bridge/src/bridge.ts
+++ b/packages/pr-agent-bridge/src/bridge.ts
@@ -1,6 +1,8 @@
 import type { PrAgentStrategy } from '@meebox/shared';
 import { defaultExec } from './exec.js';
+import { PrAgentRunError } from './types.js';
 import type {
+  ChatRunOptions,
   ExecFn,
   PrAgentBridge,
   PrAgentRunOptions,
@@ -11,6 +13,10 @@ import type {
 // 3-8 min；5 min 经常打 timeout。设到 10 min 让绝大多数真实 PR 能跑完，仍能兜住
 // 卡死的子进程不让它无限挂着。需要更长的话调用方可在 opts.timeoutMs 显式覆盖
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+// chat 通道单次默认 5 min：编排 / 判定调用通常远快于 /review，但推理型模型仍可能慢。
+const DEFAULT_CHAT_TIMEOUT_MS = 5 * 60 * 1000;
+// 强制 UTF-8（中文 Windows 默认码页会让含 emoji 的输出崩，见 buildInvocation）。
+const UTF8_ENV = { PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8' } as const;
 
 /** 各策略共享的骨架：把 RunOptions 翻成 (cmd, args, env) 后委派给 ExecFn */
 abstract class BaseBridge implements PrAgentBridge {
@@ -40,7 +46,31 @@ abstract class BaseBridge implements PrAgentBridge {
     });
   }
 
+  async chat(opts: ChatRunOptions): Promise<PrAgentRunResult> {
+    const { cmd, args, env, cwd } = this.buildChatInvocation(opts);
+    const input = JSON.stringify({
+      system: opts.system ?? '',
+      user: opts.user,
+      ...(opts.temperature != null ? { temperature: opts.temperature } : {}),
+    });
+    return this.exec(cmd, args, {
+      timeoutMs: opts.timeoutMs ?? DEFAULT_CHAT_TIMEOUT_MS,
+      env,
+      cwd,
+      input,
+      signal: opts.signal,
+    });
+  }
+
   protected abstract buildInvocation(opts: PrAgentRunOptions): {
+    cmd: string;
+    args: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+  };
+
+  /** chat 通道的 (cmd, args, env, cwd)；仅嵌入式支持，其余策略抛错。 */
+  protected abstract buildChatInvocation(opts: ChatRunOptions): {
     cmd: string;
     args: string[];
     env?: Record<string, string>;
@@ -91,6 +121,18 @@ export class LocalCliBridge extends BaseBridge {
       env: opts.env,
     };
   }
+
+  protected buildChatInvocation(): {
+    cmd: string;
+    args: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+  } {
+    throw new PrAgentRunError(
+      'chat 通道仅支持嵌入式运行时（local-cli 策略无 meebox 运行时）',
+      'spawn-failed',
+    );
+  }
 }
 
 /**
@@ -136,6 +178,22 @@ export class EmbeddedRuntimeBridge extends BaseBridge {
       cmd: this.pythonPath,
       args: [...cli, '--pr_url', opts.prUrl, opts.tool, ...(opts.extraArgs ?? [])],
       env: { ...(opts.env ?? {}), ...utf8 },
+    };
+  }
+
+  protected buildChatInvocation(opts: ChatRunOptions): {
+    cmd: string;
+    args: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+  } {
+    // 跑随运行时打包的 chat helper：复用 pr-agent 已被 shim 补丁的 LiteLLMAIHandler
+    // （provider 路由 / CLI 模式 / 去 temperature / usage 哨兵全继承）。
+    return {
+      cmd: this.pythonPath,
+      args: ['-m', 'meebox_pragent_shim.chat'],
+      env: { ...(opts.env ?? {}), ...UTF8_ENV },
+      cwd: opts.cwd,
     };
   }
 }

--- a/packages/pr-agent-bridge/src/exec.ts
+++ b/packages/pr-agent-bridge/src/exec.ts
@@ -9,11 +9,18 @@ interface DataEmitter {
   on(event: 'data', cb: (chunk: Buffer | string) => void): void;
 }
 
+interface WritableLike {
+  write(chunk: string): unknown;
+  end(): unknown;
+}
+
 interface SpawnedChild {
   /** 子进程 pid；spawn 失败时为 undefined。用于调用方做进程树级清理。 */
   pid?: number;
   stdout: DataEmitter | null;
   stderr: DataEmitter | null;
+  /** 子进程 stdin；opts.input 时写入后 end。spawn 失败 / fake child 可为空。 */
+  stdin?: WritableLike | null;
   on(event: 'error', cb: (err: Error) => void): void;
   on(event: 'close', cb: (code: number | null, signal: NodeJS.Signals | null) => void): void;
   kill(signal?: NodeJS.Signals | number): boolean;
@@ -87,6 +94,16 @@ export function createExec(spawnFn: SpawnFn = spawn as unknown as SpawnFn): Exec
           ),
         );
         return;
+      }
+
+      // 把 prompt 等输入写进子进程 stdin（chat 通道用），写完即 end 触发 EOF。
+      if (opts.input != null) {
+        try {
+          child.stdin?.write(opts.input);
+          child.stdin?.end();
+        } catch {
+          /* stdin 已关闭 / 子进程已退出，忽略 */
+        }
       }
 
       const timer = setTimeout(() => {

--- a/packages/pr-agent-bridge/src/types.ts
+++ b/packages/pr-agent-bridge/src/types.ts
@@ -81,6 +81,29 @@ export interface ExecOptions {
   cwd?: string;
   /** 用户主动取消信号；abort 后 SIGKILL 子进程并 reject reason='cancelled' */
   signal?: AbortSignal;
+  /** 写入子进程 stdin 的内容（写完即 end）；chat 通道传 prompt 用。 */
+  input?: string;
+}
+
+/**
+ * 编排器「独立 LLM 通道」的一次原始对话调用（见 docs/arch/06-agent.md §3）。
+ * 复用嵌入式运行时的 litellm（provider 路由 / 代理 / token 采集已解决）：
+ * 子进程跑 `meebox_pragent_shim.chat`，prompt 经 stdin 传入，结果走 stdout，
+ * token 用量经 `@@MEEBOX_USAGE@@` 哨兵打到 stderr（与 pr-agent run 同一套）。
+ */
+export interface ChatRunOptions {
+  /** system 段（可空）。 */
+  system?: string;
+  /** user 段（必填）。 */
+  user: string;
+  /** 采样温度；anthropic 经 shim 自动剔除。 */
+  temperature?: number;
+  /** 注入子进程的 env（LLM key / model / 代理，复用 buildPragentEnv）。 */
+  env?: Record<string, string>;
+  /** 子进程工作目录；建议传中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。 */
+  cwd?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 /**
@@ -100,4 +123,10 @@ export interface PrAgentBridge {
   review(opts: Omit<PrAgentRunOptions, 'tool'>): Promise<PrAgentRunResult>;
   /** 通用入口；后续加 /ask /improve 时直接用 run */
   run(opts: PrAgentRunOptions): Promise<PrAgentRunResult>;
+  /**
+   * 编排器的独立 LLM 对话通道（复用嵌入式 litellm，见 ChatRunOptions）。
+   * 仅嵌入式策略支持；local-cli 策略调用即抛错。结果 stdout = 回复文本，
+   * stderr 含 `@@MEEBOX_USAGE@@` token 哨兵（调用方按既有解析器累加）。
+   */
+  chat(opts: ChatRunOptions): Promise<PrAgentRunResult>;
 }

--- a/packages/pr-agent-bridge/tests/bridge.test.ts
+++ b/packages/pr-agent-bridge/tests/bridge.test.ts
@@ -110,6 +110,11 @@ describe('LocalCliBridge', () => {
     expect(calls[0]!.args).toEqual(['--pr_url', '', 'review']);
     expect(calls[0]!.opts.env).toEqual({ CONFIG__GIT_PROVIDER: 'local' });
   });
+
+  it('chat: local-cli 不支持，调用即抛错（无嵌入式运行时）', async () => {
+    const bridge = new LocalCliBridge('v', makeRecordingExec().exec);
+    await expect(bridge.chat({ user: 'hi' })).rejects.toThrow(/嵌入式/);
+  });
 });
 
 describe('EmbeddedRuntimeBridge', () => {
@@ -165,5 +170,34 @@ describe('EmbeddedRuntimeBridge', () => {
     const bridge = new EmbeddedRuntimeBridge('embedded Python 3.12.13', PY, makeRecordingExec().exec);
     expect(bridge.strategy).toBe('embedded');
     expect(bridge.version).toBe('embedded Python 3.12.13');
+  });
+
+  it('chat: 跑 meebox_pragent_shim.chat，prompt 走 stdin，UTF-8 + 中性 cwd', async () => {
+    const { exec, calls } = makeRecordingExec({ stdout: 'reply' });
+    const bridge = new EmbeddedRuntimeBridge('v', PY, exec);
+    const res = await bridge.chat({
+      system: 'sys',
+      user: 'hi',
+      env: { OPENAI__KEY: 'sk' },
+      cwd: '/tmp/neutral',
+    });
+    expect(res.stdout).toBe('reply');
+    expect(calls[0]!.cmd).toBe(PY);
+    expect(calls[0]!.args).toEqual(['-m', 'meebox_pragent_shim.chat']);
+    expect(calls[0]!.opts.cwd).toBe('/tmp/neutral');
+    expect(calls[0]!.opts.env).toEqual({
+      OPENAI__KEY: 'sk',
+      PYTHONUTF8: '1',
+      PYTHONIOENCODING: 'utf-8',
+    });
+    expect(JSON.parse(calls[0]!.opts.input!)).toEqual({ system: 'sys', user: 'hi' });
+    expect(calls[0]!.opts.timeoutMs).toBe(5 * 60 * 1000);
+  });
+
+  it('chat: temperature 仅在显式传入时进 payload', async () => {
+    const { exec, calls } = makeRecordingExec();
+    const bridge = new EmbeddedRuntimeBridge('v', PY, exec);
+    await bridge.chat({ user: 'hi', temperature: 0.7 });
+    expect(JSON.parse(calls[0]!.opts.input!)).toEqual({ system: '', user: 'hi', temperature: 0.7 });
   });
 });


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) P2「会话 Agent 化」的**编排器基座**（纯基础件，编排循环 P2.4 待后续接入）。

### P2.1 会话/工具类型 + §2 上下文装配（纯逻辑）
- `session.ts`：`AgentSession` / `AgentStep` / `AgentTodoItem` / `ToolCatalogEntry` / `AgentRecommendation` 等领域类型。
- `assemble.ts`：`assembleSystemContext` 按设计 §2 固定次序装配系统上下文（SOUL → AGENTS → 工具目录 → 命中规则 → MEMORY + USER → PR 元数据 → 会话快照 → 语言行为指令），空段跳过，工具目录标注 mutating/disabled。

### P2.2 独立 LLM 对话通道（复用嵌入式 litellm）
- 不在 TS 重写 7 个 provider 的路由，复用 pr-agent **已被 shim 补丁**的 `LiteLLMAIHandler`。
- `PrAgentBridge.chat(ChatRunOptions)`：嵌入式跑 `meebox_pragent_shim.chat`，prompt 经 stdin、回复走 stdout、token 用量经 `@@MEEBOX_USAGE@@` 哨兵（与 pr-agent run 同一套累加）。
- `exec` 增 stdin（`input`）；`local-cli` 策略 chat 即抛错。
- `chat.py` shim：调 `chat_completion`，provider 路由 / CLI 模式 / Anthropic 去 temperature / usage 全继承。

### 验证
`lint` / `typecheck`（13 projects）/ `test`（9 projects，含 agent assemble 4 例 + bridge chat 例）全绿；`chat.py` 嵌入式运行时 import 冒烟 OK。实时 LLM round-trip 需真实密钥，留待运行期冒烟。

### 后续（同里程碑）
P2.3 会话持久化、**P2.4 编排循环**（plan→dispatch→judge→summary，把基座接成可用编排器）、P2.5 自然语言路由 + IPC。

🤖 Generated with [Claude Code](https://claude.com/claude-code)