### PR TITLE
feat(agent): P4 收尾 + 步骤流式（队列优先级 / 列表徽标 / stepProgress）

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -36,10 +36,12 @@ import {
   writeCommentsCache,
   writeAutopilotLedger,
   needsAutoReview,
+  getAutopilotLedger,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
 import { pickMatchingRule } from '@meebox/rules';
 import type {
+  AgentRecommendationVerdict,
   AgentSession,
   AppInfo,
   ConnectionSummary,
@@ -1667,6 +1669,23 @@ export function registerIpcHandlers({
       await writeConfig(bootstrap.paths.configFile, { ...bootstrap.config, agent });
       bootstrap.config.agent = agent;
       logger.info({ enabled: req.enabled }, 'autopilot toggled');
+    },
+  );
+
+  ipcMain.handle(
+    'agent:autopilotLedgers',
+    async (
+      _evt,
+      req: IpcChannels['agent:autopilotLedgers']['request'],
+    ): Promise<IpcChannels['agent:autopilotLedgers']['response']> => {
+      const out: Record<string, AgentRecommendationVerdict> = {};
+      for (const id of req.localIds) {
+        const ledger = await getAutopilotLedger(stateStore, id);
+        if (ledger?.decision === 'review' && ledger.recommendation) {
+          out[id] = ledger.recommendation;
+        }
+      }
+      return out;
     },
   );
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -115,6 +115,8 @@ export function registerIpcHandlers({
     pr: StoredPullRequest;
     resolve: (run: ReviewRun) => void;
     reject: (err: Error) => void;
+    /** 优先级泳道：user（手动发起，高）/ agent（编排 / AutoPilot 派发，低）。见 §7 调度。 */
+    priority: 'user' | 'agent';
     /** 仅 active 状态填；用于 cancel SIGKILL */
     ac?: AbortController;
   }
@@ -1193,6 +1195,7 @@ export function registerIpcHandlers({
     pr: StoredPullRequest,
     tool: ReviewRunTool,
     question?: string,
+    priority: 'user' | 'agent' = 'user',
   ): Promise<ReviewRun> => {
     if (tool !== 'ask') {
       const sameTask = (q: QueueItem): boolean =>
@@ -1215,12 +1218,20 @@ export function registerIpcHandlers({
         },
         req: { localId: pr.localId, tool, question },
         pr,
+        priority,
         resolve,
         reject,
       };
-      waiting.push(item);
+      // 优先级插队：user 任务排到所有 agent 任务之前（同泳道内仍 FIFO）；不打断在跑的 run。
+      if (priority === 'user') {
+        const firstAgentIdx = waiting.findIndex((q) => q.priority === 'agent');
+        if (firstAgentIdx >= 0) waiting.splice(firstAgentIdx, 0, item);
+        else waiting.push(item);
+      } else {
+        waiting.push(item);
+      }
       logger.info(
-        { runId, localId: pr.localId, tool, queueLen: waiting.length },
+        { runId, localId: pr.localId, tool, priority, queueLen: waiting.length },
         'pragent run enqueued',
       );
       pump();
@@ -1292,7 +1303,8 @@ export function registerIpcHandlers({
     });
     return runAgentReview(pr, {
       stateStore,
-      enqueueRun: enqueuePragentRun,
+      // 编排派发的 run 走 agent 低优先级泳道：用户随时点 /review 会插到它们之前。
+      enqueueRun: (p, tool, question) => enqueuePragentRun(p, tool, question, 'agent'),
       chat,
       agentContext,
       matchedRule,

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -6,6 +6,7 @@ import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import type {
   AgentRecommendation,
+  AgentStep,
   Finding,
   IpcChannels,
   LocalPrStatus,
@@ -18,7 +19,7 @@ import type {
 
 type MatchedRule = IpcChannels['rules:matchForPr']['response'];
 import type { ReviewDraft } from '@meebox/shared';
-import { invoke } from '../api';
+import { invoke, subscribe } from '../api';
 import {
   ChatIcon,
   ChevronIcon,
@@ -152,6 +153,7 @@ export function ChatPane({
     summary: string;
     recommendation?: AgentRecommendation;
   } | null>(null);
+  const [agentSteps, setAgentSteps] = useState<AgentStep[]>([]);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
@@ -184,6 +186,8 @@ export function ChatPane({
     setLoadingOlder(false);
     setError(null);
     setMatchedRule(null);
+    setAgentSteps([]);
+    setAgentResult(null);
     if (!prLocalId) return;
     let cancelled = false;
     void (async () => {
@@ -205,6 +209,14 @@ export function ChatPane({
     return () => {
       cancelled = true;
     };
+  }, [prLocalId]);
+
+  // Agent 步骤流式：订阅 main 的 agent:stepProgress，按当前 PR 过滤实时追加。
+  useEffect(() => {
+    if (!prLocalId) return;
+    return subscribe('agent:stepProgress', (ev) => {
+      if (ev.prLocalId === prLocalId) setAgentSteps((s) => [...s, ev.step]);
+    });
   }, [prLocalId]);
 
   // 本 PR 的运行中 run 集合发生「移除」→ 那条跑完了：单独 fetch 它 + 按 runId 升序
@@ -309,6 +321,7 @@ export function ChatPane({
     if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
     setError(null);
     setAgentResult(null);
+    setAgentSteps([]);
     setAgentRunning(true);
     try {
       const session = await invoke('agent:run', { localId: pr.localId });
@@ -602,6 +615,17 @@ export function ChatPane({
         {concurrencyReached && (
           <div className="chat-busy" role="status">
             {t('chatPane.concurrencyReached', { n: maxConcurrency })}
+          </div>
+        )}
+        {agentSteps.length > 0 && (
+          <div className="chat-agent-steps">
+            {agentSteps.map((s, i) => (
+              <div key={i} className="chat-agent-step">
+                <span className="chat-agent-step-kind">{s.toolCall?.tool ?? s.kind}</span>
+                {s.thought && <span className="chat-agent-step-thought">{s.thought}</span>}
+                {s.result && <span className="chat-agent-step-result muted">{s.result}</span>}
+              </div>
+            ))}
           </div>
         )}
         {agentResult && (

--- a/apps/desktop/src/renderer/src/components/PrItem.tsx
+++ b/apps/desktop/src/renderer/src/components/PrItem.tsx
@@ -1,15 +1,24 @@
 import { useTranslation } from 'react-i18next';
-import type { StoredPullRequest } from '@meebox/shared';
+import type { AgentRecommendationVerdict, StoredPullRequest } from '@meebox/shared';
 import { Avatar } from './Avatar';
 import { PersonIcon, PullRequestIcon } from './icons';
+
+/** AutoPilot 建议 verdict → 复用 chatPane.agent.* 文案（不另加 i18n）。 */
+const VERDICT_TITLE: Record<string, string> = {
+  approve: 'chatPane.agent.verdictApprove',
+  needs_work: 'chatPane.agent.verdictNeedsWork',
+  manual_review: 'chatPane.agent.verdictManualReview',
+};
 
 interface PrItemProps {
   pr: StoredPullRequest;
   selected: boolean;
   onClick: () => void;
+  /** AutoPilot 已自动评审给出的建议倾向（来自台账）；无则不显示徽标。 */
+  autopilotVerdict?: AgentRecommendationVerdict | null;
 }
 
-export function PrItem({ pr, selected, onClick }: PrItemProps) {
+export function PrItem({ pr, selected, onClick, autopilotVerdict }: PrItemProps) {
   const { t } = useTranslation();
   const approvedCount = pr.reviewers.filter((r) => r.status === 'approved').length;
   const needsWorkCount = pr.reviewers.filter((r) => r.status === 'needsWork').length;
@@ -51,8 +60,17 @@ export function PrItem({ pr, selected, onClick }: PrItemProps) {
               <PersonIcon />
               {pr.author.displayName}
             </span>
-            {(approvedCount > 0 || needsWorkCount > 0 || canMerge) && (
+            {(approvedCount > 0 || needsWorkCount > 0 || canMerge || autopilotVerdict) && (
               <span className="pr-item-review-chips">
+                {autopilotVerdict && (
+                  <span
+                    className={`review-chip autopilot-chip autopilot-${autopilotVerdict}`}
+                    title={t(VERDICT_TITLE[autopilotVerdict])}
+                    aria-label={`AutoPilot ${autopilotVerdict}`}
+                  >
+                    ★
+                  </span>
+                )}
                 {canMerge && (
                   <span
                     className="review-chip review-chip-mergeable"

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { LocalPrStatus, PrDiscoveryFilter, StoredPullRequest } from '@meebox/shared';
+import type {
+  AgentRecommendationVerdict,
+  LocalPrStatus,
+  PrDiscoveryFilter,
+  StoredPullRequest,
+} from '@meebox/shared';
+import { invoke } from '../api';
 import { PrItem } from './PrItem';
 
 // 'conflict' / 'mergeable' 是按远端 merge 状态跨 localStatus 横切的筛选；'all' 不限定
@@ -84,6 +90,10 @@ export function Sidebar({
   const [filter, setFilter] = useState<FilterKey>('pending');
   // 哪些组当前折叠了。默认空集合 = 全部展开。
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  // AutoPilot 台账 recommendation（per localId），PR 列表徽标用；prs 变化时批量重取。
+  const [autopilotVerdicts, setAutopilotVerdicts] = useState<
+    Record<string, AgentRecommendationVerdict>
+  >({});
 
   // 有发现分类标签时（GitHub / Bitbucket 均含「我创建的」），reviewer 决断类（通过/需修改）
   // 只对「待我评审」有意义、其余标签下恒空，故精简隐藏；无分类的场景保持全部六项。
@@ -96,6 +106,22 @@ export function Sidebar({
   useEffect(() => {
     if (hasDiscoveryTabs && DECISION_STATUS_FILTERS.has(filter)) setFilter('pending');
   }, [hasDiscoveryTabs, filter]);
+
+  // AutoPilot 徽标：批量取当前 PR 的台账建议（prs 变化时刷新；ledger 在下次 poll 更新 prs 后体现）。
+  useEffect(() => {
+    const localIds = prs.map((p) => p.localId);
+    if (localIds.length === 0) {
+      setAutopilotVerdicts({});
+      return;
+    }
+    let cancelled = false;
+    void invoke('agent:autopilotLedgers', { localIds }).then((v) => {
+      if (!cancelled) setAutopilotVerdicts(v);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prs]);
 
   // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
   // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。
@@ -256,6 +282,7 @@ export function Sidebar({
                         pr={pr}
                         selected={selectedId === pr.localId}
                         onClick={() => onSelect(pr)}
+                        autopilotVerdict={autopilotVerdicts[pr.localId] ?? null}
                       />
                     ))}
                   </div>

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -192,6 +192,33 @@
   white-space: pre-wrap;
 }
 
+// Agent 步骤流式列表：跑动时实时追加（describe → review → judge → ask → 总结）
+.chat-agent-steps {
+  margin: $space-3 $space-6 0;
+  display: flex;
+  flex-direction: column;
+  gap: $space-2;
+}
+.chat-agent-step {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: $space-3;
+  font-size: $fs-sm;
+}
+.chat-agent-step-kind {
+  font-family: $font-mono;
+  color: $color-info;
+  flex-shrink: 0;
+}
+.chat-agent-step-thought {
+  color: $text-body;
+}
+.chat-agent-step-result {
+  flex-basis: 100%;
+  white-space: pre-wrap;
+}
+
 // === 空态 ===
 .chat-empty {
   display: flex;

--- a/apps/desktop/src/renderer/src/styles/sidebar.scss
+++ b/apps/desktop/src/renderer/src/styles/sidebar.scss
@@ -296,6 +296,24 @@
       display: block;
     }
   }
+
+  // AutoPilot 建议徽标（★）：approve 绿 / needs_work 琥珀 / manual_review 蓝
+  &.autopilot-chip {
+    padding: 1px $space-2;
+
+    &.autopilot-approve {
+      background: $color-approved;
+      color: $text-on-accent;
+    }
+    &.autopilot-needs_work {
+      background: $color-warning;
+      color: $text-on-accent;
+    }
+    &.autopilot-manual_review {
+      background: $color-accent;
+      color: $text-on-accent;
+    }
+  }
 }
 
 .tag-needs-work {

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,4 +1,4 @@
-import type { AgentSession, AgentStep } from './agent-contract.js';
+import type { AgentRecommendationVerdict, AgentSession, AgentStep } from './agent-contract.js';
 import type { AppInfo, AppPaths, UpdateCheckResult } from './app-info.js';
 import type { Config } from './config.js';
 import type { SupportedLanguage } from './language.js';
@@ -406,6 +406,14 @@ export interface IpcChannels {
   'agent:run': {
     request: { localId: string };
     response: AgentSession;
+  };
+  /**
+   * 批量读 AutoPilot 台账：返回各 PR 已自动评审的 recommendation（仅 decision=review 且有
+   * 建议者）。PR 列表据此显示徽标，无需逐个加载会话。
+   */
+  'agent:autopilotLedgers': {
+    request: { localIds: string[] };
+    response: Record<string, AgentRecommendationVerdict>;
   };
   /**
    * 列出指定 PR 的全部草稿 (pending / edited / posted / rejected 都返回，UI 端按


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P4 收尾 + P2.5b 部分**（汇入 `feat/agent`）。

- **队列优先级泳道（§7）**：`QueueItem.priority`（user/agent）；user 任务插到所有 agent 任务之前（同泳道 FIFO，不打断在跑 run）；编排 / AutoPilot 派发的 run 走 agent 低优先级——用户随时点 `/review` 会插到它们之前。
- **Agent 步骤流式（P2.5b）**：ChatPane 订阅 `agent:stepProgress`，按当前 PR 实时追加显示（describe → review → judge → ask → 总结）；切 PR / 新 run 清空。
- **PR 列表 AutoPilot 建议徽标（P4）**：`agent:autopilotLedgers` 批量读台账 → Sidebar 传 PrItem 渲染 ★ 徽标（三色：approve 绿 / needs_work 琥珀 / manual_review 蓝，复用既有 verdict 文案、无新 i18n）。

### 验证
`lint` / `typecheck`（13）/ `test`（9）/ `build`（含 SCSS）全绿。

### 剩余（P2.5b 较大件）
自然语言→**自由规划编排**（需新 ReAct 引擎）、**stop/continue**（需可中断编排）——独立后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)