### PR TITLE
feat(agent): 会话持久化 + 契约类型迁入 shared（含注释稳定化）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14050,7 +14050,8 @@
       "name": "@meebox/agent",
       "version": "0.0.0",
       "dependencies": {
-        "@meebox/rules": "*"
+        "@meebox/rules": "*",
+        "@meebox/shared": "*"
       },
       "devDependencies": {
         "vitest": "^4.1.0"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -22,7 +22,8 @@
     }
   },
   "dependencies": {
-    "@meebox/rules": "*"
+    "@meebox/rules": "*",
+    "@meebox/shared": "*"
   },
   "devDependencies": {
     "vitest": "^4.1.0"

--- a/packages/agent/src/assemble.ts
+++ b/packages/agent/src/assemble.ts
@@ -1,6 +1,6 @@
 import type { Rule } from '@meebox/rules';
+import type { AgentTodoItem, ToolCatalogEntry } from '@meebox/shared';
 import type { AgentContext } from './types.js';
-import type { AgentTodoItem, ToolCatalogEntry } from './session.js';
 
 /** 当前 PR 的最小元数据（装配进上下文）。 */
 export interface AssemblePrMeta {
@@ -21,9 +21,9 @@ export interface AssembleInput {
   context: AgentContext;
   pr: AssemblePrMeta;
   toolCatalog: ToolCatalogEntry[];
-  /** 命中的规则（按 §2 第 4 项注入正文）；无命中传 null。 */
+  /** 命中的规则（按「上下文注入」次序注入正文）；无命中传 null。 */
   matchedRule?: Rule | null;
-  /** 输出 / 记忆写入语言（解析后的 locale code；空 = 默认 en-US，见 §2 第 8 项）。 */
+  /** 输出 / 记忆写入语言（解析后的 locale code；空 = 默认 en-US，见「语言行为指令」）。 */
   language?: string;
   session?: AssembleSessionSnapshot;
 }
@@ -74,7 +74,7 @@ function renderLanguage(language: string | undefined): string {
 }
 
 /**
- * 现读现装配：按 §2 固定次序拼接系统上下文。空段跳过。
+ * 现读现装配：按「上下文注入」固定次序拼接系统上下文。空段跳过。
  * 次序：SOUL → AGENTS → 工具目录 → 命中规则 → MEMORY + USER → PR 元数据
  *      → 会话快照 → 语言行为指令。
  */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,14 +11,3 @@ export type {
   AssemblePrMeta,
   AssembleSessionSnapshot,
 } from './assemble.js';
-export type {
-  AgentRecommendation,
-  AgentRecommendationVerdict,
-  AgentSession,
-  AgentSessionStatus,
-  AgentStep,
-  AgentStepKind,
-  AgentTodoItem,
-  AgentToolCall,
-  ToolCatalogEntry,
-} from './session.js';

--- a/packages/agent/src/layout.ts
+++ b/packages/agent/src/layout.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 /**
- * Agent 目录的固定文件布局（见 docs/arch/06-agent.md §1）。
+ * Agent 目录的固定文件布局（见 docs/arch/06-agent.md「Agent 目录」）。
  * - SOUL.md  灵魂：核心职责与边界（Agent 只读，默认由模版规定）
  * - AGENTS.md 工作规范与红线
  * - MEMORY.md 长期记忆（可写）

--- a/packages/agent/src/load.ts
+++ b/packages/agent/src/load.ts
@@ -22,7 +22,7 @@ const EMPTY_FILES: AgentContextFiles = { soul: '', agents: '', memory: '', user:
 
 /**
  * 现读现装配：每次执行重新读 Agent 目录的 SOUL / AGENTS / MEMORY / USER 与 rules/，
- * **无缓存**（见 docs/arch/06-agent.md §2）。空 agentDir → 全空上下文（Agent 退化为原生）。
+ * **无缓存**（见 docs/arch/06-agent.md「上下文注入」）。空 agentDir → 全空上下文（Agent 退化为原生）。
  */
 export async function loadAgentContext(
   agentDir: string,

--- a/packages/agent/src/scaffold.ts
+++ b/packages/agent/src/scaffold.ts
@@ -14,7 +14,7 @@ async function exists(p: string): Promise<boolean> {
 
 /**
  * 幂等脚手架：把缺失的模版文件写入 agentDir（已存在不覆盖），并确保 rules/ 子目录存在。
- * 返回**实际创建**的文件相对路径列表（已存在的不计）。见 docs/arch/06-agent.md §8。
+ * 返回**实际创建**的文件相对路径列表（已存在的不计）。见 docs/arch/06-agent.md「提示词模版」。
  */
 export async function scaffoldAgentDir(agentDir: string): Promise<string[]> {
   if (!agentDir) throw new Error('scaffoldAgentDir: agentDir 不能为空');

--- a/packages/agent/src/templates.ts
+++ b/packages/agent/src/templates.ts
@@ -5,7 +5,7 @@ import user from '../resources/USER.md?raw';
 import ruleExample from '../resources/rules/example.md?raw';
 
 /**
- * Agent 目录初始化模版（统一 **en-US**、不做 i18n，见 docs/arch/06-agent.md §8）。
+ * Agent 目录初始化模版（统一 **en-US**、不做 i18n，见 docs/arch/06-agent.md「提示词模版」）。
  * 模版正文是 `resources/` 下的独立 `.md` 资源文件，构建期经 Vite `?raw` 内联；
  * 本文件只保留**加载/清单逻辑**。用户初始化后可自由改写成目标语言；
  * `SOUL.md` 默认完全由本模版规定、Agent 无权改写。

--- a/packages/agent/tests/assemble.test.ts
+++ b/packages/agent/tests/assemble.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { assembleSystemContext } from '../src/assemble.js';
+import type { ToolCatalogEntry } from '@meebox/shared';
 import type { AgentContext } from '../src/types.js';
-import type { ToolCatalogEntry } from '../src/session.js';
 
 const emptyContext: AgentContext = {
   files: { soul: '', agents: '', memory: '', user: '' },

--- a/packages/poller/src/agent-session.ts
+++ b/packages/poller/src/agent-session.ts
@@ -1,0 +1,142 @@
+import type {
+  AgentSession,
+  AgentSessionFile,
+  AgentSessionStatus,
+  AgentStep,
+  AgentTodoItem,
+  AgentTranscriptFile,
+  AgentRecommendation,
+} from '@meebox/shared';
+import type { StateStore } from '@meebox/state-store';
+import { makeRunId } from './runs.js';
+
+/**
+ * Agent 会话落在 `prs/<localId>/agent/`：每个 PR 一份 session + 一条 transcript，
+ * 与 meta / comments / runs 同处该 PR 目录，PR 退场时 deleteDir 整棵清掉（与它们同寿命）。
+ * localId 是 prHashId 出来的 12 位 hex，无路径不安全字符，不需 sanitize。
+ */
+function sessionKey(prLocalId: string): string {
+  return `prs/${prLocalId}/agent/session`;
+}
+function transcriptKey(prLocalId: string): string {
+  return `prs/${prLocalId}/agent/transcript`;
+}
+
+export interface StartAgentSessionInput {
+  prLocalId: string;
+  maxSteps: number;
+  /** 外部预分配的 session id（与队列 id 对齐）；缺省按时序生成。 */
+  id?: string;
+}
+
+/**
+ * 起一个新会话：写初始 running 状态，并把 transcript 清空（新会话覆盖旧的，
+ * 每个 PR 同时只有一份当前会话，见「会话隔离」）。
+ */
+export async function startAgentSession(
+  stateStore: StateStore,
+  input: StartAgentSessionInput,
+  now: () => Date = () => new Date(),
+): Promise<AgentSession> {
+  const at = now();
+  const session: AgentSession = {
+    id: input.id ?? makeRunId(at),
+    prLocalId: input.prLocalId,
+    status: 'running',
+    todo: [],
+    stepCount: 0,
+    maxSteps: input.maxSteps,
+    startedAt: at.toISOString(),
+  };
+  await stateStore.write<AgentSessionFile>(sessionKey(input.prLocalId), {
+    schema_version: 1,
+    session,
+  });
+  await stateStore.write<AgentTranscriptFile>(transcriptKey(input.prLocalId), {
+    schema_version: 1,
+    steps: [],
+  });
+  return session;
+}
+
+export interface AgentSessionPatch {
+  status?: AgentSessionStatus;
+  todo?: AgentTodoItem[];
+  stepCount?: number;
+  summary?: string;
+  recommendation?: AgentRecommendation;
+  finishedAt?: string;
+  terminationReason?: string;
+}
+
+/**
+ * Merge patch 到已存在的会话并重写。会话不存在返回 null（不重建空记录，避免
+ * start 失败后的 update 静默成功；与 finishReviewRun 一致）。
+ */
+export async function updateAgentSession(
+  stateStore: StateStore,
+  prLocalId: string,
+  patch: AgentSessionPatch,
+): Promise<AgentSession | null> {
+  const file = await stateStore.read<AgentSessionFile>(sessionKey(prLocalId));
+  if (!file) return null;
+  const next: AgentSession = { ...file.session, ...patch };
+  await stateStore.write<AgentSessionFile>(sessionKey(prLocalId), {
+    schema_version: 1,
+    session: next,
+  });
+  return next;
+}
+
+export async function getAgentSession(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<AgentSession | null> {
+  const file = await stateStore.read<AgentSessionFile>(sessionKey(prLocalId));
+  return file?.session ?? null;
+}
+
+export async function getAgentTranscript(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<AgentStep[]> {
+  const file = await stateStore.read<AgentTranscriptFile>(transcriptKey(prLocalId));
+  return file?.steps ?? [];
+}
+
+/**
+ * 追加一个编排步骤到 transcript，并同步会话的 stepCount（= transcript 长度）。
+ * 会话不存在返回 null（必须先 start）。`at` 缺省时打当前时间。
+ */
+export async function appendAgentStep(
+  stateStore: StateStore,
+  prLocalId: string,
+  step: AgentStep,
+  now: () => Date = () => new Date(),
+): Promise<AgentSession | null> {
+  const sessionFile = await stateStore.read<AgentSessionFile>(sessionKey(prLocalId));
+  if (!sessionFile) return null;
+
+  const steps = await getAgentTranscript(stateStore, prLocalId);
+  steps.push({ ...step, at: step.at ?? now().toISOString() });
+  await stateStore.write<AgentTranscriptFile>(transcriptKey(prLocalId), {
+    schema_version: 1,
+    steps,
+  });
+
+  const next: AgentSession = { ...sessionFile.session, stepCount: steps.length };
+  await stateStore.write<AgentSessionFile>(sessionKey(prLocalId), {
+    schema_version: 1,
+    session: next,
+  });
+  return next;
+}
+
+/** 清掉某 PR 的会话 + transcript（删 `prs/<localId>/agent/*`）。 */
+export async function clearAgentSession(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<void> {
+  await stateStore.delete(sessionKey(prLocalId));
+  await stateStore.delete(transcriptKey(prLocalId));
+}

--- a/packages/poller/src/index.ts
+++ b/packages/poller/src/index.ts
@@ -4,5 +4,6 @@ export * from './pr-hash-id.js';
 export * from './pr-state.js';
 export * from './comments-cache.js';
 export * from './runs.js';
+export * from './agent-session.js';
 export * from './drafts.js';
 export * from './parse-output.js';

--- a/packages/poller/tests/agent-session.test.ts
+++ b/packages/poller/tests/agent-session.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { StateStore } from '@meebox/state-store';
+import {
+  appendAgentStep,
+  clearAgentSession,
+  getAgentSession,
+  getAgentTranscript,
+  startAgentSession,
+  updateAgentSession,
+} from '../src/agent-session.js';
+
+/** 内存版 StateStore：覆盖 read/write/delete/list/deleteDir，供持久化逻辑单测。 */
+class MemStore implements StateStore {
+  private m = new Map<string, unknown>();
+  async read<T>(key: string): Promise<T | null> {
+    return this.m.has(key) ? (structuredClone(this.m.get(key)) as T) : null;
+  }
+  async write<T>(key: string, data: T): Promise<void> {
+    this.m.set(key, structuredClone(data));
+  }
+  async delete(key: string): Promise<void> {
+    this.m.delete(key);
+  }
+  async *list(prefix: string): AsyncIterable<string> {
+    for (const k of this.m.keys()) if (k === prefix || k.startsWith(`${prefix}/`)) yield k;
+  }
+  async deleteDir(prefix: string): Promise<void> {
+    for (const k of [...this.m.keys()]) if (k === prefix || k.startsWith(`${prefix}/`)) this.m.delete(k);
+  }
+}
+
+const PR = 'abc123def456';
+const fixedNow = (): Date => new Date('2026-06-15T10:00:00.000Z');
+
+let store: MemStore;
+beforeEach(() => {
+  store = new MemStore();
+});
+
+describe('startAgentSession', () => {
+  it('writes a running session + empty transcript', async () => {
+    const s = await startAgentSession(store, { prLocalId: PR, maxSteps: 5 }, fixedNow);
+    expect(s.status).toBe('running');
+    expect(s.stepCount).toBe(0);
+    expect(s.todo).toEqual([]);
+    expect(s.maxSteps).toBe(5);
+    expect(s.prLocalId).toBe(PR);
+
+    expect(await getAgentSession(store, PR)).toEqual(s);
+    expect(await getAgentTranscript(store, PR)).toEqual([]);
+  });
+
+  it('uses an external id when given', async () => {
+    const s = await startAgentSession(store, { prLocalId: PR, maxSteps: 3, id: 'sess-1' });
+    expect(s.id).toBe('sess-1');
+  });
+
+  it('resets the transcript on restart', async () => {
+    await startAgentSession(store, { prLocalId: PR, maxSteps: 5 });
+    await appendAgentStep(store, PR, { kind: 'plan', thought: 'first' });
+    expect(await getAgentTranscript(store, PR)).toHaveLength(1);
+    await startAgentSession(store, { prLocalId: PR, maxSteps: 5 });
+    expect(await getAgentTranscript(store, PR)).toEqual([]);
+  });
+});
+
+describe('updateAgentSession', () => {
+  it('merges a patch and rewrites', async () => {
+    await startAgentSession(store, { prLocalId: PR, maxSteps: 5 });
+    const next = await updateAgentSession(store, PR, {
+      status: 'done',
+      summary: 'looks fine',
+      recommendation: { verdict: 'approve', reason: 'no issues' },
+      finishedAt: '2026-06-15T10:01:00.000Z',
+    });
+    expect(next?.status).toBe('done');
+    expect(next?.summary).toBe('looks fine');
+    expect(next?.recommendation?.verdict).toBe('approve');
+    expect((await getAgentSession(store, PR))?.status).toBe('done');
+  });
+
+  it('returns null when the session does not exist', async () => {
+    expect(await updateAgentSession(store, 'missing', { status: 'done' })).toBeNull();
+  });
+});
+
+describe('appendAgentStep', () => {
+  it('appends to transcript, stamps at, and syncs stepCount', async () => {
+    await startAgentSession(store, { prLocalId: PR, maxSteps: 5 });
+    const s1 = await appendAgentStep(store, PR, { kind: 'plan', thought: 'plan it' }, fixedNow);
+    expect(s1?.stepCount).toBe(1);
+    const s2 = await appendAgentStep(
+      store,
+      PR,
+      { kind: 'tool', toolCall: { tool: '/review' } },
+      fixedNow,
+    );
+    expect(s2?.stepCount).toBe(2);
+
+    const steps = await getAgentTranscript(store, PR);
+    expect(steps).toHaveLength(2);
+    expect(steps[0]?.at).toBe('2026-06-15T10:00:00.000Z');
+    expect(steps[1]?.toolCall?.tool).toBe('/review');
+  });
+
+  it('returns null when no session was started', async () => {
+    expect(await appendAgentStep(store, 'missing', { kind: 'plan' })).toBeNull();
+  });
+});
+
+describe('clearAgentSession', () => {
+  it('removes session and transcript', async () => {
+    await startAgentSession(store, { prLocalId: PR, maxSteps: 5 });
+    await appendAgentStep(store, PR, { kind: 'plan' });
+    await clearAgentSession(store, PR);
+    expect(await getAgentSession(store, PR)).toBeNull();
+    expect(await getAgentTranscript(store, PR)).toEqual([]);
+  });
+});

--- a/packages/pr-agent-bridge/src/types.ts
+++ b/packages/pr-agent-bridge/src/types.ts
@@ -86,7 +86,7 @@ export interface ExecOptions {
 }
 
 /**
- * 编排器「独立 LLM 通道」的一次原始对话调用（见 docs/arch/06-agent.md §3）。
+ * 编排器「独立 LLM 通道」的一次原始对话调用（见 docs/arch/06-agent.md「会话 Agent 化」）。
  * 复用嵌入式运行时的 litellm（provider 路由 / 代理 / token 采集已解决）：
  * 子进程跑 `meebox_pragent_shim.chat`，prompt 经 stdin 传入，结果走 stdout，
  * token 用量经 `@@MEEBOX_USAGE@@` 哨兵打到 stderr（与 pr-agent run 同一套）。

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -1,9 +1,10 @@
 /**
- * Agent 会话与工具目录的领域类型（见 docs/arch/06-agent.md §3 / 数据契约）。
- * 纯类型 + 不依赖运行时；编排器、持久化、IPC 后续接入。
+ * 高阶 Agent 的会话与工具契约类型（见 docs/arch/06-agent.md「会话 Agent 化」与「数据契约」）。
+ * 这些类型被**持久化**（@meebox/poller）、**经 IPC 传输**（ipc.ts）、并在渲染层呈现，
+ * 故置于 shared（与 ReviewRun / Finding 同处）。@meebox/agent 的纯逻辑从此引用。
  */
 
-/** 工具的副作用分类与可用性（红线落地的依据，见 §4）。 */
+/** 工具的副作用分类与可用性（红线落地的依据，见「工具修改红线」）。 */
 export interface ToolCatalogEntry {
   /** 工具指令名，如 `/describe`。 */
   name: string;
@@ -17,7 +18,7 @@ export interface ToolCatalogEntry {
 
 export type AgentSessionStatus = 'running' | 'paused' | 'done' | 'failed' | 'cancelled';
 
-/** 编排步骤的种类：规划 / 工具分发 / 判读（见 §3 计量边界）。 */
+/** 编排步骤的种类：规划 / 工具分发 / 判读（见「步与子任务的计量边界」）。 */
 export type AgentStepKind = 'plan' | 'tool' | 'judge';
 
 export interface AgentTodoItem {
@@ -41,11 +42,13 @@ export interface AgentStep {
   toolCall?: AgentToolCall;
   /** 工具结果 / 判读结论的摘要。 */
   result?: string;
+  /** 步骤产生时间（ISO）。 */
+  at?: string;
 }
 
 export type AgentRecommendationVerdict = 'approve' | 'needs_work' | 'manual_review';
 
-/** 收尾建议（非约束性，不触发任何写操作，见 §6）。 */
+/** 收尾建议（非约束性，不触发任何写操作，见「AutoPilot」）。 */
 export interface AgentRecommendation {
   verdict: AgentRecommendationVerdict;
   reason: string;
@@ -67,4 +70,16 @@ export interface AgentSession {
   finishedAt?: string;
   /** 终止原因（如「步数上限中止」「用户暂停」）。 */
   terminationReason?: string;
+}
+
+/** 持久化包装：`prs/<localId>/agent/session.json`。 */
+export interface AgentSessionFile {
+  schema_version: 1;
+  session: AgentSession;
+}
+
+/** 持久化包装：`prs/<localId>/agent/transcript.json`（步骤流式追加）。 */
+export interface AgentTranscriptFile {
+  schema_version: 1;
+  steps: AgentStep[];
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-contract.js';
 export * from './app-info.js';
 export * from './config.js';
 export * from './inline-comment-policy.js';


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) P2.3：为编排循环（P2.4）铺好**会话持久化**与**契约类型**，并顺手做了一处注释稳定化。

### 契约类型迁入 `@meebox/shared`（`feat(agent)`）
- `AgentSession` / `AgentStep` / `ToolCatalogEntry` / `AgentRecommendation` 等从 `@meebox/agent` 迁到 `@meebox/shared`（`agent-contract.ts`）。
- 理由：这些类型被**持久化**（poller）、**经 IPC 传输**、并在渲染层呈现，须与 `ReviewRun`/`Finding` 同处 `shared`；否则 `shared/ipc.ts` 引用它们会与 `@meebox/agent` 形成依赖环（P2.5 会用到）。`@meebox/agent` 纯逻辑改从 `shared` 引用。

### 会话持久化（`@meebox/poller`，StateStore）
- `startAgentSession` / `updateAgentSession` / `getAgentSession` / `appendAgentStep` / `getAgentTranscript` / `clearAgentSession`，落 `prs/<localId>/agent/{session,transcript}`，与 runs 同寿命（PR 退场 deleteDir 清掉）；步骤追加同步 `stepCount`。
- 内存 StateStore 单测覆盖 start/update/append/clear + 重启清空 transcript。

### 注释稳定化（`refactor`）
- 代码注释里的 `§2`/`§3` 绑定设计文档可变结构（文档重排即静默失效），改为引用稳定的小节**概念名**（可 grep），保留 `.md` 文件指针。

### 验证
`lint` / `typecheck`（13 projects）/ `test`（9 projects，含 agent assemble + poller agent-session 例）全绿。

### 后续（同里程碑）
**P2.4 编排循环**（plan→dispatch→judge→summary，把装配 + LLM 通道 + 持久化接成可用编排器）、P2.5 自然语言路由 + IPC。

🤖 Generated with [Claude Code](https://claude.com/claude-code)