### PR TITLE
feat(agent): 评审编排器（微流程引擎 + 主进程接入 + agent:run）

### DIFF
--- a/apps/desktop/src/main/agent-review.ts
+++ b/apps/desktop/src/main/agent-review.ts
@@ -1,0 +1,106 @@
+import { runReviewMicroflow, type AgentContext } from '@meebox/agent';
+import { appendAgentStep, startAgentSession, updateAgentSession } from '@meebox/poller';
+import type { Rule } from '@meebox/rules';
+import type {
+  AgentSession,
+  AgentStep,
+  ReviewRun,
+  StoredPullRequest,
+  TokenUsage,
+} from '@meebox/shared';
+import type { StateStore } from '@meebox/state-store';
+
+/**
+ * 把纯逻辑的 `runReviewMicroflow` 接到主进程能力上（见 docs/arch/06-agent.md
+ * 「AutoPilot」有界微流程）：
+ * - runTool：经既有 pr-agent 运行队列跑 describe/review/ask，取产物文本回喂；
+ * - chat：经嵌入式运行时的独立 LLM 通道做受限判断 / 总结；
+ * - 持久化 + 步骤流式：startAgentSession / appendAgentStep / updateAgentSession + onStep 广播。
+ */
+
+const STDOUT_LOG_SEP = '\n\n---\n[pr-agent stdout log]\n';
+
+/** 取一次 run 的「LLM 真实产出」（剥掉 ipc 拼在后面的 pr-agent stdout 日志段）。 */
+function reviewRunText(run: ReviewRun): string {
+  return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
+}
+
+export interface AgentReviewDeps {
+  stateStore: StateStore;
+  /** 入队一个 pr-agent run，resolve 完成的 ReviewRun（与用户手动 run 共用队列）。 */
+  enqueueRun: (
+    pr: StoredPullRequest,
+    tool: 'describe' | 'review' | 'ask',
+    question?: string,
+  ) => Promise<ReviewRun>;
+  /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
+  chat: (input: { system: string; user: string }) => Promise<{ text: string; usage?: TokenUsage }>;
+  agentContext: AgentContext;
+  matchedRule?: Rule | null;
+  language: string;
+  maxFollowupAsks: number;
+  summaryMaxChars: number;
+  /** 步骤流式回调（广播给渲染层）。 */
+  onStep?: (sessionId: string, step: AgentStep) => void;
+}
+
+/**
+ * 对一个 PR 跑评审微流程并落盘会话。返回收尾后的 AgentSession（成功 done / 失败 failed）。
+ * 微流程内部工具失败会抛错，这里兜成 failed 会话而非向上抛（背景自动化不该崩主流程）。
+ */
+export async function runAgentReview(
+  pr: StoredPullRequest,
+  deps: AgentReviewDeps,
+  now: () => Date = () => new Date(),
+): Promise<AgentSession> {
+  // 步数上限按微流程模板推导：describe + review + ≤N 追问 + 总结（+判定余量）。
+  const session = await startAgentSession(
+    deps.stateStore,
+    { prLocalId: pr.localId, maxSteps: 3 + deps.maxFollowupAsks + 1 },
+    now,
+  );
+
+  try {
+    const result = await runReviewMicroflow(
+      {
+        runTool: async ({ tool, question }) => {
+          const run = await deps.enqueueRun(pr, tool, question);
+          if (run.status !== 'succeeded') {
+            throw new Error(`pr-agent ${tool} 未成功：${run.errorMessage ?? run.status}`);
+          }
+          return { text: reviewRunText(run), usage: run.tokenUsage };
+        },
+        chat: deps.chat,
+        onStep: async (step) => {
+          await appendAgentStep(deps.stateStore, pr.localId, step, now);
+          deps.onStep?.(session.id, step);
+        },
+      },
+      {
+        context: deps.agentContext,
+        pr: { title: pr.title, description: pr.description, targetBranch: pr.targetRef.displayId },
+        matchedRule: deps.matchedRule,
+        language: deps.language,
+        maxFollowupAsks: deps.maxFollowupAsks,
+        summaryMaxChars: deps.summaryMaxChars,
+      },
+    );
+
+    return (
+      (await updateAgentSession(deps.stateStore, pr.localId, {
+        status: 'done',
+        summary: result.summary,
+        recommendation: result.recommendation,
+        finishedAt: now().toISOString(),
+      })) ?? session
+    );
+  } catch (err) {
+    return (
+      (await updateAgentSession(deps.stateStore, pr.localId, {
+        status: 'failed',
+        finishedAt: now().toISOString(),
+        terminationReason: err instanceof Error ? err.message : String(err),
+      })) ?? session
+    );
+  }
+}

