### PR TITLE
feat(agent): Agent 开箱即用——默认目录回落、移除启用开关、控制台 UTF-8、规划兜底

### DIFF
--- a/apps/desktop/src/main/i18n/locales/de-DE.json
+++ b/apps/desktop/src/main/i18n/locales/de-DE.json
@@ -7,7 +7,6 @@
     "rejected": "Entwurf wurde abgelehnt, wird übersprungen"
   },
   "prAgent": {
-    "agentNotEnabled": "Agent ist nicht aktiviert. Bitte das Agent-Verzeichnis in den Einstellungen festlegen und aktivieren.",
     "askNeedsQuestion": "/ask erfordert eine Frage",
     "duplicateTask": "Eine /{{tool}}-Aufgabe für diesen PR wird bereits ausgeführt oder steht in der Warteschlange; bitte nicht erneut auslösen.",
     "notReady": "pr-agent ist nicht bereit",

--- a/apps/desktop/src/main/i18n/locales/en-US.json
+++ b/apps/desktop/src/main/i18n/locales/en-US.json
@@ -7,7 +7,6 @@
     "rejected": "Draft was rejected, skipping"
   },
   "prAgent": {
-    "agentNotEnabled": "Agent is not enabled. Set the Agent directory in Settings and enable it.",
     "askNeedsQuestion": "/ask requires a question",
     "duplicateTask": "A /{{tool}} task for this PR is already running or queued; do not trigger it again.",
     "notReady": "pr-agent not ready",

--- a/apps/desktop/src/main/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/main/i18n/locales/ja-JP.json
@@ -7,7 +7,6 @@
     "rejected": "下書きは却下されました。スキップします"
   },
   "prAgent": {
-    "agentNotEnabled": "Agent が有効になっていません。設定で Agent ディレクトリを指定して有効化してください。",
     "askNeedsQuestion": "/ask には質問の指定が必要です",
     "duplicateTask": "この PR の /{{tool}} タスクはすでに実行中またはキュー待ちです。再度トリガーしないでください。",
     "notReady": "pr-agent が準備できていません",

--- a/apps/desktop/src/main/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/main/i18n/locales/zh-CN.json
@@ -7,7 +7,6 @@
     "rejected": "草稿已被拒绝，跳过"
   },
   "prAgent": {
-    "agentNotEnabled": "Agent 未启用。请在设置中配置 Agent 目录并启用。",
     "askNeedsQuestion": "/ask 需要提供 question",
     "duplicateTask": "该 PR 的 /{{tool}} 任务已在执行或排队中，请勿重复触发",
     "notReady": "pr-agent 未就绪",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, nativeTheme, shell } from 'electron';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import type { Logger } from 'pino';
 import { ensureWorkspace, type BootstrapResult } from '@meebox/config';
@@ -39,6 +40,17 @@ let lastUpdateCheckMs = PROCESS_START_MS;
 // 让运行期不落 .pyc，安装目录文件数稳定（仅装包时的量）。子进程经 spawn 继承本进程 env。
 // 代价：每次 python 启动重编译（略慢）；评审为 LLM 网络主导，影响有限。
 process.env.PYTHONDONTWRITEBYTECODE = '1';
+
+// Windows 控制台默认活动代码页为本地化 OEM 页（简中为 cp936/GBK），而 Node/pino 按 UTF-8 写出
+// 字节 → 中文日志在 dev 终端显示为乱码。启动期把附着控制台的输出代码页切到 65001(UTF-8)，使其与
+// 写出的 UTF-8 字节对齐。仅 win32；无附着控制台（打包态）时 chcp 静默失败，已 try 吞掉、无副作用。
+if (process.platform === 'win32') {
+  try {
+    execSync('chcp 65001', { stdio: 'ignore' });
+  } catch {
+    /* 无控制台 / chcp 不可用：忽略，日志仍按 UTF-8 字节写出 */
+  }
+}
 
 // macOS 免费(ad-hoc)路线：Chromium 的 os_crypt 首启会建「<App> Safe Storage」钥匙串项
 // 加密 cookie/本地存储，但 ad-hoc 签名身份不稳定(cdhash 每次构建变) → 每次启动弹「访问钥匙串」。

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { Logger } from 'pino';
 import { ensureWorkspace, type BootstrapResult } from '@meebox/config';
