### PR TITLE
feat(agent): 工具修改红线机制（grants 门控 + 运行时硬校验）

### DIFF
--- a/apps/desktop/src/main/agent-review.ts
+++ b/apps/desktop/src/main/agent-review.ts
@@ -7,6 +7,7 @@ import type {
   ReviewRun,
   StoredPullRequest,
   TokenUsage,
+  ToolCatalogEntry,
 } from '@meebox/shared';
 import type { StateStore } from '@meebox/state-store';
 
@@ -38,6 +39,8 @@ export interface AgentReviewDeps {
   agentContext: AgentContext;
   matchedRule?: Rule | null;
   language: string;
+  /** 工具目录（含修改红线标注）；注入编排器系统上下文。 */
+  toolCatalog?: ToolCatalogEntry[];
   maxFollowupAsks: number;
   summaryMaxChars: number;
   /** 步骤流式回调（广播给渲染层）。 */
@@ -81,6 +84,7 @@ export async function runAgentReview(
         pr: { title: pr.title, description: pr.description, targetBranch: pr.targetRef.displayId },
         matchedRule: deps.matchedRule,
         language: deps.language,
+        toolCatalog: deps.toolCatalog,
         maxFollowupAsks: deps.maxFollowupAsks,
         summaryMaxChars: deps.summaryMaxChars,
       },

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -6,7 +6,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { Logger } from 'pino';
-import { judgeAutopilotBatch, loadAgentContext, loadAgentRules } from '@meebox/agent';
+import {
+  buildToolCatalog,
+  judgeAutopilotBatch,
+  loadAgentContext,
+  loadAgentRules,
+} from '@meebox/agent';
 import type { AgentContext } from '@meebox/agent';
 import { writeConfig, type BootstrapResult } from '@meebox/config';
 import { PrAgentRunError, type PrAgentBridge } from '@meebox/pr-agent-bridge';
@@ -1292,6 +1297,8 @@ export function registerIpcHandlers({
       agentContext,
       matchedRule,
       language: getMainLanguage(),
+      // 工具目录注入：修改类工具按 grants 门控（默认全禁，红线见 buildToolCatalog）。
+      toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
       maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
       summaryMaxChars: agentCfg.summary_max_chars,
       onStep: (sessionId, step) => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,7 @@ export type {
   AssembleSessionSnapshot,
 } from './assemble.js';
 export { runReviewMicroflow, extractJson } from './orchestrator.js';
+export { buildToolCatalog, assertToolAllowed, READ_TOOLS, MUTATING_TOOLS } from './tool-catalog.js';
 export { judgeAutopilotBatch } from './autopilot-judge.js';
 export type {
   AutopilotJudgeInput,

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -4,6 +4,7 @@ import type {
   AgentRecommendationVerdict,
   AgentStep,
   TokenUsage,
+  ToolCatalogEntry,
 } from '@meebox/shared';
 import { assembleSystemContext, type AssemblePrMeta } from './assemble.js';
 import type { AgentContext } from './types.js';
@@ -39,6 +40,8 @@ export interface ReviewOrchestratorInput {
   pr: AssemblePrMeta;
   matchedRule?: Rule | null;
   language?: string;
+  /** 注入提示词的工具目录（含修改红线标注，见 buildToolCatalog）。 */
+  toolCatalog?: ToolCatalogEntry[];
   /** 条件性追问 /ask 的硬上限（默认 2）。 */
   maxFollowupAsks?: number;
   /** 总结严格篇幅上限（默认 800 字符）。 */
@@ -150,7 +153,7 @@ export async function runReviewMicroflow(
   const system = assembleSystemContext({
     context: input.context,
     pr: input.pr,
-    toolCatalog: [],
+    toolCatalog: input.toolCatalog ?? [],
     matchedRule: input.matchedRule,
     language: input.language,
   });

--- a/packages/agent/src/tool-catalog.ts
+++ b/packages/agent/src/tool-catalog.ts
@@ -1,0 +1,60 @@
+import type { ToolCatalogEntry } from '@meebox/shared';
+
+/**
+ * 工具目录与修改红线（见 docs/arch/06-agent.md「工具修改红线」）。
+ *
+ * 读 / 分析类工具 Agent 始终可自主调用；修改类（对远端有副作用）**默认禁止**，仅在
+ * `grants` 显式授权时放行——以**禁用态**注入目录（Agent 知其存在但不可调用），并由
+ * `assertToolAllowed` 在分发入口**运行时硬校验**：即便 LLM 越权产出修改类调用也被拒。
+ */
+
+/** 只读 / 分析类工具：始终可用。 */
+export const READ_TOOLS = [
+  { name: '/describe', summary: 'Generate the PR description.' },
+  { name: '/review', summary: 'Generate review findings.' },
+  { name: '/ask', summary: 'Ask a free-form question about the PR.' },
+] as const;
+
+/** 修改类工具：对远端有副作用，默认禁止；`grant` 是授权它所需的 grants 项。 */
+export const MUTATING_TOOLS = [
+  { name: '/approve', summary: 'Approve the PR.', grant: 'approve' },
+  { name: '/needswork', summary: 'Request changes on the PR.', grant: 'needs_work' },
+  { name: '/publish', summary: 'Publish review comments to the remote.', grant: 'publish_comment' },
+] as const;
+
+/**
+ * 构建工具目录：读类 enabled=true；修改类仅在 grants 含其授权项时 enabled，否则禁用态。
+ */
+export function buildToolCatalog(grants: ReadonlyArray<string> = []): ToolCatalogEntry[] {
+  const granted = new Set(grants);
+  return [
+    ...READ_TOOLS.map(
+      (t): ToolCatalogEntry => ({ name: t.name, summary: t.summary, mutating: false, enabled: true }),
+    ),
+    ...MUTATING_TOOLS.map(
+      (t): ToolCatalogEntry => ({
+        name: t.name,
+        summary: t.summary,
+        mutating: true,
+        enabled: granted.has(t.grant),
+      }),
+    ),
+  ];
+}
+
+/**
+ * 运行时硬校验（红线落地）：分发某工具前调用。未知工具 / 修改类且未授权 → 抛错；
+ * 读类 / 已授权 → 放行。这是「提示词被绕过 ≠ 操作被执行」的最后一道闸。
+ */
+export function assertToolAllowed(
+  toolName: string,
+  catalog: ReadonlyArray<ToolCatalogEntry>,
+): void {
+  const entry = catalog.find((e) => e.name === toolName);
+  if (!entry) throw new Error(`未知工具：${toolName}`);
+  if (entry.mutating && !entry.enabled) {
+    throw new Error(
+      `工具 ${toolName} 为修改类且未授权，红线拒绝（需 grants 显式授权或用户直接指令）`,
+    );
+  }
+}

--- a/packages/agent/tests/tool-catalog.test.ts
+++ b/packages/agent/tests/tool-catalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { assertToolAllowed, buildToolCatalog } from '../src/tool-catalog.js';
+
+describe('buildToolCatalog', () => {
+  it('enables read tools and disables mutating tools by default', () => {
+    const cat = buildToolCatalog();
+    expect(cat.find((e) => e.name === '/review')).toMatchObject({ mutating: false, enabled: true });
+    expect(cat.find((e) => e.name === '/approve')).toMatchObject({ mutating: true, enabled: false });
+  });
+
+  it('enables a mutating tool only when its grant is present', () => {
+    const cat = buildToolCatalog(['approve']);
+    expect(cat.find((e) => e.name === '/approve')?.enabled).toBe(true);
+    expect(cat.find((e) => e.name === '/needswork')?.enabled).toBe(false);
+  });
+});
+
+describe('assertToolAllowed', () => {
+  const cat = buildToolCatalog(['approve']);
+
+  it('allows read tools and granted mutating tools', () => {
+    expect(() => assertToolAllowed('/review', cat)).not.toThrow();
+    expect(() => assertToolAllowed('/approve', cat)).not.toThrow();
+  });
+
+  it('rejects ungranted mutating tools (red line)', () => {
+    expect(() => assertToolAllowed('/needswork', cat)).toThrow(/红线/);
+  });
+
+  it('rejects unknown tools', () => {
+    expect(() => assertToolAllowed('/bogus', cat)).toThrow(/未知工具/);
+  });
+});


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P3d**：落地设计 `docs/arch/06-agent.md`「工具修改红线」(汇入 `feat/agent`)。

- **`@meebox/agent/tool-catalog`**：
  - `READ_TOOLS`（describe / review / ask）始终可用；`MUTATING_TOOLS`（approve / needswork / publish）默认禁、按 `grants` 授权。
  - `buildToolCatalog(grants)` 构建目录：修改类未授权 → **禁用态注入**（Agent 知其存在但不可调用）。
  - `assertToolAllowed(tool, catalog)` **运行时硬校验**：修改类未授权 / 未知工具即抛错——即便 LLM 越权产出该调用也被拒（「提示词被绕过 ≠ 操作被执行」的最后一道闸）。
- 工具目录注入编排器系统上下文（`orchestrator` / `agent-review` 透传）；`grants` 取自 `agent.autopilot.grants`（默认空 = 全禁）。
- 单测覆盖 读类可用 / 修改类默认禁 / grant 放行 / 红线拒绝 / 未知工具。

### 范围说明
当前微流程**只用只读工具**（结构性安全，无修改类分发路径）。本机制是为修改类 / 自由规划分发路径**预置的硬闸**——一旦那些路径接入，红线即生效。

### 验证
`lint` / `typecheck`（13）/ `test`（9）/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)