### PR TITLE
feat(agent): 聊天框一键自动评审入口 + 收尾总结卡

### DIFF
--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import type {
+  AgentRecommendation,
   Finding,
   IpcChannels,
   LocalPrStatus,
@@ -40,6 +41,13 @@ export const CHAT_MIN_WIDTH = 280;
 export const CHAT_MAX_WIDTH = 720;
 /** 历史 run 的分页大小：进入 PR 默认展示最新 N 条，向上滚动到顶端再追加一批 */
 const RUNS_PAGE_SIZE = 10;
+
+/** Agent 建议 verdict → i18n key（chatPane.agent.*）。 */
+const VERDICT_LABEL_KEY: Record<string, string> = {
+  approve: 'chatPane.agent.verdictApprove',
+  needs_work: 'chatPane.agent.verdictNeedsWork',
+  manual_review: 'chatPane.agent.verdictManualReview',
+};
 
 interface ChatPaneProps {
   pr: StoredPullRequest | null;
@@ -138,6 +146,12 @@ export function ChatPane({
   // 当前 PR 命中的规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
   const [matchedRule, setMatchedRule] = useState<MatchedRule>(null);
   const [showRulePreview, setShowRulePreview] = useState(false);
+  // Agent 自动评审（微流程：describe→review→条件追问→总结）：运行态 + 收尾结果。
+  const [agentRunning, setAgentRunning] = useState(false);
+  const [agentResult, setAgentResult] = useState<{
+    summary: string;
+    recommendation?: AgentRecommendation;
+  } | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
@@ -286,6 +300,28 @@ export function ChatPane({
       await invoke('pragent:run', { localId: pr.localId, tool, question });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经
+  // 既有运行队列展示在历史里；收尾总结 + 建议落 agentResult 单独呈现。
+  const handleAgentReview = async (): Promise<void> => {
+    if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
+    setError(null);
+    setAgentResult(null);
+    setAgentRunning(true);
+    try {
+      const session = await invoke('agent:run', { localId: pr.localId });
+      if (session.summary) {
+        setAgentResult({ summary: session.summary, recommendation: session.recommendation });
+      }
+      if (session.status === 'failed') {
+        setError(session.terminationReason ?? t('chatPane.agent.failed'));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAgentRunning(false);
     }
   };
 
@@ -492,6 +528,19 @@ export function ChatPane({
         </button>
       )}
 
+      {pr && prAgent.available && (
+        <div className="chat-agent-bar">
+          <button
+            type="button"
+            className="chat-agent-review-btn"
+            disabled={!llmConfigured || agentRunning}
+            onClick={() => void handleAgentReview()}
+          >
+            {agentRunning ? t('chatPane.agent.autoReviewRunning') : t('chatPane.agent.autoReview')}
+          </button>
+        </div>
+      )}
+
       <div className="chat-pane-body" ref={bodyRef}>
         {visibleRuns.length === 0 && !hasMyActive && myWaiting.length === 0 && (
           <ChatEmpty
@@ -553,6 +602,24 @@ export function ChatPane({
         {concurrencyReached && (
           <div className="chat-busy" role="status">
             {t('chatPane.concurrencyReached', { n: maxConcurrency })}
+          </div>
+        )}
+        {agentResult && (
+          <div className="chat-agent-summary" role="status">
+            <div className="chat-agent-summary-head">
+              <strong>{t('chatPane.agent.summaryTitle')}</strong>
+              {agentResult.recommendation && (
+                <span
+                  className={`chat-agent-verdict verdict-${agentResult.recommendation.verdict}`}
+                >
+                  {t(VERDICT_LABEL_KEY[agentResult.recommendation.verdict])}
+                </span>
+              )}
+            </div>
+            <p className="chat-agent-summary-text">{agentResult.summary}</p>
+            {agentResult.recommendation?.reason && (
+              <p className="muted">{agentResult.recommendation.reason}</p>
+            )}
           </div>
         )}
         {error && (

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -14,6 +14,15 @@
     "openInBrowser": "Im Browser öffnen"
   },
   "chatPane": {
+    "agent": {
+      "autoReview": "Auto-Review",
+      "autoReviewRunning": "Wird geprüft…",
+      "failed": "Agent-Review fehlgeschlagen",
+      "summaryTitle": "Agent-Zusammenfassung",
+      "verdictApprove": "Sieht gut aus",
+      "verdictManualReview": "Manuelle Prüfung",
+      "verdictNeedsWork": "Nachbesserung nötig"
+    },
     "aiSuggestionPrefix": "[KI-Vorschlag]",
     "anchorJumpTitle": "Zur entsprechenden Zeile im Code springen",
     "askArgQuestion": "Frage",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -14,6 +14,15 @@
     "openInBrowser": "Open in browser"
   },
   "chatPane": {
+    "agent": {
+      "autoReview": "Auto Review",
+      "autoReviewRunning": "Reviewing…",
+      "failed": "Agent review failed",
+      "summaryTitle": "Agent summary",
+      "verdictApprove": "Looks good",
+      "verdictManualReview": "Manual review",
+      "verdictNeedsWork": "Needs work"
+    },
     "aiSuggestionPrefix": "[AI suggestion]",
     "anchorJumpTitle": "Jump to the corresponding line in code",
     "askArgQuestion": "question",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -14,6 +14,15 @@
     "openInBrowser": "ブラウザで開く"
   },
   "chatPane": {
+    "agent": {
+      "autoReview": "自動レビュー",
+      "autoReviewRunning": "レビュー中…",
+      "failed": "Agent レビューに失敗しました",
+      "summaryTitle": "Agent サマリー",
+      "verdictApprove": "問題なし",
+      "verdictManualReview": "手動レビュー推奨",
+      "verdictNeedsWork": "要修正"
+    },
     "aiSuggestionPrefix": "[AI 提案]",
     "anchorJumpTitle": "コードの該当行へジャンプ",
     "askArgQuestion": "質問",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -14,6 +14,15 @@
     "openInBrowser": "浏览器打开"
   },
   "chatPane": {
+    "agent": {
+      "autoReview": "自动评审",
+      "autoReviewRunning": "评审中…",
+      "failed": "Agent 评审失败",
+      "summaryTitle": "Agent 总结",
+      "verdictApprove": "建议通过",
+      "verdictManualReview": "建议人工复核",
+      "verdictNeedsWork": "建议修改"
+    },
     "aiSuggestionPrefix": "[AI 建议]",
     "anchorJumpTitle": "跳转到代码对应行",
     "askArgQuestion": "问题",

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -130,6 +130,68 @@
   flex: 1;
 }
 
+// === Agent 自动评审：触发条 + 收尾总结卡 ===
+.chat-agent-bar {
+  display: flex;
+  padding: $space-2 $space-6;
+  border-bottom: 1px solid $border-muted;
+  flex-shrink: 0;
+}
+.chat-agent-review-btn {
+  padding: $space-2 $space-5;
+  background: $color-accent-bg-fade;
+  border: 1px solid $border-muted;
+  border-radius: $radius-sm;
+  color: $color-info;
+  font-size: $fs-sm;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: $color-accent-strong-fade;
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+.chat-agent-summary {
+  margin: $space-4 $space-6;
+  padding: $space-4 $space-5;
+  border: 1px solid $border-muted;
+  border-radius: $radius-md;
+  background: $color-accent-bg-fade;
+  flex-shrink: 0;
+}
+.chat-agent-summary-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $space-3;
+  margin-bottom: $space-3;
+}
+.chat-agent-verdict {
+  font-size: $fs-sm;
+  font-weight: 600;
+  white-space: nowrap;
+
+  &.verdict-approve {
+    color: $color-approved;
+  }
+  &.verdict-needs_work {
+    color: $color-warning;
+  }
+  &.verdict-manual_review {
+    color: $color-info;
+  }
+}
+.chat-agent-summary-text {
+  margin: 0 0 $space-3;
+  font-size: $fs-md;
+  color: $text-body;
+  white-space: pre-wrap;
+}
+
 // === 空态 ===
 .chat-empty {
   display: flex;


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P2.5**：让 P2.4 的评审编排器**可从 UI 触发**（汇入 `feat/agent`）。

- **ChatPane**：规则 chip 下方新增「自动评审」按钮 → `invoke('agent:run')`。`describe`/`review`/`ask` 子 run 经既有运行队列展示在历史里；收尾 `summary` + `recommendation`（建议通过 / 修改 / 人工复核，三色）落单独**总结卡**。
- **chat-pane.scss**：触发条 + 总结卡样式（沿用 token 变量）。
- 渲染层四语 i18n 补 `chatPane.agent.*`（嵌套块，递归字典序）。

### 范围说明
当前是**微流程触发**（固定模板：describe→review→条件追问→总结）。自然语言→自由规划编排、`agent:stepProgress` 步骤流式订阅、stop/continue 留待后续（P2.5b）。

### 验证
`lint` / `typecheck`（13）/ `test`（9）/ `build`（含 SCSS 编译）全绿。真实 LLM round-trip 需密钥，留待运行期冒烟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)