+import { scaffoldAgentDir } from '@meebox/agent';
 import { resolveLanguage } from '@meebox/shared';
 import { createLogger } from '@meebox/logger';
 import { createPrAgentBridge, type PrAgentBridge } from '@meebox/pr-agent-bridge';
@@ -108,6 +109,17 @@ async function start(): Promise<void> {
     { firstRun: bootstrap.firstRun, appDir: bootstrap.paths.appDir },
     'meebox main process started',
   );
+
+  // Agent 目录脚手架：未配置自定义目录时，Agent 上下文默认落在工作目录下的 agent/（见 ipc.ts
+  // effectiveAgentDir）。启动期幂等补齐默认目录的模版（已存在不覆盖），使首次使用即有 SOUL/AGENTS
+  // 等上下文文件可读。失败不阻断启动（运行期 loadAgentContext 仍会按缺失文件降级 + warn）。
+  void scaffoldAgentDir(bootstrap.paths.agentDir)
+    .then((created) => {
+      if (created.length) logger.info({ created }, 'agent dir scaffolded');
+    })
+    .catch((err: unknown) => {
+      logger.warn({ err }, 'scaffold agent dir failed');
+    });
 
   // macOS GUI 启动（Finder/Dock）只有 launchd 最小 PATH，找不到本机 CLI（claude/codex，常在
   // ~/.local/bin / homebrew）。启动期前置常见目录到 process.env.PATH，使后续 spawn 的嵌入式

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -153,6 +153,9 @@ export function registerIpcHandlers({
     return pr;
   };
 
+  /** 生效的 Agent 目录：用户配置优先，未配置则回落工作目录默认位置（~/.code-meeseeks/agent）。 */
+  const effectiveAgentDir = (): string => bootstrap.config.agent.dir || bootstrap.paths.agentDir;
+
   // /ask 输出去重：pr-agent answer markdown 里会回显完整问题，跟 UI chat-user-msg
   // 气泡重复。逐行精确匹配 question (含 trim 后) 的行整行删掉，保留其余正文
   const stripAskQuestionEcho = (md: string, question: string): string => {
@@ -869,21 +872,18 @@ export function registerIpcHandlers({
           }
         }
 
-        const agentCfg = bootstrap.config.agent;
-        if (agentCfg.enabled && agentCfg.dir) {
-          const rules = await loadAgentRules(agentCfg.dir, {
-            onWarn: (msg, file) => logger.warn({ file }, `rules: ${msg}`),
-          });
-          const matched = pickMatchingRule(rules, {
-            projectKey: pr.repo.projectKey,
-            repoSlug: pr.repo.repoSlug,
-            targetBranch: pr.targetRef.displayId,
-            tool: req.tool,
-          });
-          if (matched) {
-            matchedRuleInstructions = matched.instructions;
-            matchedRuleId = matched.id;
-          }
+        const rules = await loadAgentRules(effectiveAgentDir(), {
+          onWarn: (msg, file) => logger.warn({ file }, `rules: ${msg}`),
+        });
+        const matched = pickMatchingRule(rules, {
+          projectKey: pr.repo.projectKey,
+          repoSlug: pr.repo.repoSlug,
+          targetBranch: pr.targetRef.displayId,
+          tool: req.tool,
+        });
+        if (matched) {
+          matchedRuleInstructions = matched.instructions;
+          matchedRuleId = matched.id;
         }
       }
 
@@ -1331,11 +1331,9 @@ export function registerIpcHandlers({
       req: IpcChannels['agent:run']['request'],
     ): Promise<IpcChannels['agent:run']['response']> => {
       if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
-      const agentCfg = bootstrap.config.agent;
-      if (!agentCfg.enabled || !agentCfg.dir) throw new Error(t('prAgent.agentNotEnabled'));
       const pr = await findPrOrThrow(req.localId);
       // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存。
-      const agentContext = await loadAgentContext(agentCfg.dir, {
+      const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
       return withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
@@ -1384,10 +1382,8 @@ export function registerIpcHandlers({
       req: IpcChannels['agent:ask']['request'],
     ): Promise<IpcChannels['agent:ask']['response']> => {
       if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
-      const agentCfg = bootstrap.config.agent;
-      if (!agentCfg.enabled || !agentCfg.dir) throw new Error(t('prAgent.agentNotEnabled'));
       const pr = await findPrOrThrow(req.localId);
-      const agentContext = await loadAgentContext(agentCfg.dir, {
+      const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
       const ac = new AbortController();
@@ -1418,9 +1414,8 @@ export function registerIpcHandlers({
   let autopilotBusy = false;
   let lastAutopilotEvalAt = 0;
   const runAutopilotIfDue = (): void => {
-    const agentCfg = bootstrap.config.agent;
-    const ap = agentCfg.autopilot;
-    if (!agentCfg.enabled || !agentCfg.dir || !ap.enabled || autopilotBusy || !getPrAgentBridge()) {
+    const ap = bootstrap.config.agent.autopilot;
+    if (!ap.enabled || autopilotBusy || !getPrAgentBridge()) {
       return;
     }
     const now = Date.now();
@@ -1438,7 +1433,7 @@ export function registerIpcHandlers({
         }
         if (candidates.length === 0) return;
 
-        const agentContext = await loadAgentContext(agentCfg.dir, {
+        const agentContext = await loadAgentContext(effectiveAgentDir(), {
           onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
         });
         await withAgentChat(async (chat) => {
@@ -1766,12 +1761,10 @@ export function registerIpcHandlers({
       _evt,
       req: IpcChannels['rules:matchForPr']['request'],
     ): Promise<IpcChannels['rules:matchForPr']['response']> => {
-      const cfg = bootstrap.config.agent;
-      if (!cfg.enabled || !cfg.dir) return null;
       // ask 工具不接规则 (问答自由形式，没什么"规约"可应用)
       if (req.tool === 'ask') return null;
       const pr = await findPrOrThrow(req.localId);
-      const rules = await loadAgentRules(cfg.dir, {
+      const rules = await loadAgentRules(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `rules: ${msg}`),
       });
       const matched = pickMatchingRule(rules, {

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -80,7 +80,9 @@ export function SettingsModal({
 
   // 草稿 → 整体保存：所有编辑只改本地 state，点底栏"保存"才整体写盘 + 生效
   const [reposDirInput, setReposDirInput] = useState(config.workspace.repos_dir);
-  const [agent, setAgent] = useState<Config['agent']>(config.agent);
+  // Agent 其余字段（max_steps / summary_max_chars / autopilot）在 UI 不编辑，仅持有以便保存时
+  // 原样回传、不被覆盖成默认值；只有目录经 agentDirInput 可编辑。
+  const [agent] = useState<Config['agent']>(config.agent);
   const [agentDirInput, setAgentDirInput] = useState(config.agent.dir);
   const [pollerInput, setPollerInput] = useState(String(config.poller.interval_seconds));
   const [llm, setLlm] = useState<Config['llm']>(config.llm);
@@ -95,7 +97,6 @@ export function SettingsModal({
   const [base, setBase] = useState(() => ({
     reposDir: config.workspace.repos_dir,
     agentDir: config.agent.dir,
-    agentEnabled: config.agent.enabled,
     poller: config.poller.interval_seconds,
     llm: config.llm,
     proxy: config.proxy,
@@ -268,8 +269,7 @@ export function SettingsModal({
 
   // ── 变更检测（对比基线）+ 整体保存（仅写有变更的部分，全成功后更新基线）──
   const reposDirChanged = reposDirInput.trim() !== base.reposDir;
-  const agentChanged =
-    agentDirInput.trim() !== base.agentDir || agent.enabled !== base.agentEnabled;
+  const agentChanged = agentDirInput.trim() !== base.agentDir;
   const pollerChanged = pollerInput.trim() !== String(base.poller);
   const llmChanged = JSON.stringify(llm) !== JSON.stringify(base.llm);
   const proxyChanged = JSON.stringify(proxy) !== JSON.stringify(base.proxy);
@@ -297,10 +297,10 @@ export function SettingsModal({
         await invoke('config:setPoller', { interval_seconds: n });
       }
       if (agentChanged) {
-        // 仅 UI 编辑 dir / enabled；其余字段（max_steps / summary_max_chars / autopilot）
-        // 从已加载的 config 原样保留，避免被覆盖成默认值。
+        // 仅 UI 编辑 dir；其余字段（max_steps / summary_max_chars / autopilot）从已加载的
+        // config 原样保留，避免被覆盖成默认值。
         await invoke('config:setAgent', {
-          agent: { ...agent, dir: agentDirInput.trim(), enabled: agent.enabled },
+          agent: { ...agent, dir: agentDirInput.trim() },
         });
       }
       if (llmChanged) {
@@ -323,7 +323,6 @@ export function SettingsModal({
       setBase({
         reposDir: reposDirInput.trim(),
         agentDir: agentDirInput.trim(),
-        agentEnabled: agent.enabled,
         poller: Number.parseInt(pollerInput, 10),
         llm,
         proxy,
@@ -631,18 +630,6 @@ export function SettingsModal({
                 <FolderIcon />
               </button>
             </div>
-            <label className="settings-secret-row" style={{ marginTop: 8 }}>
-              <input
-                type="checkbox"
-                checked={agent.enabled}
-                onChange={(e) => {
-                  setAgent((a) => ({ ...a, enabled: e.target.checked }));
-                  setSaved(false);
-                }}
-                aria-label={t('settings.enableAgent')}
-              />
-              <span className="muted">{t('settings.enableAgent')}</span>
-            </label>
           </section>
 
           <section className="modal-section">

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -583,7 +583,6 @@
     "editConfigYaml": "config.yaml bearbeiten",
     "editConnectionTitle": "Verbindung bearbeiten",
     "editLlmTitle": "LLM-Modell bearbeiten",
-    "enableAgent": "Agent aktivieren",
     "enableConnectionAria": "Diese Verbindung aktivieren",
     "enableProxy": "Proxy aktivieren",
     "experimental": "Experimentell",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -583,7 +583,6 @@
     "editConfigYaml": "Edit config.yaml",
     "editConnectionTitle": "Edit Connection",
     "editLlmTitle": "Edit LLM Model",
-    "enableAgent": "Enable Agent",
     "enableConnectionAria": "Activate this connection",
     "enableProxy": "Enable Proxy",
     "experimental": "Experimental",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -568,7 +568,6 @@
     "editConfigYaml": "config.yaml を編集",
     "editConnectionTitle": "接続を編集",
     "editLlmTitle": "LLM モデルを編集",
-    "enableAgent": "Agent を有効化",
     "enableConnectionAria": "この接続を有効化",
     "enableProxy": "プロキシを有効化",
     "experimental": "実験的",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -568,7 +568,6 @@
     "editConfigYaml": "编辑 config.yaml",
     "editConnectionTitle": "编辑连接",
     "editLlmTitle": "编辑 LLM 模型",
-    "enableAgent": "启用 Agent",
     "enableConnectionAria": "启用该连接",
     "enableProxy": "启用代理",
     "experimental": "实验性",

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -74,6 +74,9 @@ const PROTOCOL = [
   '- Use a tool: {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
   '- Finish:     {"thought": "...", "final": "<your answer to the user>"}',
   'Only call tools listed under "Available tools" that are NOT disabled. Prefer few precise steps.',
+  'Routing policy:',
+  '- If the request concerns this PR but no other tool clearly fits, default to /ask with a focused question.',
+  '- If the request is unrelated to this PR, do NOT call any tool — briefly decline in "final".',
 ].join('\n');
 
 export async function runPlanningAgent(

--- a/packages/agent/tests/planner.test.ts
+++ b/packages/agent/tests/planner.test.ts
@@ -101,4 +101,12 @@ describe('runPlanningAgent', () => {
     const r = await runPlanningAgent(deps, { context, pr, toolCatalog: catalog, userRequest: 'x' });
     expect(r.finalText).toBe('just some text, no json');
   });
+
+  it('injects the routing policy (PR-content → /ask fallback, unrelated → decline) into the system prompt', async () => {
+    const { deps } = makeDeps(['{"final":"done"}']);
+    await runPlanningAgent(deps, { context, pr, toolCatalog: catalog, userRequest: 'x' });
+    const system = vi.mocked(deps.chat).mock.calls[0]?.[0]?.system ?? '';
+    expect(system).toContain('default to /ask');
+    expect(system).toContain('unrelated to this PR');
+  });
 });

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -168,13 +168,13 @@ export const ConfigSchema = z.object({
    * `<agent.dir>/` 下含 SOUL.md / AGENTS.md / MEMORY.md / USER.md 与 rules/ 子目录
    * （规则正文，匹配语义见 @meebox/rules）。
    *
-   * dir 留空 = 不启用（默认），Agent 退化为原生行为；建议指向一个 git repo 让团队共享。
-   * enabled 是全局开关，dir 配了但 enabled=false 时跳过加载。
+   * Agent 无独立启用开关——只要配置了 LLM 且 pr-agent 就绪即可用。dir 留空（默认）时回落
+   * 工作目录下的默认位置（`~/.code-meeseeks/agent`，启动期幂等脚手架）；配自定义路径可指向一个
+   * git repo 让团队共享上下文。
    */
   agent: z
     .object({
       dir: z.string().default(''),
-      enabled: z.boolean().default(true),
       /** 单会话步数上限（默认取小值；见 docs/arch/06-agent.md「会话 Agent 化」）。 */
       max_steps: z.number().int().min(1).max(50).default(8),
       /** 收尾总结严格篇幅上限（字符）。 */

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -329,7 +329,7 @@ export interface IpcChannels {
   'config:setLanguage': { request: { language: SupportedLanguage }; response: void };
   /** 写入 LLM Provider 配置到 config.yaml；下次 pragent:run 自动用新值 */
   'config:setLlm': { request: { llm: Config['llm'] }; response: void };
-  /** 写入 agent.dir + enabled 到 config.yaml；下次 pragent:run 立即生效 (现读规则) */
+  /** 写入 agent.dir 到 config.yaml；下次 pragent:run 立即生效 (现读规则) */
   'config:setAgent': { request: { agent: Config['agent'] }; response: void };
   /** 翻转 AutoPilot 开关 (agent.autopilot.enabled) 并写 config.yaml；下次 poll tick 生效。 */
   'agent:setAutopilotEnabled': { request: { enabled: boolean }; response: void };
@@ -401,7 +401,7 @@ export interface IpcChannels {
   /**
    * 对指定 PR 跑一次 Agent 评审微流程（describe→review→条件追问→总结）。同步等待，
    * 期间经 agent:stepProgress 推送步骤；返回收尾后的 AgentSession（含 summary /
-   * recommendation）。agent.enabled=false / pr-agent 不可用时 reject。
+   * recommendation）。pr-agent 不可用时 reject。
    */
   'agent:run': {
     request: { localId: string };


### PR DESCRIPTION
## 背景

来自运行期实测反馈的三处调整 + 一处规划路由收敛，目标是让 Agent「开箱即用」、降低无谓门槛。

## 变更

### 1. Agent 目录默认回落工作目录
未配置自定义 `agent.dir` 时，Agent 上下文回落到工作目录下的默认位置 `~/.code-meeseeks/agent`，启动期幂等脚手架补齐 SOUL/AGENTS/MEMORY/USER 与 rules/，首次使用即有上下文可读。新增 `effectiveAgentDir()` 统一解析（用户配置优先，否则回落默认）。

### 2. 移除 Agent 启用/关闭开关
Agent 不再需要独立开关——只要配置了 LLM 且 pr-agent 就绪即可用。移除 `config.agent.enabled` 字段、`agent:run / agent:ask / autopilot / rules:matchForPr` 的 enabled 门控、设置页「启用 Agent」勾选项，以及相关 i18n（`settings.enableAgent` / `prAgent.agentNotEnabled`）。

> 注：状态栏的 AutoPilot 开关（`agent.autopilot.enabled`）保留，不在此次移除范围。

### 3. 修复 Windows 控制台中文日志乱码
Windows 控制台默认 OEM 代码页（简中 cp936/GBK）与 Node/pino 写出的 UTF-8 字节不一致 → 中文日志乱码。启动期在 win32 上将输出代码页切到 65001(UTF-8)，无控制台时静默忽略。

### 4. 自由规划路由兜底
为规划编排器补充路由策略（写入系统提示）：
- 请求与本 PR 内容相关、但无其他工具明确指向 → 默认走 `/ask` 兜底
- 请求与本 PR 无关 → 不调用任何工具，直接简短拒绝

## 验证
- `lint` / `typecheck` / `test` / `build` 全通过
- 新增 planner 测试断言路由策略已注入系统提示