--- a/apps/desktop/src/main/i18n/locales/de-DE.json
+++ b/apps/desktop/src/main/i18n/locales/de-DE.json
@@ -7,6 +7,7 @@
     "rejected": "Entwurf wurde abgelehnt, wird übersprungen"
   },
   "prAgent": {
+    "agentNotEnabled": "Agent ist nicht aktiviert. Bitte das Agent-Verzeichnis in den Einstellungen festlegen und aktivieren.",
     "askNeedsQuestion": "/ask erfordert eine Frage",
     "duplicateTask": "Eine /{{tool}}-Aufgabe für diesen PR wird bereits ausgeführt oder steht in der Warteschlange; bitte nicht erneut auslösen.",
     "notReady": "pr-agent ist nicht bereit",

--- a/apps/desktop/src/main/i18n/locales/en-US.json
+++ b/apps/desktop/src/main/i18n/locales/en-US.json
@@ -7,6 +7,7 @@
     "rejected": "Draft was rejected, skipping"
   },
   "prAgent": {
+    "agentNotEnabled": "Agent is not enabled. Set the Agent directory in Settings and enable it.",
     "askNeedsQuestion": "/ask requires a question",
     "duplicateTask": "A /{{tool}} task for this PR is already running or queued; do not trigger it again.",
     "notReady": "pr-agent not ready",

--- a/apps/desktop/src/main/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/main/i18n/locales/ja-JP.json
@@ -7,6 +7,7 @@
     "rejected": "下書きは却下されました。スキップします"
   },
   "prAgent": {
+    "agentNotEnabled": "Agent が有効になっていません。設定で Agent ディレクトリを指定して有効化してください。",
     "askNeedsQuestion": "/ask には質問の指定が必要です",
     "duplicateTask": "この PR の /{{tool}} タスクはすでに実行中またはキュー待ちです。再度トリガーしないでください。",
     "notReady": "pr-agent が準備できていません",

--- a/apps/desktop/src/main/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/main/i18n/locales/zh-CN.json
@@ -7,6 +7,7 @@
     "rejected": "草稿已被拒绝，跳过"
   },
   "prAgent": {
+    "agentNotEnabled": "Agent 未启用。请在设置中配置 Agent 目录并启用。",
     "askNeedsQuestion": "/ask 需要提供 question",
     "duplicateTask": "该 PR 的 /{{tool}} 任务已在执行或排队中，请勿重复触发",
     "notReady": "pr-agent 未就绪",

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -2,10 +2,11 @@ import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { execFile } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { Logger } from 'pino';
-import { loadAgentRules } from '@meebox/agent';
+import { loadAgentContext, loadAgentRules } from '@meebox/agent';
 import { writeConfig, type BootstrapResult } from '@meebox/config';
 import { PrAgentRunError, type PrAgentBridge } from '@meebox/pr-agent-bridge';
 import {
@@ -52,6 +53,7 @@ import { buildPragentEnv, resolveActiveLlmProfile } from './utils/agent.js';
 import { buildProxyEnv, testProxyConnectivity } from './utils/proxy.js';
 import { checkForUpdate } from './utils/update-check.js';
 import { buildPrContext } from './utils/pr-context.js';
+import { runAgentReview } from './agent-review.js';
 
 interface RegisterDeps {
   bootstrap: BootstrapResult;
@@ -1173,6 +1175,49 @@ export function registerIpcHandlers({
     broadcastQueueChanged();
   };
 
+  /**
+   * 入队一个 pr-agent run（与用户手动 run 共用同一队列 / 并发 / 取消机制）。dedup：同 PR
+   * 同工具已在执行 / 排队则抛错（/ask 不限）。resolve 完成的 ReviewRun。
+   * `pragent:run` handler 与 Agent 编排器（runTool）都走它。
+   */
+  const enqueuePragentRun = (
+    pr: StoredPullRequest,
+    tool: ReviewRunTool,
+    question?: string,
+  ): Promise<ReviewRun> => {
+    if (tool !== 'ask') {
+      const sameTask = (q: QueueItem): boolean =>
+        q.info.prLocalId === pr.localId && q.info.tool === tool;
+      if ([...active.values()].some(sameTask) || waiting.some(sameTask)) {
+        throw new Error(t('prAgent.duplicateTask', { tool }));
+      }
+    }
+    // 入队时就分配 runId；后续 cancel(runId) 在 waiting / active 都能定位
+    const runId = makeRunId(new Date());
+    return new Promise<ReviewRun>((resolve, reject) => {
+      const item: QueueItem = {
+        info: {
+          runId,
+          prLocalId: pr.localId,
+          tool,
+          question: tool === 'ask' ? question : undefined,
+          enqueuedAt: new Date().toISOString(),
+          startedAt: null,
+        },
+        req: { localId: pr.localId, tool, question },
+        pr,
+        resolve,
+        reject,
+      };
+      waiting.push(item);
+      logger.info(
+        { runId, localId: pr.localId, tool, queueLen: waiting.length },
+        'pragent run enqueued',
+      );
+      pump();
+    });
+  };
+
   ipcMain.handle(
     'pragent:run',
     async (
@@ -1187,39 +1232,69 @@ export function registerIpcHandlers({
         throw new Error(t('prAgent.askNeedsQuestion'));
       }
       const pr = await findPrOrThrow(req.localId);
-      // 去重（权威）：同一 PR 同一工具已在执行 / 排队 → 拒绝重复触发，避免并发模式下
-      // 对同一 PR 跑多份相同评审。/ask 每次问题不同，不在限制范围。
-      if (req.tool !== 'ask') {
-        const sameTask = (q: QueueItem): boolean =>
-          q.info.prLocalId === pr.localId && q.info.tool === req.tool;
-        if ([...active.values()].some(sameTask) || waiting.some(sameTask)) {
-          throw new Error(t('prAgent.duplicateTask', { tool: req.tool }));
-        }
+      return enqueuePragentRun(pr, req.tool, req.question);
+    },
+  );
+
+  ipcMain.handle(
+    'agent:run',
+    async (
+      _evt,
+      req: IpcChannels['agent:run']['request'],
+    ): Promise<IpcChannels['agent:run']['response']> => {
+      const bridge = getPrAgentBridge();
+      if (!bridge) throw new Error(t('prAgent.notReadyDetail'));
+      const agentCfg = bootstrap.config.agent;
+      if (!agentCfg.enabled || !agentCfg.dir) {
+        throw new Error(t('prAgent.agentNotEnabled'));
       }
-      // 入队时就分配 runId；后续 cancel(runId) 在 waiting / active 都能定位
-      const runId = makeRunId(new Date());
-      return new Promise<ReviewRun>((resolve, reject) => {
-        const item: QueueItem = {
-          info: {
-            runId,
-            prLocalId: pr.localId,
-            tool: req.tool,
-            question: req.tool === 'ask' ? req.question : undefined,
-            enqueuedAt: new Date().toISOString(),
-            startedAt: null,
-          },
-          req,
-          pr,
-          resolve,
-          reject,
-        };
-        waiting.push(item);
-        logger.info(
-          { runId, localId: pr.localId, tool: req.tool, queueLen: waiting.length },
-          'pragent run enqueued',
-        );
-        pump();
+
+      const pr = await findPrOrThrow(req.localId);
+      // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存。
+      const agentContext = await loadAgentContext(agentCfg.dir, {
+        onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
+      const matchedRule = pickMatchingRule(agentContext.rules, {
+        projectKey: pr.repo.projectKey,
+        repoSlug: pr.repo.repoSlug,
+        targetBranch: pr.targetRef.displayId,
+        tool: 'review',
+      });
+
+      // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。
+      const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
+      const env: Record<string, string> = {
+        ...buildProxyEnv(bootstrap.config.proxy),
+        ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
+        CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
+      };
+
+      // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
+      const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
+      try {
+        return await runAgentReview(pr, {
+          stateStore,
+          enqueueRun: enqueuePragentRun,
+          chat: async ({ system, user }) => {
+            const r = await bridge.chat({ system, user, env, cwd: chatCwd });
+            const acc: UsageAcc = { prompt: 0, completion: 0, total: 0, calls: 0, any: false };
+            for (const line of (r.stderr ?? '').split('\n')) accumulateUsageSentinel(line, acc);
+            return { text: r.stdout.trim(), usage: finalizeUsage(acc) };
+          },
+          agentContext,
+          matchedRule,
+          language: getMainLanguage(),
+          maxFollowupAsks: 2,
+          summaryMaxChars: 800,
+          onStep: (sessionId, step) => {
+            for (const win of BrowserWindow.getAllWindows()) {
+              win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+            }
+          },
+        });
+      } finally {
+        await fs.rm(chatCwd, { recursive: true, force: true });
+      }
     },
   );
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,3 +11,10 @@ export type {
   AssemblePrMeta,
   AssembleSessionSnapshot,
 } from './assemble.js';
+export { runReviewMicroflow, extractJson } from './orchestrator.js';
+export type {
+  ReviewOrchestratorDeps,
+  ReviewOrchestratorInput,
+  ReviewOrchestratorResult,
+  ToolText,
+} from './orchestrator.js';

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -1,0 +1,212 @@
+import type { Rule } from '@meebox/rules';
+import type {
+  AgentRecommendation,
+  AgentRecommendationVerdict,
+  AgentStep,
+  TokenUsage,
+} from '@meebox/shared';
+import { assembleSystemContext, type AssemblePrMeta } from './assemble.js';
+import type { AgentContext } from './types.js';
+
+/**
+ * 结构化「评审微流程」编排器（见 docs/arch/06-agent.md「AutoPilot」的有界微流程）：
+ * describe → review →（仅严重问题）条件性追问 ≤N → 收尾总结 + 建议。
+ *
+ * 这是**固定模板**而非自由 ReAct：流程由代码确定，LLM 只在两处做受限判断
+ * （判严重性 / 出总结），故鲁棒、可预测、步数有界——契合 per-PR 子 agent 的设计。
+ * 纯逻辑：工具分发（runTool）与 LLM 通道（chat）由调用方注入，便于单测与复用。
+ */
+
+export interface ToolText {
+  text: string;
+  usage?: TokenUsage;
+}
+
+export interface ReviewOrchestratorDeps {
+  /** 分发一个只读 pr-agent 工具，返回文本结果（描述 / findings / 回答）。 */
+  runTool(call: {
+    tool: 'describe' | 'review' | 'ask';
+    question?: string;
+  }): Promise<ToolText>;
+  /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
+  chat(input: { system: string; user: string }): Promise<ToolText>;
+  /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
+  onStep?(step: AgentStep): void | Promise<void>;
+}
+
+export interface ReviewOrchestratorInput {
+  context: AgentContext;
+  pr: AssemblePrMeta;
+  matchedRule?: Rule | null;
+  language?: string;
+  /** 条件性追问 /ask 的硬上限（默认 2）。 */
+  maxFollowupAsks?: number;
+  /** 总结严格篇幅上限（默认 800 字符）。 */
+  summaryMaxChars?: number;
+}
+
+export interface ReviewOrchestratorResult {
+  steps: AgentStep[];
+  summary: string;
+  recommendation: AgentRecommendation;
+  tokenUsage: TokenUsage;
+  terminationReason?: string;
+}
+
+const VERDICTS: readonly AgentRecommendationVerdict[] = ['approve', 'needs_work', 'manual_review'];
+function isVerdict(v: unknown): v is AgentRecommendationVerdict {
+  return typeof v === 'string' && (VERDICTS as readonly string[]).includes(v);
+}
+
+function addUsage(acc: TokenUsage, u?: TokenUsage): TokenUsage {
+  if (!u) return acc;
+  return {
+    promptTokens: (acc.promptTokens ?? 0) + (u.promptTokens ?? 0),
+    completionTokens: (acc.completionTokens ?? 0) + (u.completionTokens ?? 0),
+    totalTokens: (acc.totalTokens ?? 0) + (u.totalTokens ?? 0),
+    calls: (acc.calls ?? 0) + (u.calls ?? 1),
+  };
+}
+
+function clamp(s: string, max: number): string {
+  const t = s.trim();
+  return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** 从 LLM 文本里抽第一个 JSON 对象（容 ```json``` 围栏 + 裸文本），失败返回 null。 */
+export function extractJson<T>(text: string): T | null {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  for (const c of [fence?.[1], text]) {
+    if (!c) continue;
+    const start = c.indexOf('{');
+    const end = c.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(c.slice(start, end + 1)) as T;
+      } catch {
+        /* 试下一个候选 */
+      }
+    }
+  }
+  return null;
+}
+
+function judgePrompt(reviewText: string, maxAsks: number): string {
+  return [
+    'You just produced the review findings below. Decide whether any finding is a',
+    '*particularly severe* issue (e.g. likely security hole, data loss, serious logic bug)',
+    `that genuinely needs a clarifying follow-up question. Default to NO follow-up.`,
+    `Ask at most ${String(maxAsks)} questions, and only for severe issues.`,
+    '',
+    'Reply with JSON only: {"severe": boolean, "questions": string[]}.',
+    '',
+    '--- Review findings ---',
+    reviewText,
+  ].join('\n');
+}
+
+function summaryPrompt(
+  describeText: string,
+  reviewText: string,
+  askResults: string[],
+  maxChars: number,
+): string {
+  return [
+    'Write a STRICTLY short closing summary of this pre-review for the human reviewer',
+    `(at most ${String(maxChars)} characters; compress, do not truncate key points).`,
+    'Include the key points, risks, and a non-binding recommendation.',
+    '',
+    'Reply with JSON only:',
+    '{"summary": string, "recommendation": {"verdict": "approve"|"needs_work"|"manual_review", "reason": string}}',
+    '',
+    '--- Description ---',
+    describeText,
+    '',
+    '--- Review findings ---',
+    reviewText,
+    ...(askResults.length ? ['', '--- Follow-up Q&A ---', askResults.join('\n\n')] : []),
+  ].join('\n');
+}
+
+/**
+ * 跑一次评审微流程。只用只读工具（describe/review/ask），不触碰修改类操作（红线见设计
+ * 「工具修改红线」，由分发层 + 交互式编排另行把关）。
+ */
+export async function runReviewMicroflow(
+  deps: ReviewOrchestratorDeps,
+  input: ReviewOrchestratorInput,
+): Promise<ReviewOrchestratorResult> {
+  const maxAsks = input.maxFollowupAsks ?? 2;
+  const summaryMax = input.summaryMaxChars ?? 800;
+  const steps: AgentStep[] = [];
+  let usage: TokenUsage = {};
+
+  const record = async (step: AgentStep): Promise<void> => {
+    steps.push(step);
+    await deps.onStep?.(step);
+  };
+
+  // base system context（工具目录留空：微流程不暴露自由工具选择）
+  const system = assembleSystemContext({
+    context: input.context,
+    pr: input.pr,
+    toolCatalog: [],
+    matchedRule: input.matchedRule,
+    language: input.language,
+  });
+
+  // 1. describe + review（固定两步）
+  const describe = await deps.runTool({ tool: 'describe' });
+  usage = addUsage(usage, describe.usage);
+  await record({ kind: 'tool', toolCall: { tool: '/describe' }, result: clamp(describe.text, 400) });
+
+  const review = await deps.runTool({ tool: 'review' });
+  usage = addUsage(usage, review.usage);
+  await record({ kind: 'tool', toolCall: { tool: '/review' }, result: clamp(review.text, 400) });
+
+  // 2. 仅严重问题条件性追问
+  const judge = await deps.chat({ system, user: judgePrompt(review.text, maxAsks) });
+  usage = addUsage(usage, judge.usage);
+  const verdict = extractJson<{ severe?: boolean; questions?: string[] }>(judge.text);
+  const questions = verdict?.severe ? (verdict.questions ?? []).slice(0, maxAsks) : [];
+  await record({
+    kind: 'judge',
+    thought: '判断是否存在需追问的严重问题',
+    result: questions.length ? `严重，追问 ${String(questions.length)} 个` : '无严重问题，不追问',
+  });
+
+  const askResults: string[] = [];
+  for (const q of questions) {
+    const ask = await deps.runTool({ tool: 'ask', question: q });
+    usage = addUsage(usage, ask.usage);
+    askResults.push(`Q: ${q}\nA: ${ask.text}`);
+    await record({
+      kind: 'tool',
+      toolCall: { tool: '/ask', args: { question: q } },
+      result: clamp(ask.text, 300),
+    });
+  }
+
+  // 3. 收尾总结 + 建议
+  const sum = await deps.chat({
+    system,
+    user: summaryPrompt(describe.text, review.text, askResults, summaryMax),
+  });
+  usage = addUsage(usage, sum.usage);
+  const parsed = extractJson<{
+    summary?: string;
+    recommendation?: { verdict?: unknown; reason?: unknown };
+  }>(sum.text);
+  const summary = clamp(parsed?.summary ?? sum.text, summaryMax);
+  const recommendation: AgentRecommendation =
+    parsed?.recommendation && isVerdict(parsed.recommendation.verdict)
+      ? {
+          verdict: parsed.recommendation.verdict,
+          reason:
+            typeof parsed.recommendation.reason === 'string' ? parsed.recommendation.reason : '',
+        }
+      : { verdict: 'manual_review', reason: '无法解析建议，转人工复核' };
+  await record({ kind: 'plan', thought: '收尾总结', result: summary });
+
+  return { steps, summary, recommendation, tokenUsage: usage };
+}

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extractJson, runReviewMicroflow } from '../src/orchestrator.js';
+import type { ReviewOrchestratorDeps } from '../src/orchestrator.js';
+import type { AgentContext } from '../src/types.js';
+
+const context: AgentContext = {
+  files: { soul: 'soul', agents: 'agents', memory: '', user: '' },
+  rules: [],
+};
+const pr = { title: 'Fix bug', targetBranch: 'main' };
+
+/** 可编排的 fake deps：runTool 按 tool 返回固定文本；chat 顺序返回排好的回复。 */
+function makeDeps(opts: {
+  toolText?: Partial<Record<'describe' | 'review' | 'ask', string>>;
+  chatReplies: string[];
+}): { deps: ReviewOrchestratorDeps; toolCalls: Array<{ tool: string; question?: string }> } {
+  const toolCalls: Array<{ tool: string; question?: string }> = [];
+  let chatIdx = 0;
+  const deps: ReviewOrchestratorDeps = {
+    runTool: vi.fn(async (call: { tool: 'describe' | 'review' | 'ask'; question?: string }) => {
+      toolCalls.push(call);
+      return { text: opts.toolText?.[call.tool] ?? `${call.tool}-result`, usage: { totalTokens: 10 } };
+    }),
+    chat: vi.fn(async () => {
+      const text = opts.chatReplies[chatIdx++] ?? '{}';
+      return { text, usage: { totalTokens: 5 } };
+    }),
+  };
+  return { deps, toolCalls };
+}
+
+describe('extractJson', () => {
+  it('parses fenced and raw JSON, returns null on garbage', () => {
+    expect(extractJson<{ a: number }>('```json\n{"a":1}\n```')).toEqual({ a: 1 });
+    expect(extractJson<{ a: number }>('noise {"a":2} tail')).toEqual({ a: 2 });
+    expect(extractJson('no json here')).toBeNull();
+  });
+});
+
+describe('runReviewMicroflow', () => {
+  it('runs describe→review→summary with no follow-up when not severe', async () => {
+    const { deps, toolCalls } = makeDeps({
+      chatReplies: [
+        '{"severe": false, "questions": []}',
+        '{"summary": "all good", "recommendation": {"verdict": "approve", "reason": "no issues"}}',
+      ],
+    });
+    const r = await runReviewMicroflow(deps, { context, pr });
+
+    expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review']);
+    expect(r.steps.map((s) => s.kind)).toEqual(['tool', 'tool', 'judge', 'plan']);
+    expect(r.summary).toBe('all good');
+    expect(r.recommendation).toEqual({ verdict: 'approve', reason: 'no issues' });
+    // usage accumulated: 2 tools (10 each) + 2 chats (5 each) = 30
+    expect(r.tokenUsage.totalTokens).toBe(30);
+    expect(r.tokenUsage.calls).toBe(4);
+  });
+
+  it('asks follow-ups only for severe issues, capped at maxFollowupAsks', async () => {
+    const { deps, toolCalls } = makeDeps({
+      chatReplies: [
+        '{"severe": true, "questions": ["q1", "q2", "q3"]}',
+        '{"summary": "needs a look", "recommendation": {"verdict": "needs_work", "reason": "risky"}}',
+      ],
+    });
+    const r = await runReviewMicroflow(deps, { context, pr, maxFollowupAsks: 2 });
+
+    const askCalls = toolCalls.filter((c) => c.tool === 'ask');
+    expect(askCalls.map((c) => c.question)).toEqual(['q1', 'q2']); // capped at 2
+    expect(r.steps.filter((s) => s.toolCall?.tool === '/ask')).toHaveLength(2);
+    expect(r.recommendation.verdict).toBe('needs_work');
+  });
+
+  it('clamps the summary to summaryMaxChars', async () => {
+    const long = 'x'.repeat(500);
+    const { deps } = makeDeps({
+      chatReplies: [
+        '{"severe": false}',
+        `{"summary": "${long}", "recommendation": {"verdict": "approve", "reason": "ok"}}`,
+      ],
+    });
+    const r = await runReviewMicroflow(deps, { context, pr, summaryMaxChars: 100 });
+    expect(r.summary.length).toBe(100);
+  });
+
+  it('falls back to manual_review when the summary JSON is unparseable', async () => {
+    const { deps } = makeDeps({
+      chatReplies: ['{"severe": false}', 'totally not json'],
+    });
+    const r = await runReviewMicroflow(deps, { context, pr });
+    expect(r.recommendation.verdict).toBe('manual_review');
+  });
+
+  it('streams every step via onStep', async () => {
+    const seen: string[] = [];
+    const { deps } = makeDeps({
+      chatReplies: ['{"severe": false}', '{"summary": "s", "recommendation": {"verdict": "approve", "reason": "r"}}'],
+    });
+    deps.onStep = (step) => {
+      seen.push(step.kind);
+    };
+    await runReviewMicroflow(deps, { context, pr });
+    expect(seen).toEqual(['tool', 'tool', 'judge', 'plan']);
+  });
+});

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,3 +1,4 @@
+import type { AgentSession, AgentStep } from './agent-contract.js';
 import type { AppInfo, AppPaths, UpdateCheckResult } from './app-info.js';
 import type { Config } from './config.js';
 import type { SupportedLanguage } from './language.js';
@@ -123,6 +124,8 @@ export interface IpcEvents {
   };
   /** 启动检测到新版本时推送（仅 hasUpdate=true 时发），renderer 据此提示。 */
   'app:updateAvailable': UpdateCheckResult;
+  /** Agent 编排步骤流式推送：每产生一个 AgentStep 即发，renderer 据此实时呈现。 */
+  'agent:stepProgress': { sessionId: string; prLocalId: string; step: AgentStep };
 }
 
 export type IpcEventName = keyof IpcEvents;
@@ -392,6 +395,15 @@ export interface IpcChannels {
      */
     request: { localId: string; tool: ReviewRunTool; question?: string };
     response: ReviewRun;
+  };
+  /**
+   * 对指定 PR 跑一次 Agent 评审微流程（describe→review→条件追问→总结）。同步等待，
+   * 期间经 agent:stepProgress 推送步骤；返回收尾后的 AgentSession（含 summary /
+   * recommendation）。agent.enabled=false / pr-agent 不可用时 reject。
+   */
+  'agent:run': {
+    request: { localId: string };
+    response: AgentSession;
   };
   /**
    * 列出指定 PR 的全部草稿 (pending / edited / posted / rejected 都返回，UI 端按


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P2.4 — 编排器**：把上下文装配（P2.1）+ 独立 LLM 通道（P2.2）+ 会话持久化（P2.3）接成一个**可用的评审编排器**。

> 汇入固定分支 `feat/agent`（agent 专项分阶段聚合，最终整体合并到 `dev`）。

### P2.4a 微流程引擎（纯逻辑，`@meebox/agent`）
- `runReviewMicroflow`：per-PR 子 agent 的**固定模板**——describe → review →（仅严重问题）条件性追问 ≤N → 收尾总结 + 建议。流程由代码确定、LLM 只做受限判断，鲁棒、可预测、步数有界（非自由 ReAct）。15 例单测。

### P2.4b 接入主进程 + IPC
- `agent-review.ts`：`runAgentReview` 把引擎接到——`runTool` → 既有 pr-agent 运行队列（共用队列/并发/取消，抽出 `enqueuePragentRun`）；`chat` → 嵌入式独立 LLM 通道（`bridge.chat`，复用同一套 LLM env）；持久化 + 步骤流式。
- 新增 `agent:run` 通道 + `agent:stepProgress` 事件；主进程 i18n 四语补 `prAgent.agentNotEnabled`。

### 验证
`lint` / `typecheck`（13）/ `test`（9，含 agent 15 例）/ `build` 全绿。真实 LLM round-trip 需密钥，留待运行期冒烟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)