### PR TITLE
feat(agent): 自然语言自由规划 Agent + 暂停（P2.5b）

### DIFF
--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -1,0 +1,102 @@
+import { runPlanningAgent, type AgentContext, type PlanningToolResult } from '@meebox/agent';
+import { appendAgentStep, startAgentSession, updateAgentSession } from '@meebox/poller';
+import type { Rule } from '@meebox/rules';
+import type {
+  AgentSession,
+  AgentStep,
+  ReviewRun,
+  StoredPullRequest,
+  ToolCatalogEntry,
+} from '@meebox/shared';
+import type { StateStore } from '@meebox/state-store';
+
+/**
+ * 把自由规划编排器（runPlanningAgent）接到主进程：自然语言入口的「对话即委派」。
+ * runTool 把读类工具映射到既有 pr-agent 运行队列；红线由编排器经 assertToolAllowed 把关。
+ * signal 支持用户暂停（Stop）；暂停 → 会话置 paused 保态。
+ */
+
+const STDOUT_LOG_SEP = '\n\n---\n[pr-agent stdout log]\n';
+function reviewRunText(run: ReviewRun): string {
+  return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
+}
+
+const READ_TOOLS = new Set(['describe', 'review', 'ask']);
+
+export interface AgentPlanningDeps {
+  stateStore: StateStore;
+  enqueueRun: (
+    pr: StoredPullRequest,
+    tool: 'describe' | 'review' | 'ask',
+    question?: string,
+  ) => Promise<ReviewRun>;
+  chat: (input: { system: string; user: string }) => Promise<PlanningToolResult>;
+  agentContext: AgentContext;
+  toolCatalog: ToolCatalogEntry[];
+  matchedRule?: Rule | null;
+  language: string;
+  maxSteps: number;
+  signal?: AbortSignal;
+  onStep?: (sessionId: string, step: AgentStep) => void;
+}
+
+export async function runAgentPlanning(
+  pr: StoredPullRequest,
+  userRequest: string,
+  deps: AgentPlanningDeps,
+  now: () => Date = () => new Date(),
+): Promise<AgentSession> {
+  const session = await startAgentSession(
+    deps.stateStore,
+    { prLocalId: pr.localId, maxSteps: deps.maxSteps },
+    now,
+  );
+
+  try {
+    const result = await runPlanningAgent(
+      {
+        chat: deps.chat,
+        runTool: async ({ tool, question }) => {
+          const bare = tool.replace(/^\//, '');
+          if (!READ_TOOLS.has(bare)) throw new Error(`不支持的工具：${tool}`);
+          const run = await deps.enqueueRun(pr, bare as 'describe' | 'review' | 'ask', question);
+          if (run.status !== 'succeeded') {
+            throw new Error(`pr-agent ${bare} 未成功：${run.errorMessage ?? run.status}`);
+          }
+          return { text: reviewRunText(run), usage: run.tokenUsage };
+        },
+        onStep: async (step) => {
+          await appendAgentStep(deps.stateStore, pr.localId, step, now);
+          deps.onStep?.(session.id, step);
+        },
+        signal: deps.signal,
+      },
+      {
+        context: deps.agentContext,
+        pr: { title: pr.title, description: pr.description, targetBranch: pr.targetRef.displayId },
+        toolCatalog: deps.toolCatalog,
+        matchedRule: deps.matchedRule,
+        language: deps.language,
+        userRequest,
+        maxSteps: deps.maxSteps,
+      },
+    );
+
+    return (
+      (await updateAgentSession(deps.stateStore, pr.localId, {
+        status: result.terminationReason === '用户暂停' ? 'paused' : 'done',
+        summary: result.finalText,
+        finishedAt: now().toISOString(),
+        terminationReason: result.terminationReason,
+      })) ?? session
+    );
+  } catch (err) {
+    return (
+      (await updateAgentSession(deps.stateStore, pr.localId, {
+        status: 'failed',
+        finishedAt: now().toISOString(),
+        terminationReason: err instanceof Error ? err.message : String(err),
+      })) ?? session
+    );
+  }
+}

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -65,6 +65,7 @@ import { buildProxyEnv, testProxyConnectivity } from './utils/proxy.js';
 import { checkForUpdate } from './utils/update-check.js';
 import { buildPrContext } from './utils/pr-context.js';
 import { runAgentReview } from './agent-review.js';
+import { runAgentPlanning } from './agent-planning.js';
 
 interface RegisterDeps {
   bootstrap: BootstrapResult;
@@ -1338,6 +1339,76 @@ export function registerIpcHandlers({
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
       return withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+    },
+  );
+
+  // 自由规划 Agent（自然语言入口）：每 PR 至多一个在跑，AbortController 供 agent:stop 暂停。
+  const agentControllers = new Map<string, AbortController>();
+
+  const runPlanningForPr = (
+    pr: StoredPullRequest,
+    userRequest: string,
+    agentContext: AgentContext,
+    chat: AgentChat,
+    signal: AbortSignal,
+  ): Promise<AgentSession> => {
+    const agentCfg = bootstrap.config.agent;
+    const matchedRule = pickMatchingRule(agentContext.rules, {
+      projectKey: pr.repo.projectKey,
+      repoSlug: pr.repo.repoSlug,
+      targetBranch: pr.targetRef.displayId,
+      tool: 'review',
+    });
+    return runAgentPlanning(pr, userRequest, {
+      stateStore,
+      enqueueRun: (p, tool, question) => enqueuePragentRun(p, tool, question, 'agent'),
+      chat,
+      agentContext,
+      toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
+      matchedRule,
+      language: getMainLanguage(),
+      maxSteps: agentCfg.max_steps,
+      signal,
+      onStep: (sessionId, step) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+        }
+      },
+    });
+  };
+
+  ipcMain.handle(
+    'agent:ask',
+    async (
+      _evt,
+      req: IpcChannels['agent:ask']['request'],
+    ): Promise<IpcChannels['agent:ask']['response']> => {
+      if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
+      const agentCfg = bootstrap.config.agent;
+      if (!agentCfg.enabled || !agentCfg.dir) throw new Error(t('prAgent.agentNotEnabled'));
+      const pr = await findPrOrThrow(req.localId);
+      const agentContext = await loadAgentContext(agentCfg.dir, {
+        onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
+      });
+      const ac = new AbortController();
+      agentControllers.set(pr.localId, ac);
+      try {
+        return await withAgentChat((chat) =>
+          runPlanningForPr(pr, req.question, agentContext, chat, ac.signal),
+        );
+      } finally {
+        agentControllers.delete(pr.localId);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'agent:stop',
+    (_evt, req: IpcChannels['agent:stop']['request']): IpcChannels['agent:stop']['response'] => {
+      const ac = agentControllers.get(req.localId);
+      if (!ac) return { ok: false };
+      ac.abort();
+      return { ok: true };
     },
   );
 

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -338,6 +338,31 @@ export function ChatPane({
     }
   };
 
+  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。最终回答落 agentResult，步骤同样流式。
+  const handleAgentAsk = async (question: string): Promise<void> => {
+    if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
+    setError(null);
+    setAgentResult(null);
+    setAgentSteps([]);
+    setAgentRunning(true);
+    try {
+      const session = await invoke('agent:ask', { localId: pr.localId, question });
+      if (session.summary) setAgentResult({ summary: session.summary });
+      if (session.status === 'failed') {
+        setError(session.terminationReason ?? t('chatPane.agent.failed'));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAgentRunning(false);
+    }
+  };
+
+  // 暂停当前 PR 的 Agent 运行（agent:stop → 编排器 abort）。仅自由规划 run 可中断。
+  const handleAgentStop = (): void => {
+    if (prLocalId) void invoke('agent:stop', { localId: prLocalId });
+  };
+
   // 清空当前 PR 的执行历史（仅该 PR）：删远端记录 + 清本地列表。进行中的 run 不受影响
   // （在 chatRunStore，跑完会重新落盘）。
   const handleClearRuns = async (): Promise<void> => {
@@ -551,6 +576,11 @@ export function ChatPane({
           >
             {agentRunning ? t('chatPane.agent.autoReviewRunning') : t('chatPane.agent.autoReview')}
           </button>
+          {agentRunning && (
+            <button type="button" className="chat-agent-stop-btn" onClick={handleAgentStop}>
+              {t('chatPane.agent.stop')}
+            </button>
+          )}
         </div>
       )}
 
@@ -662,6 +692,7 @@ export function ChatPane({
         // 渲染 stop 按钮 (本 PR 有运行中 run 时可点终止)。多并发时 stop 终止最近一条。
         runningTool={myActiveRuns[myActiveRuns.length - 1]?.tool ?? null}
         onRun={(t, q) => void handleRun(t, q)}
+        onAgentAsk={(q) => void handleAgentAsk(q)}
         onCancel={
           hasMyActive
             ? () => void handleCancel(myActiveRuns[myActiveRuns.length - 1]!.runId)
@@ -753,6 +784,8 @@ interface ChatInputBarProps {
    */
   runningTool: ReviewRunTool | null;
   onRun: (tool: ReviewRunTool, question?: string) => void;
+  /** 无 '/' 前缀的自然语言输入 → 交给自由规划 Agent（对话即委派，见设计「会话 Agent 化」）。 */
+  onAgentAsk: (question: string) => void;
   /**
    * 终止当前活动 run。仅 runningTool 非空时有意义；ChatPane 已绑好对应 runId。
    * stop 按钮跟 send 共用槽位：runningTool 时点击触发此回调而非 onRun
@@ -840,6 +873,7 @@ function ChatInputBar({
   llmConfigured,
   runningTool,
   onRun,
+  onAgentAsk,
   onCancel,
   onSetReviewStatus,
 }: ChatInputBarProps) {
@@ -987,9 +1021,13 @@ function ChatInputBar({
       }
       cmd = found;
     } else {
-      // COMMANDS 里固定有 /ask，find 不会为 undefined — 用 ! 让 TS 收窄即可
-      cmd = COMMANDS.find((c) => c.kind === 'pragent' && c.name === 'ask')!;
-      rest = trimmed;
+      // 无 '/' → 自然语言「对话即委派」：交给自由规划 Agent（而非 /ask）。
+      setHistory(pushChatHistory(input));
+      setHistoryIdx(-1);
+      draftBeforeHistoryRef.current = '';
+      setInput('');
+      onAgentAsk(trimmed);
+      return;
     }
     // review-action：/approve /needswork 没有参数，多余文本拒绝以免误用
     if (cmd.kind === 'review-action') {

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -18,6 +18,7 @@
       "autoReview": "Auto-Review",
       "autoReviewRunning": "Wird geprüft…",
       "failed": "Agent-Review fehlgeschlagen",
+      "stop": "Stopp",
       "summaryTitle": "Agent-Zusammenfassung",
       "verdictApprove": "Sieht gut aus",
       "verdictManualReview": "Manuelle Prüfung",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -18,6 +18,7 @@
       "autoReview": "Auto Review",
       "autoReviewRunning": "Reviewing…",
       "failed": "Agent review failed",
+      "stop": "Stop",
       "summaryTitle": "Agent summary",
       "verdictApprove": "Looks good",
       "verdictManualReview": "Manual review",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -18,6 +18,7 @@
       "autoReview": "自動レビュー",
       "autoReviewRunning": "レビュー中…",
       "failed": "Agent レビューに失敗しました",
+      "stop": "停止",
       "summaryTitle": "Agent サマリー",
       "verdictApprove": "問題なし",
       "verdictManualReview": "手動レビュー推奨",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -18,6 +18,7 @@
       "autoReview": "自动评审",
       "autoReviewRunning": "评审中…",
       "failed": "Agent 评审失败",
+      "stop": "停止",
       "summaryTitle": "Agent 总结",
       "verdictApprove": "建议通过",
       "verdictManualReview": "建议人工复核",

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -155,6 +155,21 @@
     cursor: not-allowed;
   }
 }
+.chat-agent-stop-btn {
+  margin-left: $space-3;
+  padding: $space-2 $space-5;
+  background: transparent;
+  border: 1px solid $color-danger;
+  border-radius: $radius-sm;
+  color: $color-danger;
+  font-size: $fs-sm;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(244, 135, 113, 0.15);
+  }
+}
 .chat-agent-summary {
   margin: $space-4 $space-6;
   padding: $space-4 $space-5;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,13 @@ export type {
   AssembleSessionSnapshot,
 } from './assemble.js';
 export { runReviewMicroflow, extractJson } from './orchestrator.js';
+export { runPlanningAgent } from './planner.js';
+export type {
+  PlanningDeps,
+  PlanningInput,
+  PlanningResult,
+  PlanningToolResult,
+} from './planner.js';
 export { buildToolCatalog, assertToolAllowed, READ_TOOLS, MUTATING_TOOLS } from './tool-catalog.js';
 export { judgeAutopilotBatch } from './autopilot-judge.js';
 export type {

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -1,0 +1,155 @@
+import type { Rule } from '@meebox/rules';
+import type { AgentStep, TokenUsage, ToolCatalogEntry } from '@meebox/shared';
+import { assembleSystemContext, type AssemblePrMeta } from './assemble.js';
+import { extractJson } from './orchestrator.js';
+import { assertToolAllowed } from './tool-catalog.js';
+import type { AgentContext } from './types.js';
+
+/**
+ * 自由规划（ReAct）编排器（见 docs/arch/06-agent.md「会话 Agent 化」）：交互式入口的自然
+ * 语言请求由它处理——每步 chat 规划下一动作（调工具 / 收尾），解析 JSON 动作，红线硬校验后
+ * 分发工具、把结果回喂，循环到 final 或步数上限。与固定微流程（runReviewMicroflow）互补。
+ *
+ * 纯逻辑：chat / runTool 注入；红线经 assertToolAllowed 落地（修改类未授权即拒、回喂让 LLM 改选）。
+ */
+
+export interface PlanningToolResult {
+  text: string;
+  usage?: TokenUsage;
+}
+
+export interface PlanningDeps {
+  /** 规划 LLM 调用（单 system + user）。 */
+  chat: (input: { system: string; user: string }) => Promise<PlanningToolResult>;
+  /** 分发一个工具，返回文本结果（红线已由编排器先行校验）。 */
+  runTool: (call: { tool: string; question?: string }) => Promise<PlanningToolResult>;
+  onStep?: (step: AgentStep) => void | Promise<void>;
+  /** 用户暂停信号；abort 后循环在下一步前停下，返回 terminationReason='用户暂停'。 */
+  signal?: AbortSignal;
+}
+
+export interface PlanningInput {
+  context: AgentContext;
+  pr: AssemblePrMeta;
+  toolCatalog: ToolCatalogEntry[];
+  matchedRule?: Rule | null;
+  language?: string;
+  /** 用户的自然语言请求。 */
+  userRequest: string;
+  /** 步数上限（默认 8）。 */
+  maxSteps?: number;
+}
+
+export interface PlanningResult {
+  steps: AgentStep[];
+  finalText: string;
+  tokenUsage: TokenUsage;
+  terminationReason?: string;
+}
+
+interface PlannerAction {
+  thought?: string;
+  tool?: string;
+  question?: string;
+  final?: string;
+}
+
+function addUsage(acc: TokenUsage, u?: TokenUsage): TokenUsage {
+  if (!u) return acc;
+  return {
+    promptTokens: (acc.promptTokens ?? 0) + (u.promptTokens ?? 0),
+    completionTokens: (acc.completionTokens ?? 0) + (u.completionTokens ?? 0),
+    totalTokens: (acc.totalTokens ?? 0) + (u.totalTokens ?? 0),
+    calls: (acc.calls ?? 0) + (u.calls ?? 1),
+  };
+}
+
+function clamp(s: string, max: number): string {
+  const t = s.trim();
+  return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
+}
+
+const PROTOCOL = [
+  'Each turn, reply with JSON ONLY for the next action:',
+  '- Use a tool: {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
+  '- Finish:     {"thought": "...", "final": "<your answer to the user>"}',
+  'Only call tools listed under "Available tools" that are NOT disabled. Prefer few precise steps.',
+].join('\n');
+
+export async function runPlanningAgent(
+  deps: PlanningDeps,
+  input: PlanningInput,
+): Promise<PlanningResult> {
+  const maxSteps = input.maxSteps ?? 8;
+  const steps: AgentStep[] = [];
+  let usage: TokenUsage = {};
+  const history: string[] = [];
+
+  const system = `${assembleSystemContext({
+    context: input.context,
+    pr: input.pr,
+    toolCatalog: input.toolCatalog,
+    matchedRule: input.matchedRule,
+    language: input.language,
+  })}\n\n---\n\n# Protocol\n\n${PROTOCOL}`;
+
+  const record = async (step: AgentStep): Promise<void> => {
+    steps.push(step);
+    await deps.onStep?.(step);
+  };
+
+  for (let i = 0; i < maxSteps; i++) {
+    if (deps.signal?.aborted) {
+      return { steps, finalText: '', tokenUsage: usage, terminationReason: '用户暂停' };
+    }
+
+    const user = [
+      `User request: ${input.userRequest}`,
+      history.length ? `\nProgress so far:\n${history.join('\n')}` : '',
+      '\nReply with the next JSON action.',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const r = await deps.chat({ system, user });
+    usage = addUsage(usage, r.usage);
+    const action = extractJson<PlannerAction>(r.text);
+
+    // 无法解析 / 既无 tool 又无 final → 当作收尾（原文兜底）。
+    if (!action || (!action.tool && !action.final)) {
+      const finalText = action?.final ?? r.text.trim();
+      await record({ kind: 'plan', thought: action?.thought, result: finalText });
+      return { steps, finalText, tokenUsage: usage };
+    }
+
+    if (action.final && !action.tool) {
+      await record({ kind: 'plan', thought: action.thought, result: action.final });
+      return { steps, finalText: action.final, tokenUsage: usage };
+    }
+
+    const tool = action.tool ?? '';
+    // 红线硬校验：修改类未授权 / 未知工具即拒，回喂让 LLM 改选（不崩流程）。
+    try {
+      assertToolAllowed(tool, input.toolCatalog);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await record({ kind: 'judge', thought: action.thought, toolCall: { tool }, result: `拒绝：${msg}` });
+      history.push(`Refused ${tool}: ${msg}`);
+      continue;
+    }
+
+    const res = await deps.runTool({ tool, question: action.question });
+    usage = addUsage(usage, res.usage);
+    await record({
+      kind: 'tool',
+      thought: action.thought,
+      toolCall: { tool, args: action.question ? { question: action.question } : undefined },
+      result: clamp(res.text, 400),
+    });
+    history.push(
+      `Called ${tool}${action.question ? ` ("${action.question}")` : ''} → ${clamp(res.text, 600)}`,
+    );
+  }
+
+  return { steps, finalText: '', tokenUsage: usage, terminationReason: '步数上限中止' };
+}

--- a/packages/agent/tests/planner.test.ts
+++ b/packages/agent/tests/planner.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runPlanningAgent, type PlanningDeps } from '../src/planner.js';
+import { buildToolCatalog } from '../src/tool-catalog.js';
+import type { AgentContext } from '../src/types.js';
+
+const context: AgentContext = {
+  files: { soul: 's', agents: 'a', memory: '', user: '' },
+  rules: [],
+};
+const pr = { title: 'T', targetBranch: 'main' };
+const catalog = buildToolCatalog(); // read 可用、修改类禁用
+
+function makeDeps(
+  chatReplies: string[],
+  toolText: Record<string, string> = {},
+): { deps: PlanningDeps; toolCalls: Array<{ tool: string; question?: string }> } {
+  const toolCalls: Array<{ tool: string; question?: string }> = [];
+  let i = 0;
+  const deps: PlanningDeps = {
+    chat: vi.fn(async () => ({
+      text: chatReplies[i++] ?? '{"final":"done"}',
+      usage: { totalTokens: 5 },
+    })),
+    runTool: vi.fn(async (call: { tool: string; question?: string }) => {
+      toolCalls.push(call);
+      return { text: toolText[call.tool] ?? `${call.tool}-result`, usage: { totalTokens: 10 } };
+    }),
+  };
+  return { deps, toolCalls };
+}
+
+describe('runPlanningAgent', () => {
+  it('dispatches a tool then finishes; accumulates usage', async () => {
+    const { deps, toolCalls } = makeDeps([
+      '{"thought":"review it","tool":"/review"}',
+      '{"thought":"done","final":"LGTM"}',
+    ]);
+    const r = await runPlanningAgent(deps, {
+      context,
+      pr,
+      toolCatalog: catalog,
+      userRequest: 'check this',
+    });
+    expect(toolCalls.map((c) => c.tool)).toEqual(['/review']);
+    expect(r.finalText).toBe('LGTM');
+    expect(r.steps.map((s) => s.kind)).toEqual(['tool', 'plan']);
+    expect(r.tokenUsage.totalTokens).toBe(20); // 2 chat(5) + 1 tool(10)
+  });
+
+  it('refuses ungranted mutating tools (red line) and lets the agent re-plan', async () => {
+    const { deps, toolCalls } = makeDeps(['{"tool":"/approve"}', '{"final":"cannot approve"}']);
+    const r = await runPlanningAgent(deps, {
+      context,
+      pr,
+      toolCatalog: catalog,
+      userRequest: 'approve it',
+    });
+    expect(toolCalls).toHaveLength(0); // /approve never dispatched
+    expect(r.steps[0]?.kind).toBe('judge'); // refusal recorded
+    expect(r.finalText).toBe('cannot approve');
+  });
+
+  it('allows a granted mutating tool', async () => {
+    const { deps, toolCalls } = makeDeps(['{"tool":"/approve"}', '{"final":"approved"}']);
+    const r = await runPlanningAgent(deps, {
+      context,
+      pr,
+      toolCatalog: buildToolCatalog(['approve']),
+      userRequest: 'approve',
+    });
+    expect(toolCalls.map((c) => c.tool)).toEqual(['/approve']);
+    expect(r.finalText).toBe('approved');
+  });
+
+  it('stops at maxSteps', async () => {
+    const { deps } = makeDeps(['{"tool":"/review"}', '{"tool":"/review"}', '{"tool":"/review"}']);
+    const r = await runPlanningAgent(deps, {
+      context,
+      pr,
+      toolCatalog: catalog,
+      userRequest: 'loop',
+      maxSteps: 2,
+    });
+    expect(r.terminationReason).toBe('步数上限中止');
+  });
+
+  it('stops immediately when the signal is aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const { deps } = makeDeps(['{"tool":"/review"}']);
+    const r = await runPlanningAgent(
+      { ...deps, signal: ac.signal },
+      { context, pr, toolCatalog: catalog, userRequest: 'x' },
+    );
+    expect(r.terminationReason).toBe('用户暂停');
+    expect(r.steps).toHaveLength(0);
+  });
+
+  it('treats unparseable output as a final answer', async () => {
+    const { deps } = makeDeps(['just some text, no json']);
+    const r = await runPlanningAgent(deps, { context, pr, toolCatalog: catalog, userRequest: 'x' });
+    expect(r.finalText).toBe('just some text, no json');
+  });
+});

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -408,6 +408,16 @@ export interface IpcChannels {
     response: AgentSession;
   };
   /**
+   * 对指定 PR 跑自由规划 Agent（自然语言入口「对话即委派」）。同步等待，步骤经
+   * agent:stepProgress 推送；返回收尾会话（summary = Agent 最终回答）。
+   */
+  'agent:ask': {
+    request: { localId: string; question: string };
+    response: AgentSession;
+  };
+  /** 暂停当前 PR 的 Agent 运行（abort）；会话置 paused、保态。 */
+  'agent:stop': { request: { localId: string }; response: { ok: boolean } };
+  /**
    * 批量读 AutoPilot 台账：返回各 PR 已自动评审的 recommendation（仅 decision=review 且有
    * 建议者）。PR 列表据此显示徽标，无需逐个加载会话。
    */


### PR DESCRIPTION
## 概述

里程碑 [#2](https://github.com/huhamhire/code-meeseeks/milestone/2) **P2.5b**：「对话即委派」——聊天框无 `/` 前缀的自然语言不再走 `/ask`，改交给**自由规划 Agent**（汇入 `feat/agent`）。

- **`@meebox/agent/planner`**：`runPlanningAgent`（ReAct 引擎）——每步 `chat` 规划下一动作（JSON：工具调用 / 收尾），红线经 `assertToolAllowed` **硬校验**（修改类未授权即拒、回喂让 LLM 改选），步数上限 + abort 暂停。6 例单测。
- **主进程接入**：`agent-planning.ts` 把读类工具映射到既有运行队列（agent 低优先级）；IPC `agent:ask`（自然语言入口）+ `agent:stop`（abort → 会话置 paused）；每 PR 至多一个在跑（AbortController map）。
- **渲染层**：ChatInputBar 无 `/` 前缀 → `agent:ask`；步骤经既有 `agent:stepProgress` 流式、最终回答落总结卡；运行时显示 **Stop** 按钮。四语 i18n + SCSS。

### 范围说明
**continue（恢复 paused 会话）**需可恢复编排（从 transcript 重建），留待后续。stop 已可暂停保态。

### 验证
`lint` / `typecheck`（13）/ `test`（9，含 planner 6 例）/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)