### PR TITLE
feat(agent): AutoPilot 预评审（配置 + 台账 + 判定 + 调度器 + 状态栏开关）

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -88,7 +88,9 @@ let poller: Poller;
 let repoMirror: RepoMirrorManager;
 // IPC 运行时控制句柄（registerIpcHandlers 返回）：退出时据此中止所有进行中的 pr-agent run，
 // 触发其子进程树清理（见 before-quit）。注册前为 undefined。
-let ipcControl: { abortAllActiveRuns: () => number } | undefined;
+let ipcControl:
+  | { abortAllActiveRuns: () => number; runAutopilotIfDue: () => void }
+  | undefined;
 // 连接级本地状态（按 connectionId）：持久化上次 ping 的 currentUser，用于建连接时预热，
 // 使首轮 poll 不依赖网络即可判 approved。启动时从 state store 载入一次，ping 后增量回写。
 let connectionStates: Record<string, ConnectionState> = {};
@@ -276,6 +278,8 @@ async function start(): Promise<void> {
       }
       // 顺带做版本更新检测：内部时间戳门控成每小时至多一次，复用 poller 周期、不另起定时器
       void runUpdateCheckIfDue();
+      // AutoPilot 预评审：满足开关 + 最小间隔 + 候选时跑一遍 pass（内部门控，复用 poller 周期）。
+      ipcControl?.runAutopilotIfDue();
     },
     // PR 新增 / 内容变更时，顺手 syncMirror 把本地镜像跟上，让用户随后点开 PR
     // 时省一趟 fetch。失败不阻断 poll 流程 (mirror 也有自己的全局队列 + 错误隔离)

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1284,8 +1284,8 @@ export function registerIpcHandlers({
           agentContext,
           matchedRule,
           language: getMainLanguage(),
-          maxFollowupAsks: 2,
-          summaryMaxChars: 800,
+          maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
+          summaryMaxChars: agentCfg.summary_max_chars,
           onStep: (sessionId, step) => {
             for (const win of BrowserWindow.getAllWindows()) {
               win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1639,6 +1639,19 @@ export function registerIpcHandlers({
   );
 
   ipcMain.handle(
+    'agent:setAutopilotEnabled',
+    async (_evt, req: IpcChannels['agent:setAutopilotEnabled']['request']): Promise<void> => {
+      const agent = {
+        ...bootstrap.config.agent,
+        autopilot: { ...bootstrap.config.agent.autopilot, enabled: req.enabled },
+      };
+      await writeConfig(bootstrap.paths.configFile, { ...bootstrap.config, agent });
+      bootstrap.config.agent = agent;
+      logger.info({ enabled: req.enabled }, 'autopilot toggled');
+    },
+  );
+
+  ipcMain.handle(
     'rules:matchForPr',
     async (
       _evt,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -6,7 +6,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { Logger } from 'pino';
-import { loadAgentContext, loadAgentRules } from '@meebox/agent';
+import { judgeAutopilotBatch, loadAgentContext, loadAgentRules } from '@meebox/agent';
+import type { AgentContext } from '@meebox/agent';
 import { writeConfig, type BootstrapResult } from '@meebox/config';
 import { PrAgentRunError, type PrAgentBridge } from '@meebox/pr-agent-bridge';
 import {
@@ -28,10 +29,13 @@ import {
   startReviewRun,
   updateDraft,
   writeCommentsCache,
+  writeAutopilotLedger,
+  needsAutoReview,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
 import { pickMatchingRule } from '@meebox/rules';
 import type {
+  AgentSession,
   AppInfo,
   ConnectionSummary,
   IpcChannels,
@@ -88,7 +92,7 @@ export function registerIpcHandlers({
   connectionRuntime,
   reconfigureConnections,
   repoMirror,
-}: RegisterDeps): { abortAllActiveRuns: () => number } {
+}: RegisterDeps): { abortAllActiveRuns: () => number; runAutopilotIfDue: () => void } {
   // === pr-agent run 队列 ===
   //
   // FIFO 队列，同时只有 1 条在跑 (避免撞 LLM rate limit / 抢 worktree)，
@@ -1236,67 +1240,159 @@ export function registerIpcHandlers({
     },
   );
 
+  // ── Agent 评审编排：共享 chat 通道 + 单 PR 微流程，agent:run 与 AutoPilot 都用 ──
+  type AgentChat = (input: {
+    system: string;
+    user: string;
+  }) => Promise<{ text: string; usage?: TokenUsage }>;
+
+  /** 设置 LLM env + 临时 chat cwd + chat 函数，运行 fn，收尾清理临时目录。 */
+  const withAgentChat = async <T>(fn: (chat: AgentChat) => Promise<T>): Promise<T> => {
+    const bridge = getPrAgentBridge();
+    if (!bridge) throw new Error(t('prAgent.notReadyDetail'));
+    // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。
+    const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
+    const env: Record<string, string> = {
+      ...buildProxyEnv(bootstrap.config.proxy),
+      ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
+      CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
+    };
+    // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
+    const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
+    try {
+      const chat: AgentChat = async ({ system, user }) => {
+        const r = await bridge.chat({ system, user, env, cwd: chatCwd });
+        const acc: UsageAcc = { prompt: 0, completion: 0, total: 0, calls: 0, any: false };
+        for (const line of (r.stderr ?? '').split('\n')) accumulateUsageSentinel(line, acc);
+        return { text: r.stdout.trim(), usage: finalizeUsage(acc) };
+      };
+      return await fn(chat);
+    } finally {
+      await fs.rm(chatCwd, { recursive: true, force: true });
+    }
+  };
+
+  /** 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。 */
+  const runReviewForPr = (
+    pr: StoredPullRequest,
+    agentContext: AgentContext,
+    chat: AgentChat,
+  ): Promise<AgentSession> => {
+    const agentCfg = bootstrap.config.agent;
+    const matchedRule = pickMatchingRule(agentContext.rules, {
+      projectKey: pr.repo.projectKey,
+      repoSlug: pr.repo.repoSlug,
+      targetBranch: pr.targetRef.displayId,
+      tool: 'review',
+    });
+    return runAgentReview(pr, {
+      stateStore,
+      enqueueRun: enqueuePragentRun,
+      chat,
+      agentContext,
+      matchedRule,
+      language: getMainLanguage(),
+      maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
+      summaryMaxChars: agentCfg.summary_max_chars,
+      onStep: (sessionId, step) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+        }
+      },
+    });
+  };
+
   ipcMain.handle(
     'agent:run',
     async (
       _evt,
       req: IpcChannels['agent:run']['request'],
     ): Promise<IpcChannels['agent:run']['response']> => {
-      const bridge = getPrAgentBridge();
-      if (!bridge) throw new Error(t('prAgent.notReadyDetail'));
+      if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
       const agentCfg = bootstrap.config.agent;
-      if (!agentCfg.enabled || !agentCfg.dir) {
-        throw new Error(t('prAgent.agentNotEnabled'));
-      }
-
+      if (!agentCfg.enabled || !agentCfg.dir) throw new Error(t('prAgent.agentNotEnabled'));
       const pr = await findPrOrThrow(req.localId);
       // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存。
       const agentContext = await loadAgentContext(agentCfg.dir, {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
-      const matchedRule = pickMatchingRule(agentContext.rules, {
-        projectKey: pr.repo.projectKey,
-        repoSlug: pr.repo.repoSlug,
-        targetBranch: pr.targetRef.displayId,
-        tool: 'review',
-      });
-
-      // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。
-      const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
-      const env: Record<string, string> = {
-        ...buildProxyEnv(bootstrap.config.proxy),
-        ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
-        CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
-      };
-
-      // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
-      const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
-      try {
-        return await runAgentReview(pr, {
-          stateStore,
-          enqueueRun: enqueuePragentRun,
-          chat: async ({ system, user }) => {
-            const r = await bridge.chat({ system, user, env, cwd: chatCwd });
-            const acc: UsageAcc = { prompt: 0, completion: 0, total: 0, calls: 0, any: false };
-            for (const line of (r.stderr ?? '').split('\n')) accumulateUsageSentinel(line, acc);
-            return { text: r.stdout.trim(), usage: finalizeUsage(acc) };
-          },
-          agentContext,
-          matchedRule,
-          language: getMainLanguage(),
-          maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
-          summaryMaxChars: agentCfg.summary_max_chars,
-          onStep: (sessionId, step) => {
-            for (const win of BrowserWindow.getAllWindows()) {
-              win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
-            }
-          },
-        });
-      } finally {
-        await fs.rm(chatCwd, { recursive: true, force: true });
-      }
+      return withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
     },
   );
+
+  // === AutoPilot 调度（见 docs/arch/06-agent.md「AutoPilot」）===
+  // Agent 编排层全局单并发：一次只跑一遍 pass（busy 锁）；其派发的工具 run 在共享队列并行。
+  // 由 poller onTick 触发（见 index.ts），最小间隔守卫 + 台账去重防止打爆 LLM。
+  let autopilotBusy = false;
+  let lastAutopilotEvalAt = 0;
+  const runAutopilotIfDue = (): void => {
+    const agentCfg = bootstrap.config.agent;
+    const ap = agentCfg.autopilot;
+    if (!agentCfg.enabled || !agentCfg.dir || !ap.enabled || autopilotBusy || !getPrAgentBridge()) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastAutopilotEvalAt < ap.min_interval_seconds * 1000) return; // 最小间隔守卫
+    lastAutopilotEvalAt = now;
+    autopilotBusy = true;
+    void (async () => {
+      try {
+        // 候选：未自动评审过当前版本的 PR（台账去重），按 batch_size 截断。
+        const prs = await listStoredPullRequests(stateStore);
+        const candidates: StoredPullRequest[] = [];
+        for (const pr of prs) {
+          if (candidates.length >= ap.batch_size) break;
+          if (await needsAutoReview(stateStore, pr.localId, pr.updatedAt)) candidates.push(pr);
+        }
+        if (candidates.length === 0) return;
+
+        const agentContext = await loadAgentContext(agentCfg.dir, {
+          onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
+        });
+        await withAgentChat(async (chat) => {
+          // 批量判定（例外规则来自 AGENTS.md）。
+          const { decisions } = await judgeAutopilotBatch(chat, {
+            candidates: candidates.map((p) => ({
+              prLocalId: p.localId,
+              title: p.title,
+              description: p.description,
+            })),
+            agentsRules: agentContext.files.agents,
+          });
+          const byId = new Map(candidates.map((p) => [p.localId, p] as const));
+          for (const d of decisions) {
+            const pr = byId.get(d.prLocalId);
+            if (!pr) continue;
+            const at = new Date().toISOString();
+            if (!d.review) {
+              await writeAutopilotLedger(stateStore, {
+                prLocalId: pr.localId,
+                autoReviewedUpdatedAt: pr.updatedAt,
+                decision: 'skipped',
+                reason: d.reason,
+                at,
+              });
+              continue;
+            }
+            // 单并发：逐 PR 顺序跑编排（工具 run 在共享队列并行消化）。
+            const session = await runReviewForPr(pr, agentContext, chat);
+            await writeAutopilotLedger(stateStore, {
+              prLocalId: pr.localId,
+              autoReviewedUpdatedAt: pr.updatedAt,
+              decision: 'review',
+              recommendation: session.recommendation?.verdict,
+              at,
+            });
+          }
+        });
+        logger.info({ candidates: candidates.length }, 'autopilot pass done');
+      } catch (err) {
+        logger.warn({ err }, 'autopilot pass failed (ignored)');
+      } finally {
+        autopilotBusy = false;
+      }
+    })();
+  };
 
   ipcMain.handle(
     'pragent:cancel',
@@ -1708,6 +1804,8 @@ export function registerIpcHandlers({
       }
       return n;
     },
+    /** 每次 poll tick 由 index.ts 调用：满足开关 + 最小间隔 + 候选时跑一遍 AutoPilot pass。 */
+    runAutopilotIfDue,
   };
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -477,6 +477,25 @@ export default function App() {
         }}
         onJumpToPr={setSelectedId}
         updateInfo={updateInfo}
+        autopilotEnabled={boot.config.agent.autopilot.enabled}
+        onToggleAutopilot={() => {
+          const enabled = !boot.config.agent.autopilot.enabled;
+          void invoke('agent:setAutopilotEnabled', { enabled });
+          setBoot((b) =>
+            b
+              ? {
+                  ...b,
+                  config: {
+                    ...b.config,
+                    agent: {
+                      ...b.config.agent,
+                      autopilot: { ...b.config.agent.autopilot, enabled },
+                    },
+                  },
+                }
+              : b,
+          );
+        }}
       />
       {showSettings && (
         <SettingsModal

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -297,8 +297,10 @@ export function SettingsModal({
         await invoke('config:setPoller', { interval_seconds: n });
       }
       if (agentChanged) {
+        // 仅 UI 编辑 dir / enabled；其余字段（max_steps / summary_max_chars / autopilot）
+        // 从已加载的 config 原样保留，避免被覆盖成默认值。
         await invoke('config:setAgent', {
-          agent: { dir: agentDirInput.trim(), enabled: agent.enabled },
+          agent: { ...agent, dir: agentDirInput.trim(), enabled: agent.enabled },
         });
       }
       if (llmChanged) {

--- a/apps/desktop/src/renderer/src/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/StatusBar.tsx
@@ -36,6 +36,9 @@ interface StatusBarProps {
   onJumpToPr?: (localId: string) => void;
   /** 启动检测到的新版本；非空且 hasUpdate 时展示「新版本」chip，点击跳转下载页。 */
   updateInfo?: UpdateCheckResult | null;
+  /** AutoPilot 是否启用（agent.autopilot.enabled）；点击切换，由父组件持久化。 */
+  autopilotEnabled: boolean;
+  onToggleAutopilot: () => void;
 }
 
 export function StatusBar({
@@ -54,6 +57,8 @@ export function StatusBar({
   onSwitchActiveLlm,
   onJumpToPr,
   updateInfo,
+  autopilotEnabled,
+  onToggleAutopilot,
 }: StatusBarProps) {
   const { t } = useTranslation();
   return (
@@ -87,6 +92,16 @@ export function StatusBar({
           上跑 / 当前空闲"。放右侧贴近 LLM chip：一组都是"当前 run 用什么 / 跑得如何"的实时
           信息。pr-agent 不可用时不显示 (上方 PrAgentChip 已经红色提示) */}
       {prAgent?.available && <PrAgentActiveChip onJumpToPr={onJumpToPr} />}
+      {/* AutoPilot 开关：默认关，点击切换（持久化到 agent.autopilot.enabled，下次 poll 生效）。 */}
+      <button
+        type="button"
+        className={`statusbar-chip statusbar-chip-autopilot${autopilotEnabled ? ' is-on' : ''}`}
+        onClick={onToggleAutopilot}
+        title={autopilotEnabled ? t('statusBar.autopilotOnTitle') : t('statusBar.autopilotOffTitle')}
+        aria-pressed={autopilotEnabled}
+      >
+        {t('statusBar.autopilot')}
+      </button>
       <LlmChip llm={llm} onSwitch={onSwitchActiveLlm} onOpenSettings={onOpenSettings} />
       {updateInfo?.hasUpdate && updateInfo.url && (
         <button

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -661,6 +661,9 @@
     "searchPlaceholder": "Titel / Repo / Autor / ID suchen"
   },
   "statusBar": {
+    "autopilot": "AutoPilot",
+    "autopilotOffTitle": "AutoPilot ist aus — klicken zum Aktivieren (automatische Vorab-Review neuer PRs)",
+    "autopilotOnTitle": "AutoPilot ist an — klicken zum Deaktivieren",
     "collapseChat": "PR-Agent-Chat einklappen",
     "collapseChatAria": "Chat einklappen",
     "collapseSidebar": "Seitenleiste einklappen",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -661,6 +661,9 @@
     "searchPlaceholder": "Search title / repo / author / ID"
   },
   "statusBar": {
+    "autopilot": "AutoPilot",
+    "autopilotOffTitle": "AutoPilot is off — click to enable auto pre-review of new PRs",
+    "autopilotOnTitle": "AutoPilot is on — click to disable",
     "collapseChat": "Collapse PR Agent chat",
     "collapseChatAria": "Collapse chat",
     "collapseSidebar": "Collapse sidebar",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -646,6 +646,9 @@
     "searchPlaceholder": "タイトル / リポジトリ / 作成者 / ID を検索"
   },
   "statusBar": {
+    "autopilot": "AutoPilot",
+    "autopilotOffTitle": "AutoPilot はオフ — クリックで有効化、新規 PR を自動プレレビュー",
+    "autopilotOnTitle": "AutoPilot はオン — クリックで無効化",
     "collapseChat": "PR Agent チャットを折りたたむ",
     "collapseChatAria": "チャットを折りたたむ",
     "collapseSidebar": "サイドバーを折りたたむ",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -646,6 +646,9 @@
     "searchPlaceholder": "搜索标题 / 仓库 / 作者 / ID"
   },
   "statusBar": {
+    "autopilot": "AutoPilot",
+    "autopilotOffTitle": "AutoPilot 已关闭 — 点击启用，新 PR 自动预评审",
+    "autopilotOnTitle": "AutoPilot 已启用 — 点击关闭",
     "collapseChat": "收起 PR Agent chat",
     "collapseChatAria": "收起 chat",
     "collapseSidebar": "收起侧栏",

--- a/apps/desktop/src/renderer/src/styles/statusbar.scss
+++ b/apps/desktop/src/renderer/src/styles/statusbar.scss
@@ -41,6 +41,16 @@
   color: $text-on-accent;
 }
 
+// AutoPilot 开关 chip：默认中性（关），启用时绿底强调
+.statusbar-chip-autopilot {
+  cursor: pointer;
+
+  &.is-on {
+    background: $color-success;
+    color: $text-on-accent;
+  }
+}
+
 // 新版本提示 chip：强调蓝底，点击跳转下载页
 .statusbar-chip-update {
   background: $color-accent;

--- a/packages/agent/src/autopilot-judge.ts
+++ b/packages/agent/src/autopilot-judge.ts
@@ -1,0 +1,88 @@
+import type { TokenUsage } from '@meebox/shared';
+import { extractJson } from './orchestrator.js';
+
+/**
+ * AutoPilot 批量判定（见 docs/arch/06-agent.md「AutoPilot」的例外规则）：把一批候选 PR 的
+ * 标题 + 描述喂给 LLM，逐 PR 判「是否值得自动评审」并附原因（例如分支合并 / 回合并类、
+ * 纯依赖升级可跳过）。纯逻辑：LLM 通道注入，可单测。
+ */
+
+export interface JudgeCandidate {
+  prLocalId: string;
+  title: string;
+  description?: string;
+}
+
+export interface JudgeDecision {
+  prLocalId: string;
+  review: boolean;
+  reason: string;
+}
+
+export interface AutopilotJudgeInput {
+  candidates: JudgeCandidate[];
+  /** AGENTS.md 正文：例外规则来源（可在其中扩充跳过条件）。 */
+  agentsRules?: string;
+}
+
+export interface AutopilotJudgeResult {
+  decisions: JudgeDecision[];
+  usage?: TokenUsage;
+}
+
+const DESC_CLAMP = 600;
+
+export async function judgeAutopilotBatch(
+  chat: (input: { system: string; user: string }) => Promise<{ text: string; usage?: TokenUsage }>,
+  input: AutopilotJudgeInput,
+): Promise<AutopilotJudgeResult> {
+  if (input.candidates.length === 0) return { decisions: [] };
+
+  const system = [
+    'You decide whether each pull request below is worth an automated pre-review.',
+    'Default to reviewing, but SKIP PRs that are not worth it — e.g. branch merges /',
+    'back-merges, pure dependency bumps, or trivial mechanical changes.',
+    input.agentsRules?.trim()
+      ? `\nProject rules (may add skip exceptions):\n${input.agentsRules.trim()}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const list = input.candidates
+    .map(
+      (c, i) =>
+        `${String(i + 1)}. [id:${c.prLocalId}] ${c.title}\n${(c.description ?? '').trim().slice(0, DESC_CLAMP)}`,
+    )
+    .join('\n\n');
+
+  const user = [
+    'For each PR decide review (true) or skip (false) with a short reason.',
+    'Reply with JSON only: {"decisions": [{"prLocalId": string, "review": boolean, "reason": string}]}.',
+    '',
+    list,
+  ].join('\n');
+
+  const r = await chat({ system, user });
+  const parsed = extractJson<{
+    decisions?: Array<{ prLocalId?: unknown; review?: unknown; reason?: unknown }>;
+  }>(r.text);
+
+  const byId = new Map<string, JudgeDecision>();
+  for (const d of parsed?.decisions ?? []) {
+    if (typeof d.prLocalId === 'string') {
+      byId.set(d.prLocalId, {
+        prLocalId: d.prLocalId,
+        // 缺省 / 非显式 false → 评审（保守：宁可多评不漏）
+        review: d.review !== false,
+        reason: typeof d.reason === 'string' ? d.reason : '',
+      });
+    }
+  }
+
+  // 解析缺失的候选默认评审，保证每个候选都有决策。
+  const decisions = input.candidates.map(
+    (c) => byId.get(c.prLocalId) ?? { prLocalId: c.prLocalId, review: true, reason: 'default (unparsed)' },
+  );
+  return { decisions, usage: r.usage };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,13 @@ export type {
   AssembleSessionSnapshot,
 } from './assemble.js';
 export { runReviewMicroflow, extractJson } from './orchestrator.js';
+export { judgeAutopilotBatch } from './autopilot-judge.js';
+export type {
+  AutopilotJudgeInput,
+  AutopilotJudgeResult,
+  JudgeCandidate,
+  JudgeDecision,
+} from './autopilot-judge.js';
 export type {
   ReviewOrchestratorDeps,
   ReviewOrchestratorInput,

--- a/packages/agent/tests/autopilot-judge.test.ts
+++ b/packages/agent/tests/autopilot-judge.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { judgeAutopilotBatch } from '../src/autopilot-judge.js';
+
+describe('judgeAutopilotBatch', () => {
+  it('returns empty for no candidates without calling chat', async () => {
+    const chat = vi.fn();
+    const r = await judgeAutopilotBatch(chat, { candidates: [] });
+    expect(r.decisions).toEqual([]);
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it('parses per-PR decisions and carries usage', async () => {
+    const chat = vi.fn(async () => ({
+      text: '```json\n{"decisions": [{"prLocalId":"a","review":true,"reason":"real change"},{"prLocalId":"b","review":false,"reason":"branch merge"}]}\n```',
+      usage: { totalTokens: 12 },
+    }));
+    const r = await judgeAutopilotBatch(chat, {
+      candidates: [
+        { prLocalId: 'a', title: 'Fix bug' },
+        { prLocalId: 'b', title: 'Merge main' },
+      ],
+    });
+    expect(r.decisions).toEqual([
+      { prLocalId: 'a', review: true, reason: 'real change' },
+      { prLocalId: 'b', review: false, reason: 'branch merge' },
+    ]);
+    expect(r.usage?.totalTokens).toBe(12);
+  });
+
+  it('defaults unparsed candidates to review (conservative)', async () => {
+    const chat = vi.fn(async () => ({ text: 'not json' }));
+    const r = await judgeAutopilotBatch(chat, { candidates: [{ prLocalId: 'x', title: 'T' }] });
+    expect(r.decisions).toEqual([{ prLocalId: 'x', review: true, reason: 'default (unparsed)' }]);
+  });
+
+  it('includes AGENTS.md rules in the system prompt', async () => {
+    let system = '';
+    const chat = vi.fn(async (i: { system: string; user: string }) => {
+      system = i.system;
+      return { text: '{"decisions":[]}' };
+    });
+    await judgeAutopilotBatch(chat, {
+      candidates: [{ prLocalId: 'a', title: 'T' }],
+      agentsRules: 'Skip docs-only PRs.',
+    });
+    expect(system).toContain('Skip docs-only PRs.');
+  });
+});

--- a/packages/poller/src/autopilot-ledger.ts
+++ b/packages/poller/src/autopilot-ledger.ts
@@ -1,0 +1,41 @@
+import type { AutopilotLedger, AutopilotLedgerFile } from '@meebox/shared';
+import type { StateStore } from '@meebox/state-store';
+
+/**
+ * AutoPilot 台账落 `prs/<localId>/agent/autopilot.json`，与 session / transcript 同处该
+ * PR 目录，PR 退场时 deleteDir 一并清掉（见 docs/arch/06-agent.md「AutoPilot」）。
+ */
+function ledgerKey(prLocalId: string): string {
+  return `prs/${prLocalId}/agent/autopilot`;
+}
+
+export async function getAutopilotLedger(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<AutopilotLedger | null> {
+  const file = await stateStore.read<AutopilotLedgerFile>(ledgerKey(prLocalId));
+  return file?.ledger ?? null;
+}
+
+export async function writeAutopilotLedger(
+  stateStore: StateStore,
+  ledger: AutopilotLedger,
+): Promise<void> {
+  await stateStore.write<AutopilotLedgerFile>(ledgerKey(ledger.prLocalId), {
+    schema_version: 1,
+    ledger,
+  });
+}
+
+/**
+ * 该 PR 是否需要自动评审：无台账（从未跑过）或台账记录的 updatedAt 与当前不一致
+ * （PR 已变更）即为 true。内容未变则 false（去重，不重复跑）。
+ */
+export async function needsAutoReview(
+  stateStore: StateStore,
+  prLocalId: string,
+  currentUpdatedAt: string,
+): Promise<boolean> {
+  const ledger = await getAutopilotLedger(stateStore, prLocalId);
+  return !ledger || ledger.autoReviewedUpdatedAt !== currentUpdatedAt;
+}

--- a/packages/poller/src/index.ts
+++ b/packages/poller/src/index.ts
@@ -5,5 +5,6 @@ export * from './pr-state.js';
 export * from './comments-cache.js';
 export * from './runs.js';
 export * from './agent-session.js';
+export * from './autopilot-ledger.js';
 export * from './drafts.js';
 export * from './parse-output.js';

--- a/packages/poller/tests/autopilot-ledger.test.ts
+++ b/packages/poller/tests/autopilot-ledger.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { StateStore } from '@meebox/state-store';
+import {
+  getAutopilotLedger,
+  needsAutoReview,
+  writeAutopilotLedger,
+} from '../src/autopilot-ledger.js';
+
+class MemStore implements StateStore {
+  private m = new Map<string, unknown>();
+  async read<T>(key: string): Promise<T | null> {
+    return this.m.has(key) ? (structuredClone(this.m.get(key)) as T) : null;
+  }
+  async write<T>(key: string, data: T): Promise<void> {
+    this.m.set(key, structuredClone(data));
+  }
+  async delete(key: string): Promise<void> {
+    this.m.delete(key);
+  }
+  async *list(prefix: string): AsyncIterable<string> {
+    for (const k of this.m.keys()) if (k === prefix || k.startsWith(`${prefix}/`)) yield k;
+  }
+  async deleteDir(prefix: string): Promise<void> {
+    for (const k of [...this.m.keys()]) if (k === prefix || k.startsWith(`${prefix}/`)) this.m.delete(k);
+  }
+}
+
+const PR = 'pr123';
+let store: MemStore;
+beforeEach(() => {
+  store = new MemStore();
+});
+
+describe('autopilot ledger', () => {
+  it('write + get round-trips', async () => {
+    await writeAutopilotLedger(store, {
+      prLocalId: PR,
+      autoReviewedUpdatedAt: 't1',
+      decision: 'review',
+      recommendation: 'approve',
+      at: '2026-06-15T10:00:00.000Z',
+    });
+    const l = await getAutopilotLedger(store, PR);
+    expect(l?.decision).toBe('review');
+    expect(l?.recommendation).toBe('approve');
+    expect(await getAutopilotLedger(store, 'missing')).toBeNull();
+  });
+
+  it('needsAutoReview: true when no ledger or version changed; false when same', async () => {
+    expect(await needsAutoReview(store, PR, 't1')).toBe(true); // 无台账
+    await writeAutopilotLedger(store, {
+      prLocalId: PR,
+      autoReviewedUpdatedAt: 't1',
+      decision: 'review',
+      at: '2026-06-15T10:00:00.000Z',
+    });
+    expect(await needsAutoReview(store, PR, 't1')).toBe(false); // 同版本
+    expect(await needsAutoReview(store, PR, 't2')).toBe(true); // 内容已变
+  });
+});

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -83,3 +83,29 @@ export interface AgentTranscriptFile {
   schema_version: 1;
   steps: AgentStep[];
 }
+
+export type AutopilotDecision = 'review' | 'skipped';
+
+/**
+ * AutoPilot 每 PR 一条台账：去重 + 审计（见 docs/arch/06-agent.md「AutoPilot」）。
+ * 是否「未自动评审过当前版本」据 `autoReviewedUpdatedAt` 与当前 PR `updatedAt` 是否一致判定，
+ * 故 PR 推新 commit 后能再次进入候选、内容未变则不重复跑。
+ */
+export interface AutopilotLedger {
+  prLocalId: string;
+  /** 评审 / 判定时所对应的 PR updatedAt 快照。 */
+  autoReviewedUpdatedAt: string;
+  decision: AutopilotDecision;
+  /** 判定原因（skipped 时尤其有用，便于审计 / UI 展示）。 */
+  reason?: string;
+  /** 若评审，子 agent 给出的建议倾向（供 PR 列表徽标直接读、无需加载会话）。 */
+  recommendation?: AgentRecommendationVerdict;
+  /** 写入时间（ISO）。 */
+  at: string;
+}
+
+/** 持久化包装：`prs/<localId>/agent/autopilot.json`。 */
+export interface AutopilotLedgerFile {
+  schema_version: 1;
+  ledger: AutopilotLedger;
+}

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -175,6 +175,30 @@ export const ConfigSchema = z.object({
     .object({
       dir: z.string().default(''),
       enabled: z.boolean().default(true),
+      /** 单会话步数上限（默认取小值；见 docs/arch/06-agent.md「会话 Agent 化」）。 */
+      max_steps: z.number().int().min(1).max(50).default(8),
+      /** 收尾总结严格篇幅上限（字符）。 */
+      summary_max_chars: z.number().int().min(100).max(4000).default(800),
+      /**
+       * AutoPilot 预评审（见 docs/arch/06-agent.md「AutoPilot」）。默认关闭，状态栏可启用。
+       * enabled=false 时调度逻辑完全不跑。
+       */
+      autopilot: z
+        .object({
+          enabled: z.boolean().default(false),
+          /** 两次 AI 评估的最小间隔（秒），防高频轮询打爆 LLM。 */
+          min_interval_seconds: z.number().int().min(60).default(900),
+          /** 单批 LLM 判定的 PR 上限。 */
+          batch_size: z.number().int().min(1).max(50).default(10),
+          /** 自动评审微流程中条件性追问 /ask 的硬上限。 */
+          max_followup_asks: z.number().int().min(0).max(5).default(2),
+          /**
+           * 逐项写权限授权（默认空 = 全拒）。如 'approve' / 'needs_work' /
+           * 'publish_comment'；运行期按红线硬校验放行（见「工具修改红线」）。
+           */
+          grants: z.array(z.string()).default([]),
+        })
+        .default({}),
     })
     .default({}),
   poller: z

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -331,6 +331,8 @@ export interface IpcChannels {
   'config:setLlm': { request: { llm: Config['llm'] }; response: void };
   /** 写入 agent.dir + enabled 到 config.yaml；下次 pragent:run 立即生效 (现读规则) */
   'config:setAgent': { request: { agent: Config['agent'] }; response: void };
+  /** 翻转 AutoPilot 开关 (agent.autopilot.enabled) 并写 config.yaml；下次 poll tick 生效。 */
+  'agent:setAutopilotEnabled': { request: { enabled: boolean }; response: void };
   /** 写入轮询间隔 (秒，60~900 整数) 到 config.yaml，并热替换 poller 定时器，无需重启 */
   'config:setPoller': { request: { interval_seconds: number }; response: void };
   /**


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P3（AutoPilot）P3a–P3c**：轮询发现 PR 后自动预评审，复用 P2 的评审引擎（汇入 `feat/agent`）。

### P3a 基础件
- 配置：`agent.max_steps` / `summary_max_chars` + `agent.autopilot.{enabled(默认关) / min_interval_seconds / batch_size / max_followup_asks / grants}`。
- 台账（`@meebox/poller`）：`get`/`write`/`needsAutoReview` → `prs/<id>/agent/autopilot.json`，按 `updatedAt` 快照去重。
- 批量判定（`@meebox/agent` 纯逻辑）：`judgeAutopilotBatch` 逐 PR 判 review/skip（分支合并 / 依赖升级可跳过），AGENTS.md 例外规则注入，保守默认。

### P3b 调度器
- 抽出 `withAgentChat`（共享 LLM env + 临时 chat cwd）+ `runReviewForPr`，与 `agent:run` 共用。
- `runAutopilotIfDue`：**四道闸**（开关 + Agent 目录 + 最小间隔守卫 + 单并发 busy 锁）→ 台账去重选候选（≤ `batch_size`）→ 批量判定 → review 者**单并发逐 PR**跑微流程并写台账（含 recommendation），工具 run 仍在共享队列并行。
- 挂在 poller `onTick`（复用轮询周期、内部门控，与 `runUpdateCheckIfDue` 同模式）。

### P3c 状态栏开关
- 状态栏 AutoPilot chip（默认关，点击切换、启用时绿底）；`agent:setAutopilotEnabled` 持久化、下次 poll 生效。四语 i18n + SCSS。

### 范围说明
不自动发布（草稿 / 总结只落本地）。写权限授权（grants）门控为 **P3d**（红线硬校验）。一期 autopilot 微流程只用只读工具。

### 验证
`lint` / `typecheck`（13）/ `test`（9，含 judge + ledger 例）/ `build` 全绿。真实 LLM round-trip 需密钥，留待运行期冒烟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)