### PR TITLE
feat(agent): 多轮对话记忆与展示

### DIFF
--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -1,5 +1,11 @@
 import { runPlanningAgent, type AgentContext, type PlanningToolResult } from '@meebox/agent';
-import { appendAgentStep, startAgentSession, updateAgentSession } from '@meebox/poller';
+import {
+  appendAgentMessage,
+  appendAgentStep,
+  getAgentConversation,
+  startAgentSession,
+  updateAgentSession,
+} from '@meebox/poller';
 import type { Rule } from '@meebox/rules';
 import type {
   AgentSession,
@@ -46,6 +52,10 @@ export async function runAgentPlanning(
   deps: AgentPlanningDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
+  // 多轮对话：先读既往消息（注入规划上下文），再把本轮用户输入追加为一条消息（持久化）。
+  const history = await getAgentConversation(deps.stateStore, pr.localId);
+  await appendAgentMessage(deps.stateStore, pr.localId, { role: 'user', content: userRequest }, now);
+
   const session = await startAgentSession(
     deps.stateStore,
     { prLocalId: pr.localId, maxSteps: deps.maxSteps, userRequest },
@@ -78,9 +88,20 @@ export async function runAgentPlanning(
         matchedRule: deps.matchedRule,
         language: deps.language,
         userRequest,
+        history,
         maxSteps: deps.maxSteps,
       },
     );
+
+    // 把 Agent 收尾回答追加为一条助手消息（评审类带 recommendation）；暂停 / 空回答不记。
+    if (result.finalText && result.terminationReason !== '用户暂停') {
+      await appendAgentMessage(
+        deps.stateStore,
+        pr.localId,
+        { role: 'assistant', content: result.finalText, recommendation: result.recommendation },
+        now,
+      );
+    }
 
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -39,6 +39,8 @@ import {
   getAutopilotLedger,
   getAgentSession,
   clearAgentSession,
+  getAgentConversation,
+  appendAgentMessage,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
 import { pickMatchingRule } from '@meebox/rules';
@@ -1338,7 +1340,17 @@ export function registerIpcHandlers({
       const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
-      return withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+      const session = await withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+      // 手动一键评审计入多轮对话（作为一条 assistant 评审消息）；AutoPilot 背景评审不计（走 1476
+      // 的 runReviewForPr，不经此处）。无文本 / 失败不记。
+      if (session.status === 'done' && session.summary) {
+        await appendAgentMessage(stateStore, pr.localId, {
+          role: 'assistant',
+          content: session.summary,
+          recommendation: session.recommendation,
+        });
+      }
+      return session;
     },
   );
 
@@ -1417,6 +1429,15 @@ export function registerIpcHandlers({
       req: IpcChannels['agent:getSession']['request'],
     ): Promise<IpcChannels['agent:getSession']['response']> =>
       getAgentSession(stateStore, req.localId),
+  );
+
+  ipcMain.handle(
+    'agent:getConversation',
+    async (
+      _evt,
+      req: IpcChannels['agent:getConversation']['request'],
+    ): Promise<IpcChannels['agent:getConversation']['response']> =>
+      getAgentConversation(stateStore, req.localId),
   );
 
   // === AutoPilot 调度（见 docs/arch/06-agent.md「AutoPilot」）===

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import type {
-  AgentRecommendation,
+  AgentMessage,
   AgentStep,
   Finding,
   IpcChannels,
@@ -148,15 +148,12 @@ export function ChatPane({
   // 当前 PR 命中的规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
   const [matchedRule, setMatchedRule] = useState<MatchedRule>(null);
   const [showRulePreview, setShowRulePreview] = useState(false);
-  // Agent 自动评审（微流程：describe→review→条件追问→总结）：运行态 + 收尾结果。
+  // Agent 运行态（自动评审微流程 / 自由规划对话）。
   const [agentRunning, setAgentRunning] = useState(false);
-  const [agentResult, setAgentResult] = useState<{
-    summary: string;
-    recommendation?: AgentRecommendation;
-  } | null>(null);
   const [agentSteps, setAgentSteps] = useState<AgentStep[]>([]);
-  // 触发本次会话的用户自然语言输入（对话即委派）：回显为右对齐气泡；at 用于在时间线中定位。
-  const [userRequest, setUserRequest] = useState<{ text: string; at: string } | null>(null);
+  // 多轮对话消息（用户输入 + Agent 回答），跨回合保留、由 main 落盘 conversation.json，
+  // 切回该 PR 恢复。用户消息含临时 optimistic 项（提交即回显），收尾后整体以落盘版重载对齐。
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
   // 当前展示中的 PR id（每渲染同步）：异步 Agent 任务 resolve 时据此判断是否仍停在发起 PR，
@@ -190,7 +187,7 @@ export function ChatPane({
       time: r.startedAt,
       run: r as ReviewRun | null,
       step: null as AgentStep | null,
-      user: null as string | null,
+      message: null as AgentMessage | null,
     }));
     const stepEntries = agentSteps
       .filter((s) => s.kind === 'judge')
@@ -199,15 +196,19 @@ export function ChatPane({
         time: s.at ?? '',
         run: null,
         step: s,
-        user: null as string | null,
+        message: null as AgentMessage | null,
       }));
-    const userEntries = userRequest
-      ? [{ key: `user-${userRequest.at}`, time: userRequest.at, run: null, step: null, user: userRequest.text }]
-      : [];
-    return [...runEntries, ...stepEntries, ...userEntries].sort((a, b) =>
+    const msgEntries = messages.map((m, i) => ({
+      key: `msg-${i}-${m.at}`,
+      time: m.at,
+      run: null,
+      step: null as AgentStep | null,
+      message: m,
+    }));
+    return [...runEntries, ...stepEntries, ...msgEntries].sort((a, b) =>
       a.time.localeCompare(b.time),
     );
-  }, [visibleRuns, agentSteps, userRequest]);
+  }, [visibleRuns, agentSteps, messages]);
 
   // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
   // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
@@ -222,30 +223,24 @@ export function ChatPane({
     setError(null);
     setMatchedRule(null);
     setAgentSteps([]);
-    setAgentResult(null);
-    setUserRequest(null);
+    setMessages([]);
     if (!prLocalId) return;
     let cancelled = false;
     void (async () => {
       try {
         // listRuns 默认返回 newest-first；这里只拉最新一页 (RUNS_PAGE_SIZE)。
-        // 同时拉已落盘的 Agent 会话：把「评审总结」卡片恢复到其发起 PR，跨切换不丢失。
-        const [list, rule, session] = await Promise.all([
+        // 同时拉已落盘的多轮对话：把会话消息恢复到其 PR，跨切换 / 重启不丢失。
+        const [list, rule, conversation] = await Promise.all([
           invoke('pragent:listRuns', { localId: prLocalId, limit: RUNS_PAGE_SIZE }),
           invoke('rules:matchForPr', { localId: prLocalId, tool: 'review' }),
-          invoke('agent:getSession', { localId: prLocalId }),
+          invoke('agent:getConversation', { localId: prLocalId }),
         ]);
         if (cancelled) return;
         // 反转为升序 (chat 习惯)，UI 直接读 runs 即可
         setRuns([...list].reverse());
         setHasMoreOlder(list.length === RUNS_PAGE_SIZE);
         setMatchedRule(rule);
-        if (session?.userRequest) {
-          setUserRequest({ text: session.userRequest, at: session.startedAt });
-        }
-        if (session?.summary) {
-          setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-        }
+        setMessages(conversation);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -362,25 +357,28 @@ export function ChatPane({
     }
   };
 
-  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经
-  // 既有运行队列展示在历史里；收尾总结 + 建议落 agentResult 单独呈现。
+  // 从 main 重载某 PR 的多轮对话（落盘版为准）；仅当仍停在该 PR 才落到当前视图，避免串台。
+  const reloadConversation = async (localId: string): Promise<void> => {
+    try {
+      const conversation = await invoke('agent:getConversation', { localId });
+      if (currentPrIdRef.current === localId) setMessages(conversation);
+    } catch {
+      /* 忽略：下次 PR 切换 effect 会重载 */
+    }
+  };
+
+  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经既有运行
+  // 队列展示在历史里；收尾评审作为一条 assistant 消息落入多轮对话，完成后重载对话呈现。
   const handleAgentReview = async (): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
     const startedId = pr.localId;
     setError(null);
-    setAgentResult(null);
     setAgentSteps([]);
-    setUserRequest(null); // 自动评审无文本输入，清掉上一轮对话气泡
     setAgentRunning(true);
     try {
       const session = await invoke('agent:run', { localId: startedId });
-      // 已切到别的 PR：结果归属其发起 PR（已落盘），不串台到当前会话；回到该 PR 时由切换 effect
-      // 从落盘会话恢复总结。
-      if (currentPrIdRef.current !== startedId) return;
-      if (session.summary) {
-        setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-      }
-      if (session.status === 'failed') {
+      await reloadConversation(startedId);
+      if (currentPrIdRef.current === startedId && session.status === 'failed') {
         setError(session.terminationReason ?? t('chatPane.agent.failed'));
       }
     } catch (e) {
@@ -392,24 +390,19 @@ export function ChatPane({
     }
   };
 
-  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。最终回答落 agentResult，步骤同样流式。
+  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。用户输入即时 optimistic 回显，
+  // 收尾后以落盘对话（含用户 + 助手消息）整体对齐。
   const handleAgentAsk = async (question: string): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
     const startedId = pr.localId;
     setError(null);
-    setAgentResult(null);
     setAgentSteps([]);
-    // 立即回显用户输入气泡（main 落盘 session.userRequest 后，切回该 PR 亦能恢复）。
-    setUserRequest({ text: question, at: new Date().toISOString() });
+    setMessages((prev) => [...prev, { role: 'user', content: question, at: new Date().toISOString() }]);
     setAgentRunning(true);
     try {
       const session = await invoke('agent:ask', { localId: startedId, question });
-      // 已切到别的 PR：不串台（回该 PR 时由切换 effect 从落盘会话恢复）。
-      if (currentPrIdRef.current !== startedId) return;
-      if (session.summary) {
-        setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-      }
-      if (session.status === 'failed') {
+      await reloadConversation(startedId);
+      if (currentPrIdRef.current === startedId && session.status === 'failed') {
         setError(session.terminationReason ?? t('chatPane.agent.failed'));
       }
     } catch (e) {
@@ -432,9 +425,8 @@ export function ChatPane({
       setRuns([]);
       setHasMoreOlder(false);
       setError(null);
-      setAgentResult(null);
       setAgentSteps([]);
-      setUserRequest(null);
+      setMessages([]);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -639,7 +631,6 @@ export function ChatPane({
         {/* 使用提示仅在「全无会话内容」时显示：一旦有用户输入气泡 / run / 步骤 / 收尾结果，
             或 Agent 正在运行 / 有排队任务，即隐藏，避免输入后仍残留提示。 */}
         {timeline.length === 0 &&
-          !agentResult &&
           !agentRunning &&
           !hasMyActive &&
           myWaiting.length === 0 && (
@@ -675,10 +666,8 @@ export function ChatPane({
             />
           ) : entry.step ? (
             <AgentStepMarker key={entry.key} step={entry.step} />
-          ) : entry.user != null ? (
-            <div key={entry.key} className="chat-user-row">
-              <div className="chat-user-bubble">{entry.user}</div>
-            </div>
+          ) : entry.message ? (
+            <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
         )}
         {/* 正在跑（可并发多条）：每条一个进度条 + 实时 stdout 流，贴在历史末尾。
@@ -720,54 +709,6 @@ export function ChatPane({
             <span>{t('chatPane.agent.thinking')}</span>
           </div>
         )}
-        {/* 收尾结果两种形态：评审类（带 recommendation）→「评审总结」卡片 + 判定徽标；
-            自然对话（无 recommendation）→ 专属对话回复包装，不套用评审总结标题。 */}
-        {agentResult &&
-          (agentResult.recommendation ? (
-            <div className="chat-agent-summary" role="status">
-              <div className="chat-agent-summary-head">
-                <strong>{t('chatPane.agent.summaryTitle')}</strong>
-                <span
-                  className={`chat-agent-verdict verdict-${agentResult.recommendation.verdict}`}
-                >
-                  {t(VERDICT_LABEL_KEY[agentResult.recommendation.verdict])}
-                </span>
-              </div>
-              <div className="markdown chat-agent-summary-text">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                  components={mermaidComponents}
-                >
-                  {agentResult.summary}
-                </ReactMarkdown>
-              </div>
-              {agentResult.recommendation.reason && (
-                <div className="markdown muted chat-agent-summary-reason">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkBreaks]}
-                    rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                    components={mermaidComponents}
-                  >
-                    {agentResult.recommendation.reason}
-                  </ReactMarkdown>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="chat-agent-reply" role="status">
-              <ChatIcon size={16} />
-              <div className="markdown chat-agent-reply-body">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                  components={mermaidComponents}
-                >
-                  {agentResult.summary}
-                </ReactMarkdown>
-              </div>
-            </div>
-          ))}
         {error && (
           <div className="chat-error" role="alert">
             <strong>{t('chatPane.errorPrefix')}</strong>
@@ -1412,13 +1353,63 @@ function AskQuestion({ text }: { text: string }) {
     <div className="chat-user-msg" aria-label={t('chatPane.userQuestionAria')}>
       <QuestionIcon />
       <div className="markdown chat-user-msg-body">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkBreaks]}
-          rehypePlugins={REMOTE_REHYPE_PLUGINS}
-          components={mermaidComponents}
-        >
-          {text}
-        </ReactMarkdown>
+        <Md>{text}</Md>
+      </div>
+    </div>
+  );
+}
+
+/** chat 区统一的 markdown 渲染（与 finding 卡片同套 remark/rehype 配置）。 */
+function Md({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      rehypePlugins={REMOTE_REHYPE_PLUGINS}
+      components={mermaidComponents}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+/**
+ * 一条多轮对话消息的展示：用户 → 右对齐气泡；助手评审类（带 recommendation）→「评审总结」卡片 +
+ * 判定徽标；助手对话类（无 recommendation）→ 左对齐专属对话回复包装。
+ */
+function ConversationMessage({ message }: { message: AgentMessage }) {
+  const { t } = useTranslation();
+  if (message.role === 'user') {
+    return (
+      <div className="chat-user-row">
+        <div className="chat-user-bubble">{message.content}</div>
+      </div>
+    );
+  }
+  if (message.recommendation) {
+    return (
+      <div className="chat-agent-summary" role="status">
+        <div className="chat-agent-summary-head">
+          <strong>{t('chatPane.agent.summaryTitle')}</strong>
+          <span className={`chat-agent-verdict verdict-${message.recommendation.verdict}`}>
+            {t(VERDICT_LABEL_KEY[message.recommendation.verdict])}
+          </span>
+        </div>
+        <div className="markdown chat-agent-summary-text">
+          <Md>{message.content}</Md>
+        </div>
+        {message.recommendation.reason && (
+          <div className="markdown muted chat-agent-summary-reason">
+            <Md>{message.recommendation.reason}</Md>
+          </div>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="chat-agent-reply" role="status">
+      <ChatIcon size={16} />
+      <div className="markdown chat-agent-reply-body">
+        <Md>{message.content}</Md>
       </div>
     </div>
   );

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -1,5 +1,6 @@
 import type { Rule } from '@meebox/rules';
 import type {
+  AgentMessage,
   AgentRecommendation,
   AgentRecommendationVerdict,
   AgentStep,
@@ -43,6 +44,11 @@ export interface PlanningInput {
   language?: string;
   /** 用户的自然语言请求。 */
   userRequest: string;
+  /**
+   * 既往多轮对话（用户 / 助手消息，按时间升序，不含本轮请求）。注入规划 LLM 的上下文，使
+   * Agent 跨轮记住此前交流；**绝不**透传给 pr-agent 工具（工具只看 PR + 当轮问题）。
+   */
+  history?: AgentMessage[];
   /** 步数上限（默认 8）。 */
   maxSteps?: number;
 }
@@ -100,6 +106,29 @@ function clamp(s: string, max: number): string {
 /** 一次并行最多分发的工具数：多选时截断，防止一轮打出过多 pr-agent run。 */
 const MAX_PARALLEL_TOOLS = 3;
 
+/**
+ * 注入规划上下文的历史对话预算：单条字符上限 + 总字符预算（从最新往回累计、超预算即裁剪更早的）。
+ * 约定会话上下文不超过 LLM 上下文窗口的一半——以字符近似 token 做保守封顶：64k 字符 ≈ 16~40k token
+ * （视中英文占比），对应约 32k~64k token 半窗的目标量级。后续可按模型实际窗口精确估算 token，并引入
+ * 老消息压缩（摘要）替代直接裁剪。
+ */
+const HISTORY_MESSAGE_MAX = 2000;
+const HISTORY_BUDGET_CHARS = 64000;
+
+/** 取最近若干轮、各自限长，并按总预算从新到旧裁剪（丢弃超预算的更早消息），返回时间升序文本。 */
+function buildConversationContext(history: readonly AgentMessage[]): string {
+  const lines: string[] = [];
+  let budget = HISTORY_BUDGET_CHARS;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const m = history[i]!;
+    const line = `${m.role === 'user' ? 'User' : 'Assistant'}: ${clamp(m.content, HISTORY_MESSAGE_MAX)}`;
+    if (line.length + 1 > budget) break; // 预算耗尽：更早的对话整体裁掉
+    budget -= line.length + 1;
+    lines.push(line);
+  }
+  return lines.reverse().join('\n');
+}
+
 const PROTOCOL = [
   'Each turn, reply with JSON ONLY for the next action:',
   '- One tool:   {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
@@ -145,12 +174,19 @@ export async function runPlanningAgent(
     await deps.onStep?.(step);
   };
 
+  // 既往多轮对话注入规划上下文（按预算裁剪），让 Agent 跨轮记住交流；仅供规划 LLM 参考，
+  // 绝不透传给 pr-agent 工具。
+  const convo = buildConversationContext(input.history ?? []);
+
   for (let i = 0; i < maxSteps; i++) {
     if (deps.signal?.aborted) {
       return { steps, finalText: '', tokenUsage: usage, terminationReason: '用户暂停' };
     }
 
     const user = [
+      convo
+        ? `Conversation so far (your context only — NEVER pass any of it to tools):\n${convo}\n`
+        : '',
       `User request: ${input.userRequest}`,
       history.length ? `\nProgress so far:\n${history.join('\n')}` : '',
       '\nReply with the next JSON action.',

--- a/packages/poller/src/agent-session.ts
+++ b/packages/poller/src/agent-session.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentConversationFile,
+  AgentMessage,
   AgentSession,
   AgentSessionFile,
   AgentSessionStatus,
@@ -20,6 +22,9 @@ function sessionKey(prLocalId: string): string {
 }
 function transcriptKey(prLocalId: string): string {
   return `prs/${prLocalId}/agent/transcript`;
+}
+function conversationKey(prLocalId: string): string {
+  return `prs/${prLocalId}/agent/conversation`;
 }
 
 export interface StartAgentSessionInput {
@@ -135,11 +140,40 @@ export async function appendAgentStep(
   return next;
 }
 
-/** 清掉某 PR 的会话 + transcript（删 `prs/<localId>/agent/*`）。 */
+/** 清掉某 PR 的会话 + transcript + 多轮对话（删 `prs/<localId>/agent/*`）。 */
 export async function clearAgentSession(
   stateStore: StateStore,
   prLocalId: string,
 ): Promise<void> {
   await stateStore.delete(sessionKey(prLocalId));
   await stateStore.delete(transcriptKey(prLocalId));
+  await stateStore.delete(conversationKey(prLocalId));
+}
+
+/**
+ * 多轮对话日志（跨回合保留，独立于 per-turn 的 session / transcript 生命周期）：读取本 PR
+ * 全部消息（用户输入 + Agent 收尾回答）。无则空数组。
+ */
+export async function getAgentConversation(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<AgentMessage[]> {
+  const file = await stateStore.read<AgentConversationFile>(conversationKey(prLocalId));
+  return file?.messages ?? [];
+}
+
+/** 追加一条对话消息（用户 / 助手），返回追加后的完整消息列表。`at` 缺省打当前时间。 */
+export async function appendAgentMessage(
+  stateStore: StateStore,
+  prLocalId: string,
+  message: Omit<AgentMessage, 'at'> & { at?: string },
+  now: () => Date = () => new Date(),
+): Promise<AgentMessage[]> {
+  const messages = await getAgentConversation(stateStore, prLocalId);
+  messages.push({ ...message, at: message.at ?? now().toISOString() });
+  await stateStore.write<AgentConversationFile>(conversationKey(prLocalId), {
+    schema_version: 1,
+    messages,
+  });
+  return messages;
 }

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -54,6 +54,28 @@ export interface AgentRecommendation {
   reason: string;
 }
 
+export type AgentMessageRole = 'user' | 'assistant';
+
+/**
+ * 一条对话消息（回合级，区别于回合内的 AgentStep）。多轮对话的持久化单元：用户输入与 Agent
+ * 收尾回答各一条，按时间追加。Agent 自身上下文（规划）会读取历史消息，但**绝不**注入 pr-agent
+ * 工具调用（工具只看 PR + 当轮问题）。
+ */
+export interface AgentMessage {
+  role: AgentMessageRole;
+  content: string;
+  /** assistant 评审类回合的非约束性判定；对话 / 用户消息不填。 */
+  recommendation?: AgentRecommendation;
+  /** 产生时间（ISO），用于时间线排序。 */
+  at: string;
+}
+
+/** 持久化包装：`prs/<localId>/agent/conversation.json`（多轮消息流式追加，跨回合保留）。 */
+export interface AgentConversationFile {
+  schema_version: 1;
+  messages: AgentMessage[];
+}
+
 /** 每个 PR 一份、由子 agent 所有的会话记录（见数据契约）。 */
 export interface AgentSession {
   id: string;

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,4 +1,9 @@
-import type { AgentRecommendationVerdict, AgentSession, AgentStep } from './agent-contract.js';
+import type {
+  AgentMessage,
+  AgentRecommendationVerdict,
+  AgentSession,
+  AgentStep,
+} from './agent-contract.js';
 import type { AppInfo, AppPaths, UpdateCheckResult } from './app-info.js';
 import type { Config } from './config.js';
 import type { SupportedLanguage } from './language.js';
@@ -422,6 +427,11 @@ export interface IpcChannels {
    * 供 UI 打开 PR 时恢复「评审总结」卡片——总结归属其发起 PR、跨 PR 切换不丢失、不串台。
    */
   'agent:getSession': { request: { localId: string }; response: AgentSession | null };
+  /**
+   * 读取指定 PR 的多轮对话消息（用户输入 + Agent 回答，按时间升序）；无则空数组。
+   * UI 据此渲染多轮会话；跨 PR 切换 / 重启后恢复。
+   */
+  'agent:getConversation': { request: { localId: string }; response: AgentMessage[] };
   /**
    * 批量读 AutoPilot 台账：返回各 PR 已自动评审的 recommendation（仅 decision=review 且有
    * 建议者）。PR 列表据此显示徽标，无需逐个加载会话。


### PR DESCRIPTION
## 背景

Agent 此前只展示最近一轮的输入/输出、无跨轮记忆。本 PR 引入回合级多轮对话：保留多轮、把对话整合进 Agent 自己的规划上下文，但**不影响 pr-agent 工具调用上下文**。

## 变更

### 存储 / 管理
- 新增 `conversation.json`（独立于 per-turn 的 session / transcript 生命周期，跨回合保留）。
- `AgentMessage`（user / assistant，assistant 评审带 `recommendation`）+ `getAgentConversation` / `appendAgentMessage`；`clearAgentSession` 一并清；新增 `agent:getConversation` IPC。

### 上下文注入（仅规划，不入工具）
- 自由规划把既往对话注入规划 LLM 上下文 → `/ask` 等具备跨轮感知；**绝不**透传给 pr-agent 工具（工具只看 PR + 当轮问题）。
- 按预算从新到旧裁剪：单条 2000 字符、总 64000 字符（约对齐半个 LLM 上下文窗口的量级；以字符近似 token 的保守封顶）。

### 落库 / 展示
- `agent:ask` 追加用户 + 助手消息；手动一键评审（`agent:run`）追加一条 assistant 评审消息（AutoPilot 背景评审不计入对话）。
- ChatPane 改为渲染落盘的 `messages` 列表：用户右气泡 / 助手评审卡片（判定徽标）/ 助手对话回复，按时间与 run 卡片、judge 标记穿插；切换 PR / 重启恢复；optimistic 回显用户输入、收尾以落盘版对齐。

## 验证
- `lint` / `typecheck` / `test` / `build` 全通过。

## 关联与后续
- 一定程度上覆盖 milestone 中「continue 暂停会话」：暂停后再发消息即带完整上下文继续，无需精确恢复中断的 ReAct 循环（精确续跑仍可作为独立增强）。
- 后续（未含）：老消息**压缩**（摘要）替代直接裁剪、按模型实际窗口精确估 token、Agent 主动维护用户记忆（MEMORY/USER 写回，排除隐私）、状态栏 AutoPilot 机器人图标。