### PR TITLE
feat(agent): 主动维护记忆/规则 + 会话压缩 + AutoPilot 机器人图标

### DIFF
--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -10,7 +10,9 @@ import {
   getAgentConversation,
   startAgentSession,
   updateAgentSession,
+  writeAgentConversation,
 } from '@meebox/poller';
+import type { AgentMessage } from '@meebox/shared';
 import type { Rule } from '@meebox/rules';
 import type {
   AgentSession,
@@ -33,6 +35,45 @@ function reviewRunText(run: ReviewRun): string {
 }
 
 const READ_TOOLS = new Set(['describe', 'review', 'ask']);
+
+// 会话压缩：存储超阈值时把较早消息摘要成一条 digest、仅留最近若干条原文，控制存储与后续注入规模
+// （约定会话上下文不超 LLM 半窗：先压缩/裁剪再注入）。阈值高于注入预算，超出才触发、不频繁。
+const CONVO_COMPACT_THRESHOLD_CHARS = 80000;
+const CONVO_KEEP_RECENT = 6;
+const COMPACT_SYSTEM =
+  'You compress earlier turns of a conversation between a user and a code-review assistant into a ' +
+  'concise digest. Preserve key facts, decisions, the user’s stated preferences / 称呼, and any open ' +
+  'threads. Reply in the same language as the conversation. Output plain text only, no preamble.';
+
+/** 存储超阈值时，把较早消息摘要为一条 digest 替换之；未超阈值 / 失败则原样保留。 */
+async function maybeCompactConversation(
+  stateStore: AgentPlanningDeps['stateStore'],
+  chat: AgentPlanningDeps['chat'],
+  prLocalId: string,
+  now: () => Date,
+): Promise<void> {
+  const messages = await getAgentConversation(stateStore, prLocalId);
+  const total = messages.reduce((n, m) => n + m.content.length, 0);
+  if (total <= CONVO_COMPACT_THRESHOLD_CHARS || messages.length <= CONVO_KEEP_RECENT + 1) return;
+
+  const older = messages.slice(0, -CONVO_KEEP_RECENT);
+  const recent = messages.slice(-CONVO_KEEP_RECENT);
+  const transcript = older
+    .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
+    .join('\n\n');
+  try {
+    const { text } = await chat({ system: COMPACT_SYSTEM, user: transcript });
+    const digest: AgentMessage = {
+      role: 'assistant',
+      content: `（早期对话摘要）\n${text.trim()}`,
+      // 用最早消息的时间戳，保证 digest 仍排在时间线最前。
+      at: older[0]?.at ?? now().toISOString(),
+    };
+    await writeAgentConversation(stateStore, prLocalId, [digest, ...recent]);
+  } catch {
+    /* 压缩失败：保留原对话，下次再试（读时仍有预算裁剪兜底） */
+  }
+}
 
 export interface AgentPlanningDeps {
   stateStore: StateStore;
@@ -115,6 +156,9 @@ export async function runAgentPlanning(
     if (deps.recordMemory && (mem.user.length || mem.memory.length || mem.agents.length)) {
       await deps.recordMemory(mem);
     }
+
+    // 会话超阈值时压缩较早消息（best-effort，不阻断收尾）。
+    await maybeCompactConversation(deps.stateStore, deps.chat, pr.localId, now);
 
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {

--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -1,5 +1,11 @@
 import { runPlanningAgent, type AgentContext, type PlanningToolResult } from '@meebox/agent';
-import { appendAgentStep, startAgentSession, updateAgentSession } from '@meebox/poller';
+import {
+  appendAgentMessage,
+  appendAgentStep,
+  getAgentConversation,
+  startAgentSession,
+  updateAgentSession,
+} from '@meebox/poller';
 import type { Rule } from '@meebox/rules';
 import type {
   AgentSession,
@@ -46,6 +52,10 @@ export async function runAgentPlanning(
   deps: AgentPlanningDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
+  // 多轮对话：先读既往消息（注入规划上下文），再把本轮用户输入追加为一条消息（持久化）。
+  const history = await getAgentConversation(deps.stateStore, pr.localId);
+  await appendAgentMessage(deps.stateStore, pr.localId, { role: 'user', content: userRequest }, now);
+
   const session = await startAgentSession(
     deps.stateStore,
     { prLocalId: pr.localId, maxSteps: deps.maxSteps, userRequest },
@@ -78,9 +88,20 @@ export async function runAgentPlanning(
         matchedRule: deps.matchedRule,
         language: deps.language,
         userRequest,
+        history,
         maxSteps: deps.maxSteps,
       },
     );
+
+    // 把 Agent 收尾回答追加为一条助手消息（评审类带 recommendation）；暂停 / 空回答不记。
+    if (result.finalText && result.terminationReason !== '用户暂停') {
+      await appendAgentMessage(
+        deps.stateStore,
+        pr.localId,
+        { role: 'assistant', content: result.finalText, recommendation: result.recommendation },
+        now,
+      );
+    }
 
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {

--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -1,4 +1,9 @@
-import { runPlanningAgent, type AgentContext, type PlanningToolResult } from '@meebox/agent';
+import {
+  runPlanningAgent,
+  type AgentContext,
+  type AgentMemoryNotes,
+  type PlanningToolResult,
+} from '@meebox/agent';
 import {
   appendAgentMessage,
   appendAgentStep,
@@ -44,6 +49,8 @@ export interface AgentPlanningDeps {
   maxSteps: number;
   signal?: AbortSignal;
   onStep?: (sessionId: string, step: AgentStep) => void;
+  /** 持久化 Agent 主动记下的非隐私条目到各可写上下文文件（USER/MEMORY/AGENTS）。 */
+  recordMemory?: (notes: AgentMemoryNotes) => Promise<void>;
 }
 
 export async function runAgentPlanning(
@@ -101,6 +108,12 @@ export async function runAgentPlanning(
         { role: 'assistant', content: result.finalText, recommendation: result.recommendation },
         now,
       );
+    }
+
+    // 持久化本轮主动记忆（非隐私）到各可写文件；失败不阻断会话收尾。
+    const mem = result.memories;
+    if (deps.recordMemory && (mem.user.length || mem.memory.length || mem.agents.length)) {
+      await deps.recordMemory(mem);
     }
 
     return (

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import type { Logger } from 'pino';
 import {
+  appendAgentNotes,
   buildToolCatalog,
   judgeAutopilotBatch,
   loadAgentContext,
@@ -1384,6 +1385,18 @@ export function registerIpcHandlers({
       onStep: (sessionId, step) => {
         for (const win of BrowserWindow.getAllWindows()) {
           win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+        }
+      },
+      // 持久化 Agent 主动记下的非隐私条目到当前 Agent 目录的各可写文件（USER/MEMORY/AGENTS）；
+      // SOUL.md 永不写。下一轮 loadAgentContext 现读即生效（跨会话记忆）。
+      recordMemory: async (notes) => {
+        const dir = effectiveAgentDir();
+        for (const kind of ['user', 'memory', 'agents'] as const) {
+          const added = await appendAgentNotes(dir, kind, notes[kind]).catch((err: unknown) => {
+            logger.warn({ err, kind }, 'record agent memory failed');
+            return [] as string[];
+          });
+          if (added.length) logger.info({ kind, added }, 'agent memory recorded');
         }
       },
     });

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -39,6 +39,8 @@ import {
   getAutopilotLedger,
   getAgentSession,
   clearAgentSession,
+  getAgentConversation,
+  appendAgentMessage,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
 import { pickMatchingRule } from '@meebox/rules';
@@ -1338,7 +1340,17 @@ export function registerIpcHandlers({
       const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
-      return withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+      const session = await withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+      // 手动一键评审计入多轮对话（作为一条 assistant 评审消息）；AutoPilot 背景评审不计（走 1476
+      // 的 runReviewForPr，不经此处）。无文本 / 失败不记。
+      if (session.status === 'done' && session.summary) {
+        await appendAgentMessage(stateStore, pr.localId, {
+          role: 'assistant',
+          content: session.summary,
+          recommendation: session.recommendation,
+        });
+      }
+      return session;
     },
   );
 
@@ -1417,6 +1429,15 @@ export function registerIpcHandlers({
       req: IpcChannels['agent:getSession']['request'],
     ): Promise<IpcChannels['agent:getSession']['response']> =>
       getAgentSession(stateStore, req.localId),
+  );
+
+  ipcMain.handle(
+    'agent:getConversation',
+    async (
+      _evt,
+      req: IpcChannels['agent:getConversation']['request'],
+    ): Promise<IpcChannels['agent:getConversation']['response']> =>
+      getAgentConversation(stateStore, req.localId),
   );
 
   // === AutoPilot 调度（见 docs/arch/06-agent.md「AutoPilot」）===

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import type {
-  AgentRecommendation,
+  AgentMessage,
   AgentStep,
   Finding,
   IpcChannels,
@@ -148,15 +148,12 @@ export function ChatPane({
   // 当前 PR 命中的规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
   const [matchedRule, setMatchedRule] = useState<MatchedRule>(null);
   const [showRulePreview, setShowRulePreview] = useState(false);
-  // Agent 自动评审（微流程：describe→review→条件追问→总结）：运行态 + 收尾结果。
+  // Agent 运行态（自动评审微流程 / 自由规划对话）。
   const [agentRunning, setAgentRunning] = useState(false);
-  const [agentResult, setAgentResult] = useState<{
-    summary: string;
-    recommendation?: AgentRecommendation;
-  } | null>(null);
   const [agentSteps, setAgentSteps] = useState<AgentStep[]>([]);
-  // 触发本次会话的用户自然语言输入（对话即委派）：回显为右对齐气泡；at 用于在时间线中定位。
-  const [userRequest, setUserRequest] = useState<{ text: string; at: string } | null>(null);
+  // 多轮对话消息（用户输入 + Agent 回答），跨回合保留、由 main 落盘 conversation.json，
+  // 切回该 PR 恢复。用户消息含临时 optimistic 项（提交即回显），收尾后整体以落盘版重载对齐。
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
   // 当前展示中的 PR id（每渲染同步）：异步 Agent 任务 resolve 时据此判断是否仍停在发起 PR，
@@ -190,7 +187,7 @@ export function ChatPane({
       time: r.startedAt,
       run: r as ReviewRun | null,
       step: null as AgentStep | null,
-      user: null as string | null,
+      message: null as AgentMessage | null,
     }));
     const stepEntries = agentSteps
       .filter((s) => s.kind === 'judge')
@@ -199,15 +196,19 @@ export function ChatPane({
         time: s.at ?? '',
         run: null,
         step: s,
-        user: null as string | null,
+        message: null as AgentMessage | null,
       }));
-    const userEntries = userRequest
-      ? [{ key: `user-${userRequest.at}`, time: userRequest.at, run: null, step: null, user: userRequest.text }]
-      : [];
-    return [...runEntries, ...stepEntries, ...userEntries].sort((a, b) =>
+    const msgEntries = messages.map((m, i) => ({
+      key: `msg-${i}-${m.at}`,
+      time: m.at,
+      run: null,
+      step: null as AgentStep | null,
+      message: m,
+    }));
+    return [...runEntries, ...stepEntries, ...msgEntries].sort((a, b) =>
       a.time.localeCompare(b.time),
     );
-  }, [visibleRuns, agentSteps, userRequest]);
+  }, [visibleRuns, agentSteps, messages]);
 
   // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
   // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
@@ -222,30 +223,24 @@ export function ChatPane({
     setError(null);
     setMatchedRule(null);
     setAgentSteps([]);
-    setAgentResult(null);
-    setUserRequest(null);
+    setMessages([]);
     if (!prLocalId) return;
     let cancelled = false;
     void (async () => {
       try {
         // listRuns 默认返回 newest-first；这里只拉最新一页 (RUNS_PAGE_SIZE)。
-        // 同时拉已落盘的 Agent 会话：把「评审总结」卡片恢复到其发起 PR，跨切换不丢失。
-        const [list, rule, session] = await Promise.all([
+        // 同时拉已落盘的多轮对话：把会话消息恢复到其 PR，跨切换 / 重启不丢失。
+        const [list, rule, conversation] = await Promise.all([
           invoke('pragent:listRuns', { localId: prLocalId, limit: RUNS_PAGE_SIZE }),
           invoke('rules:matchForPr', { localId: prLocalId, tool: 'review' }),
-          invoke('agent:getSession', { localId: prLocalId }),
+          invoke('agent:getConversation', { localId: prLocalId }),
         ]);
         if (cancelled) return;
         // 反转为升序 (chat 习惯)，UI 直接读 runs 即可
         setRuns([...list].reverse());
         setHasMoreOlder(list.length === RUNS_PAGE_SIZE);
         setMatchedRule(rule);
-        if (session?.userRequest) {
-          setUserRequest({ text: session.userRequest, at: session.startedAt });
-        }
-        if (session?.summary) {
-          setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-        }
+        setMessages(conversation);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -362,25 +357,28 @@ export function ChatPane({
     }
   };
 
-  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经
-  // 既有运行队列展示在历史里；收尾总结 + 建议落 agentResult 单独呈现。
+  // 从 main 重载某 PR 的多轮对话（落盘版为准）；仅当仍停在该 PR 才落到当前视图，避免串台。
+  const reloadConversation = async (localId: string): Promise<void> => {
+    try {
+      const conversation = await invoke('agent:getConversation', { localId });
+      if (currentPrIdRef.current === localId) setMessages(conversation);
+    } catch {
+      /* 忽略：下次 PR 切换 effect 会重载 */
+    }
+  };
+
+  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经既有运行
+  // 队列展示在历史里；收尾评审作为一条 assistant 消息落入多轮对话，完成后重载对话呈现。
   const handleAgentReview = async (): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
     const startedId = pr.localId;
     setError(null);
-    setAgentResult(null);
     setAgentSteps([]);
-    setUserRequest(null); // 自动评审无文本输入，清掉上一轮对话气泡
     setAgentRunning(true);
     try {
       const session = await invoke('agent:run', { localId: startedId });
-      // 已切到别的 PR：结果归属其发起 PR（已落盘），不串台到当前会话；回到该 PR 时由切换 effect
-      // 从落盘会话恢复总结。
-      if (currentPrIdRef.current !== startedId) return;
-      if (session.summary) {
-        setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-      }
-      if (session.status === 'failed') {
+      await reloadConversation(startedId);
+      if (currentPrIdRef.current === startedId && session.status === 'failed') {
         setError(session.terminationReason ?? t('chatPane.agent.failed'));
       }
     } catch (e) {
@@ -392,24 +390,19 @@ export function ChatPane({
     }
   };
 
-  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。最终回答落 agentResult，步骤同样流式。
+  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。用户输入即时 optimistic 回显，
+  // 收尾后以落盘对话（含用户 + 助手消息）整体对齐。
   const handleAgentAsk = async (question: string): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
     const startedId = pr.localId;
     setError(null);
-    setAgentResult(null);
     setAgentSteps([]);
-    // 立即回显用户输入气泡（main 落盘 session.userRequest 后，切回该 PR 亦能恢复）。
-    setUserRequest({ text: question, at: new Date().toISOString() });
+    setMessages((prev) => [...prev, { role: 'user', content: question, at: new Date().toISOString() }]);
     setAgentRunning(true);
     try {
       const session = await invoke('agent:ask', { localId: startedId, question });
-      // 已切到别的 PR：不串台（回该 PR 时由切换 effect 从落盘会话恢复）。
-      if (currentPrIdRef.current !== startedId) return;
-      if (session.summary) {
-        setAgentResult({ summary: session.summary, recommendation: session.recommendation });
-      }
-      if (session.status === 'failed') {
+      await reloadConversation(startedId);
+      if (currentPrIdRef.current === startedId && session.status === 'failed') {
         setError(session.terminationReason ?? t('chatPane.agent.failed'));
       }
     } catch (e) {
@@ -432,9 +425,8 @@ export function ChatPane({
       setRuns([]);
       setHasMoreOlder(false);
       setError(null);
-      setAgentResult(null);
       setAgentSteps([]);
-      setUserRequest(null);
+      setMessages([]);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -639,7 +631,6 @@ export function ChatPane({
         {/* 使用提示仅在「全无会话内容」时显示：一旦有用户输入气泡 / run / 步骤 / 收尾结果，
             或 Agent 正在运行 / 有排队任务，即隐藏，避免输入后仍残留提示。 */}
         {timeline.length === 0 &&
-          !agentResult &&
           !agentRunning &&
           !hasMyActive &&
           myWaiting.length === 0 && (
@@ -675,10 +666,8 @@ export function ChatPane({
             />
           ) : entry.step ? (
             <AgentStepMarker key={entry.key} step={entry.step} />
-          ) : entry.user != null ? (
-            <div key={entry.key} className="chat-user-row">
-              <div className="chat-user-bubble">{entry.user}</div>
-            </div>
+          ) : entry.message ? (
+            <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
         )}
         {/* 正在跑（可并发多条）：每条一个进度条 + 实时 stdout 流，贴在历史末尾。
@@ -720,54 +709,6 @@ export function ChatPane({
             <span>{t('chatPane.agent.thinking')}</span>
           </div>
         )}
-        {/* 收尾结果两种形态：评审类（带 recommendation）→「评审总结」卡片 + 判定徽标；
-            自然对话（无 recommendation）→ 专属对话回复包装，不套用评审总结标题。 */}
-        {agentResult &&
-          (agentResult.recommendation ? (
-            <div className="chat-agent-summary" role="status">
-              <div className="chat-agent-summary-head">
-                <strong>{t('chatPane.agent.summaryTitle')}</strong>
-                <span
-                  className={`chat-agent-verdict verdict-${agentResult.recommendation.verdict}`}
-                >
-                  {t(VERDICT_LABEL_KEY[agentResult.recommendation.verdict])}
-                </span>
-              </div>
-              <div className="markdown chat-agent-summary-text">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                  components={mermaidComponents}
-                >
-                  {agentResult.summary}
-                </ReactMarkdown>
-              </div>
-              {agentResult.recommendation.reason && (
-                <div className="markdown muted chat-agent-summary-reason">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkBreaks]}
-                    rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                    components={mermaidComponents}
-                  >
-                    {agentResult.recommendation.reason}
-                  </ReactMarkdown>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="chat-agent-reply" role="status">
-              <ChatIcon size={16} />
-              <div className="markdown chat-agent-reply-body">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                  components={mermaidComponents}
-                >
-                  {agentResult.summary}
-                </ReactMarkdown>
-              </div>
-            </div>
-          ))}
         {error && (
           <div className="chat-error" role="alert">
             <strong>{t('chatPane.errorPrefix')}</strong>
@@ -1412,13 +1353,63 @@ function AskQuestion({ text }: { text: string }) {
     <div className="chat-user-msg" aria-label={t('chatPane.userQuestionAria')}>
       <QuestionIcon />
       <div className="markdown chat-user-msg-body">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkBreaks]}
-          rehypePlugins={REMOTE_REHYPE_PLUGINS}
-          components={mermaidComponents}
-        >
-          {text}
-        </ReactMarkdown>
+        <Md>{text}</Md>
+      </div>
+    </div>
+  );
+}
+
+/** chat 区统一的 markdown 渲染（与 finding 卡片同套 remark/rehype 配置）。 */
+function Md({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      rehypePlugins={REMOTE_REHYPE_PLUGINS}
+      components={mermaidComponents}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+/**
+ * 一条多轮对话消息的展示：用户 → 右对齐气泡；助手评审类（带 recommendation）→「评审总结」卡片 +
+ * 判定徽标；助手对话类（无 recommendation）→ 左对齐专属对话回复包装。
+ */
+function ConversationMessage({ message }: { message: AgentMessage }) {
+  const { t } = useTranslation();
+  if (message.role === 'user') {
+    return (
+      <div className="chat-user-row">
+        <div className="chat-user-bubble">{message.content}</div>
+      </div>
+    );
+  }
+  if (message.recommendation) {
+    return (
+      <div className="chat-agent-summary" role="status">
+        <div className="chat-agent-summary-head">
+          <strong>{t('chatPane.agent.summaryTitle')}</strong>
+          <span className={`chat-agent-verdict verdict-${message.recommendation.verdict}`}>
+            {t(VERDICT_LABEL_KEY[message.recommendation.verdict])}
+          </span>
+        </div>
+        <div className="markdown chat-agent-summary-text">
+          <Md>{message.content}</Md>
+        </div>
+        {message.recommendation.reason && (
+          <div className="markdown muted chat-agent-summary-reason">
+            <Md>{message.recommendation.reason}</Md>
+          </div>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="chat-agent-reply" role="status">
+      <ChatIcon size={16} />
+      <div className="markdown chat-agent-reply-body">
+        <Md>{message.content}</Md>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/StatusBar.tsx
@@ -9,6 +9,8 @@ import {
   PanelToggleIcon,
   PersonIcon,
   PullRequestIcon,
+  RobotIcon,
+  RobotOffIcon,
   SettingsIcon,
   SyncIcon,
 } from './icons';
@@ -100,7 +102,8 @@ export function StatusBar({
         title={autopilotEnabled ? t('statusBar.autopilotOnTitle') : t('statusBar.autopilotOffTitle')}
         aria-pressed={autopilotEnabled}
       >
-        {t('statusBar.autopilot')}
+        {autopilotEnabled ? <RobotIcon size={13} /> : <RobotOffIcon size={13} />}
+        <span>{t('statusBar.autopilot')}</span>
       </button>
       <LlmChip llm={llm} onSwitch={onSwitchActiveLlm} onOpenSettings={onOpenSettings} />
       {updateInfo?.hasUpdate && updateInfo.url && (

--- a/apps/desktop/src/renderer/src/components/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/icons.tsx
@@ -408,6 +408,57 @@ export function NeedsWorkIcon({ size = 14 }: IconProps) {
   );
 }
 
+/** 机器人头像：AutoPilot 启用态。天线 + 头框 + 双眼 + 两侧耳。 */
+export function RobotIcon({ size = 14 }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5.5" width="10" height="7.5" rx="1.6" />
+      <path d="M8 3.2v2.3" />
+      <circle cx="8" cy="2.6" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="6" cy="9" r="0.85" fill="currentColor" stroke="none" />
+      <circle cx="10" cy="9" r="0.85" fill="currentColor" stroke="none" />
+      <path d="M1.6 8.5v2" />
+      <path d="M14.4 8.5v2" />
+    </svg>
+  );
+}
+
+/** 机器人头像 + 斜杠：AutoPilot 关闭态。 */
+export function RobotOffIcon({ size = 14 }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5.5" width="10" height="7.5" rx="1.6" />
+      <path d="M8 3.2v2.3" />
+      <circle cx="8" cy="2.6" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="6" cy="9" r="0.85" fill="currentColor" stroke="none" />
+      <circle cx="10" cy="9" r="0.85" fill="currentColor" stroke="none" />
+      <path d="M1.6 8.5v2" />
+      <path d="M14.4 8.5v2" />
+      <path d="M2.3 2.3l11.4 11.4" />
+    </svg>
+  );
+}
+
 /** 双星火花（sparkles）：AI 自动评审动作。两颗四角星，区别于工具命令的 `/` 触发器 */
 export function AutoReviewIcon({ size = 14 }: IconProps) {
   return (

--- a/apps/desktop/src/renderer/src/styles/statusbar.scss
+++ b/apps/desktop/src/renderer/src/styles/statusbar.scss
@@ -41,9 +41,14 @@
   color: $text-on-accent;
 }
 
-// AutoPilot 开关 chip：默认中性（关），启用时绿底强调
+// AutoPilot 开关 chip：机器人图标（开）/ 斜杠机器人（关）+ 文案；默认中性，启用时绿底强调
 .statusbar-chip-autopilot {
   cursor: pointer;
+  gap: $space-2;
+
+  svg {
+    flex-shrink: 0;
+  }
 
   &.is-on {
     background: $color-success;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,6 +2,8 @@ export { AGENT_FILES, AGENT_RULES_SUBDIR, resolveAgentPaths } from './layout.js'
 export type { AgentContextKind } from './layout.js';
 export { loadAgentContext, loadAgentRules } from './load.js';
 export { scaffoldAgentDir } from './scaffold.js';
+export { appendAgentNotes } from './memory.js';
+export type { WritableAgentFile } from './memory.js';
 export { AGENT_TEMPLATES } from './templates.js';
 export type { AgentTemplate } from './templates.js';
 export type { AgentContext, AgentContextFiles, LoadAgentContextOptions } from './types.js';
@@ -14,6 +16,7 @@ export type {
 export { runReviewMicroflow, extractJson } from './orchestrator.js';
 export { runPlanningAgent } from './planner.js';
 export type {
+  AgentMemoryNotes,
   PlanningDeps,
   PlanningInput,
   PlanningResult,

--- a/packages/agent/src/memory.ts
+++ b/packages/agent/src/memory.ts
@@ -1,0 +1,56 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { resolveAgentPaths } from './layout.js';
+
+/** Agent 可写的上下文文件（SOUL.md 永远只读、绝不写）。 */
+export type WritableAgentFile = 'user' | 'memory' | 'agents';
+
+/** 各可写文件中由 Agent 自动维护的记录区标题（复用同一区，不重复建标题）。 */
+const NOTE_HEADING = '## Agent 记录';
+
+/**
+ * 把 Agent 主动记下的条目**追加**到指定可写上下文文件：
+ * - user   → USER.md：非隐私的用户信息（称呼 / 语言 / 评审习惯偏好）
+ * - memory → MEMORY.md：长期知识 / 仓库事实
+ * - agents → AGENTS.md：工作规范 / 评审约定（**仅追加**，不改写、不删除既有红线）
+ *
+ * 绝不写 SOUL.md。幂等去重：与现有正文重复（子串命中）的不再追加；返回实际新增条目。
+ * 隐私边界由提示词在生成 notes 时把关（见 planner Protocol）；此处只负责落盘与去重。
+ */
+export async function appendAgentNotes(
+  agentDir: string,
+  kind: WritableAgentFile,
+  notes: readonly string[],
+): Promise<string[]> {
+  const cleaned = notes.map((n) => n.trim()).filter(Boolean);
+  if (!agentDir || cleaned.length === 0) return [];
+
+  const file = resolveAgentPaths(agentDir)[kind];
+  let content = '';
+  try {
+    content = await readFile(file, 'utf8');
+  } catch {
+    content = '';
+  }
+
+  const haystack = content.toLowerCase();
+  const fresh: string[] = [];
+  const seen = new Set<string>();
+  for (const note of cleaned) {
+    const key = note.toLowerCase();
+    if (seen.has(key) || haystack.includes(key)) continue;
+    seen.add(key);
+    fresh.push(note);
+  }
+  if (fresh.length === 0) return [];
+
+  let next = content;
+  if (!next.includes(NOTE_HEADING)) {
+    next = `${next.trimEnd()}${next.trim() ? '\n\n' : ''}${NOTE_HEADING}\n`;
+  }
+  next = `${next.trimEnd()}\n${fresh.map((n) => `- ${n}`).join('\n')}\n`;
+
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, next, 'utf8');
+  return fresh;
+}

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -59,6 +59,8 @@ export interface PlanningResult {
   tokenUsage: TokenUsage;
   /** 收尾建议（仅评审类请求；非约束性）。供 UI 展示判定徽标，与 AutoPilot / 微流程一致。 */
   recommendation?: AgentRecommendation;
+  /** 本轮主动记下、待持久化到各可写文件的非隐私条目（去重后写盘由上层处理）。 */
+  memories: AgentMemoryNotes;
   terminationReason?: string;
 }
 
@@ -71,6 +73,38 @@ interface PlannerAction {
   final?: string;
   /** 评审类收尾的非约束性判定建议（verdict + 理由）；非评审请求省略。 */
   recommendation?: { verdict?: unknown; reason?: unknown };
+  /**
+   * 主动记下的**非隐私**条目，按目标可写文件分组：user→USER.md（用户信息），memory→MEMORY.md
+   * （长期知识），agents→AGENTS.md（工作规范，仅追加）。SOUL.md 永不写。
+   */
+  remember?: { user?: unknown; memory?: unknown; agents?: unknown };
+}
+
+/** Agent 主动记忆，按目标可写文件分组（键与 WritableAgentFile 对齐）。 */
+export interface AgentMemoryNotes {
+  user: string[];
+  memory: string[];
+  agents: string[];
+}
+
+function emptyMemoryNotes(): AgentMemoryNotes {
+  return { user: [], memory: [], agents: [] };
+}
+
+function toNoteList(raw: unknown): string[] {
+  if (typeof raw === 'string') return raw.trim() ? [raw.trim()] : [];
+  if (Array.isArray(raw)) {
+    return raw.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((x) => x.trim());
+  }
+  return [];
+}
+
+/** 把一个动作里的 remember 累加进 acc（容错；非对象忽略）。 */
+function accumulateRemember(value: PlannerAction['remember'], acc: AgentMemoryNotes): void {
+  if (!value || typeof value !== 'object') return;
+  acc.user.push(...toNoteList(value.user));
+  acc.memory.push(...toNoteList(value.memory));
+  acc.agents.push(...toNoteList(value.agents));
 }
 
 const VERDICTS: readonly AgentRecommendationVerdict[] = ['approve', 'needs_work', 'manual_review'];
@@ -143,6 +177,15 @@ const PROTOCOL = [
   '(must-fix / concerns as a bulleted list, empty-safe), "## 建议" (next steps); AND include a',
   '"recommendation" object: {"verdict": "approve"|"needs_work"|"manual_review", "reason": "<one line>"}.',
   'verdict is non-binding (no write action). Omit "recommendation" for non-review answers.',
+  'Memory: persist useful, stable, NON-private facts across sessions via a "remember" object on your',
+  'action, grouped by target file (short notes in the user\'s language):',
+  '  {"remember": {"user": ["称呼: Kyle"], "memory": ["repo uses g-<id> for gray apps"], "agents": ["..."]}}',
+  '- user   → the person you talk to: preferred 称呼, language, review/working habits & preferences.',
+  '- memory → durable knowledge about this project / repo (facts that help future reviews).',
+  '- agents → working norms / review conventions you should keep following (append-only).',
+  'NEVER record private or sensitive data: real identity beyond a chosen 称呼, email / phone / address,',
+  'employer-confidential specifics, secrets / tokens. When unsure whether something is private, do NOT',
+  'record it. Only remember when there is something genuinely worth persisting — omit otherwise.',
   'Conversation & scope:',
   '- Natural conversation is fine: greet, say who you are, ask a clarifying question — answer directly',
   '  in "final" without calling tools.',
@@ -160,6 +203,7 @@ export async function runPlanningAgent(
   const steps: AgentStep[] = [];
   let usage: TokenUsage = {};
   const history: string[] = [];
+  const memories = emptyMemoryNotes();
 
   const system = `${assembleSystemContext({
     context: input.context,
@@ -180,7 +224,7 @@ export async function runPlanningAgent(
 
   for (let i = 0; i < maxSteps; i++) {
     if (deps.signal?.aborted) {
-      return { steps, finalText: '', tokenUsage: usage, terminationReason: '用户暂停' };
+      return { steps, finalText: '', tokenUsage: usage, memories, terminationReason: '用户暂停' };
     }
 
     const user = [
@@ -197,6 +241,8 @@ export async function runPlanningAgent(
     const r = await deps.chat({ system, user });
     usage = addUsage(usage, r.usage);
     const action = extractJson<PlannerAction>(r.text);
+    // 累加本动作携带的记忆（任何动作都可附 remember）。
+    accumulateRemember(action?.remember, memories);
 
     const hasCalls = Boolean(action?.tool) || Boolean(action?.tools?.length);
 
@@ -204,7 +250,7 @@ export async function runPlanningAgent(
     if (!action || (!hasCalls && !action.final)) {
       const finalText = action?.final ?? r.text.trim();
       await record({ kind: 'plan', thought: action?.thought, result: finalText });
-      return { steps, finalText, tokenUsage: usage };
+      return { steps, finalText, tokenUsage: usage, memories };
     }
 
     if (action.final && !hasCalls) {
@@ -214,6 +260,7 @@ export async function runPlanningAgent(
         finalText: action.final,
         tokenUsage: usage,
         recommendation: parseRecommendation(action.recommendation),
+        memories,
       };
     }
 
@@ -254,5 +301,5 @@ export async function runPlanningAgent(
     }
   }
 
-  return { steps, finalText: '', tokenUsage: usage, terminationReason: '步数上限中止' };
+  return { steps, finalText: '', tokenUsage: usage, memories, terminationReason: '步数上限中止' };
 }

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -1,5 +1,6 @@
 import type { Rule } from '@meebox/rules';
 import type {
+  AgentMessage,
   AgentRecommendation,
   AgentRecommendationVerdict,
   AgentStep,
@@ -43,6 +44,11 @@ export interface PlanningInput {
   language?: string;
   /** 用户的自然语言请求。 */
   userRequest: string;
+  /**
+   * 既往多轮对话（用户 / 助手消息，按时间升序，不含本轮请求）。注入规划 LLM 的上下文，使
+   * Agent 跨轮记住此前交流；**绝不**透传给 pr-agent 工具（工具只看 PR + 当轮问题）。
+   */
+  history?: AgentMessage[];
   /** 步数上限（默认 8）。 */
   maxSteps?: number;
 }
@@ -100,6 +106,29 @@ function clamp(s: string, max: number): string {
 /** 一次并行最多分发的工具数：多选时截断，防止一轮打出过多 pr-agent run。 */
 const MAX_PARALLEL_TOOLS = 3;
 
+/**
+ * 注入规划上下文的历史对话预算：单条字符上限 + 总字符预算（从最新往回累计、超预算即裁剪更早的）。
+ * 约定会话上下文不超过 LLM 上下文窗口的一半——以字符近似 token 做保守封顶：64k 字符 ≈ 16~40k token
+ * （视中英文占比），对应约 32k~64k token 半窗的目标量级。后续可按模型实际窗口精确估算 token，并引入
+ * 老消息压缩（摘要）替代直接裁剪。
+ */
+const HISTORY_MESSAGE_MAX = 2000;
+const HISTORY_BUDGET_CHARS = 64000;
+
+/** 取最近若干轮、各自限长，并按总预算从新到旧裁剪（丢弃超预算的更早消息），返回时间升序文本。 */
+function buildConversationContext(history: readonly AgentMessage[]): string {
+  const lines: string[] = [];
+  let budget = HISTORY_BUDGET_CHARS;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const m = history[i]!;
+    const line = `${m.role === 'user' ? 'User' : 'Assistant'}: ${clamp(m.content, HISTORY_MESSAGE_MAX)}`;
+    if (line.length + 1 > budget) break; // 预算耗尽：更早的对话整体裁掉
+    budget -= line.length + 1;
+    lines.push(line);
+  }
+  return lines.reverse().join('\n');
+}
+
 const PROTOCOL = [
   'Each turn, reply with JSON ONLY for the next action:',
   '- One tool:   {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
@@ -145,12 +174,19 @@ export async function runPlanningAgent(
     await deps.onStep?.(step);
   };
 
+  // 既往多轮对话注入规划上下文（按预算裁剪），让 Agent 跨轮记住交流；仅供规划 LLM 参考，
+  // 绝不透传给 pr-agent 工具。
+  const convo = buildConversationContext(input.history ?? []);
+
   for (let i = 0; i < maxSteps; i++) {
     if (deps.signal?.aborted) {
       return { steps, finalText: '', tokenUsage: usage, terminationReason: '用户暂停' };
     }
 
     const user = [
+      convo
+        ? `Conversation so far (your context only — NEVER pass any of it to tools):\n${convo}\n`
+        : '',
       `User request: ${input.userRequest}`,
       history.length ? `\nProgress so far:\n${history.join('\n')}` : '',
       '\nReply with the next JSON action.',

--- a/packages/agent/tests/memory.test.ts
+++ b/packages/agent/tests/memory.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { appendAgentNotes } from '../src/memory.js';
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), 'meebox-agent-mem-'));
+}
+
+describe('appendAgentNotes', () => {
+  it('appends notes to USER.md under a managed heading and returns the added items', async () => {
+    const dir = await tempDir();
+    const added = await appendAgentNotes(dir, 'user', ['称呼: Kyle', '偏好简体中文']);
+    expect(added).toEqual(['称呼: Kyle', '偏好简体中文']);
+    const content = await readFile(path.join(dir, 'USER.md'), 'utf8');
+    expect(content).toContain('## Agent 记录');
+    expect(content).toContain('- 称呼: Kyle');
+    expect(content).toContain('- 偏好简体中文');
+  });
+
+  it('dedups against existing content and within the batch (no duplicate writes)', async () => {
+    const dir = await tempDir();
+    await appendAgentNotes(dir, 'memory', ['repo uses g- prefix']);
+    const added = await appendAgentNotes(dir, 'memory', ['repo uses g- prefix', 'new fact', 'new fact']);
+    expect(added).toEqual(['new fact']); // 已存在的 / 批内重复的被跳过
+    const content = await readFile(path.join(dir, 'MEMORY.md'), 'utf8');
+    expect(content.match(/repo uses g- prefix/g)).toHaveLength(1);
+    expect(content.match(/new fact/g)).toHaveLength(1);
+  });
+
+  it('writes to the file matching the kind (agents → AGENTS.md, append-only)', async () => {
+    const dir = await tempDir();
+    await appendAgentNotes(dir, 'agents', ['always verify tenant mapping']);
+    const content = await readFile(path.join(dir, 'AGENTS.md'), 'utf8');
+    expect(content).toContain('- always verify tenant mapping');
+  });
+
+  it('returns empty for blank input without writing', async () => {
+    const dir = await tempDir();
+    const added = await appendAgentNotes(dir, 'user', ['', '   ']);
+    expect(added).toEqual([]);
+  });
+});

--- a/packages/agent/tests/planner.test.ts
+++ b/packages/agent/tests/planner.test.ts
@@ -137,6 +137,22 @@ describe('runPlanningAgent', () => {
     expect(r.steps).toHaveLength(0);
   });
 
+  it('accumulates remember notes by target file across actions', async () => {
+    const { deps } = makeDeps([
+      '{"tool":"/review","remember":{"user":["称呼: Kyle"]}}',
+      '{"final":"done","remember":{"memory":["repo uses g- prefix"],"agents":["check tenant mapping"]}}',
+    ]);
+    const r = await runPlanningAgent(deps, {
+      context,
+      pr,
+      toolCatalog: catalog,
+      userRequest: 'x',
+    });
+    expect(r.memories.user).toEqual(['称呼: Kyle']);
+    expect(r.memories.memory).toEqual(['repo uses g- prefix']);
+    expect(r.memories.agents).toEqual(['check tenant mapping']);
+  });
+
   it('returns a structured recommendation when the review close includes one', async () => {
     const { deps } = makeDeps([
       '{"final":"## 摘要\\n...","recommendation":{"verdict":"needs_work","reason":"fix log key"}}',

--- a/packages/poller/src/agent-session.ts
+++ b/packages/poller/src/agent-session.ts
@@ -162,6 +162,18 @@ export async function getAgentConversation(
   return file?.messages ?? [];
 }
 
+/** 整体重写某 PR 的多轮对话（用于压缩 / 摘要替换旧消息）。 */
+export async function writeAgentConversation(
+  stateStore: StateStore,
+  prLocalId: string,
+  messages: AgentMessage[],
+): Promise<void> {
+  await stateStore.write<AgentConversationFile>(conversationKey(prLocalId), {
+    schema_version: 1,
+    messages,
+  });
+}
+
 /** 追加一条对话消息（用户 / 助手），返回追加后的完整消息列表。`at` 缺省打当前时间。 */
 export async function appendAgentMessage(
   stateStore: StateStore,

--- a/packages/poller/src/agent-session.ts
+++ b/packages/poller/src/agent-session.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentConversationFile,
+  AgentMessage,
   AgentSession,
   AgentSessionFile,
   AgentSessionStatus,
@@ -20,6 +22,9 @@ function sessionKey(prLocalId: string): string {
 }
 function transcriptKey(prLocalId: string): string {
   return `prs/${prLocalId}/agent/transcript`;
+}
+function conversationKey(prLocalId: string): string {
+  return `prs/${prLocalId}/agent/conversation`;
 }
 
 export interface StartAgentSessionInput {
@@ -135,11 +140,40 @@ export async function appendAgentStep(
   return next;
 }
 
-/** 清掉某 PR 的会话 + transcript（删 `prs/<localId>/agent/*`）。 */
+/** 清掉某 PR 的会话 + transcript + 多轮对话（删 `prs/<localId>/agent/*`）。 */
 export async function clearAgentSession(
   stateStore: StateStore,
   prLocalId: string,
 ): Promise<void> {
   await stateStore.delete(sessionKey(prLocalId));
   await stateStore.delete(transcriptKey(prLocalId));
+  await stateStore.delete(conversationKey(prLocalId));
+}
+
+/**
+ * 多轮对话日志（跨回合保留，独立于 per-turn 的 session / transcript 生命周期）：读取本 PR
+ * 全部消息（用户输入 + Agent 收尾回答）。无则空数组。
+ */
+export async function getAgentConversation(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<AgentMessage[]> {
+  const file = await stateStore.read<AgentConversationFile>(conversationKey(prLocalId));
+  return file?.messages ?? [];
+}
+
+/** 追加一条对话消息（用户 / 助手），返回追加后的完整消息列表。`at` 缺省打当前时间。 */
+export async function appendAgentMessage(
+  stateStore: StateStore,
+  prLocalId: string,
+  message: Omit<AgentMessage, 'at'> & { at?: string },
+  now: () => Date = () => new Date(),
+): Promise<AgentMessage[]> {
+  const messages = await getAgentConversation(stateStore, prLocalId);
+  messages.push({ ...message, at: message.at ?? now().toISOString() });
+  await stateStore.write<AgentConversationFile>(conversationKey(prLocalId), {
+    schema_version: 1,
+    messages,
+  });
+  return messages;
 }

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -54,6 +54,28 @@ export interface AgentRecommendation {
   reason: string;
 }
 
+export type AgentMessageRole = 'user' | 'assistant';
+
+/**
+ * 一条对话消息（回合级，区别于回合内的 AgentStep）。多轮对话的持久化单元：用户输入与 Agent
+ * 收尾回答各一条，按时间追加。Agent 自身上下文（规划）会读取历史消息，但**绝不**注入 pr-agent
+ * 工具调用（工具只看 PR + 当轮问题）。
+ */
+export interface AgentMessage {
+  role: AgentMessageRole;
+  content: string;
+  /** assistant 评审类回合的非约束性判定；对话 / 用户消息不填。 */
+  recommendation?: AgentRecommendation;
+  /** 产生时间（ISO），用于时间线排序。 */
+  at: string;
+}
+
+/** 持久化包装：`prs/<localId>/agent/conversation.json`（多轮消息流式追加，跨回合保留）。 */
+export interface AgentConversationFile {
+  schema_version: 1;
+  messages: AgentMessage[];
+}
+
 /** 每个 PR 一份、由子 agent 所有的会话记录（见数据契约）。 */
 export interface AgentSession {
   id: string;

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -1,4 +1,9 @@
-import type { AgentRecommendationVerdict, AgentSession, AgentStep } from './agent-contract.js';
+import type {
+  AgentMessage,
+  AgentRecommendationVerdict,
+  AgentSession,
+  AgentStep,
+} from './agent-contract.js';
 import type { AppInfo, AppPaths, UpdateCheckResult } from './app-info.js';
 import type { Config } from './config.js';
 import type { SupportedLanguage } from './language.js';
@@ -422,6 +427,11 @@ export interface IpcChannels {
    * 供 UI 打开 PR 时恢复「评审总结」卡片——总结归属其发起 PR、跨 PR 切换不丢失、不串台。
    */
   'agent:getSession': { request: { localId: string }; response: AgentSession | null };
+  /**
+   * 读取指定 PR 的多轮对话消息（用户输入 + Agent 回答，按时间升序）；无则空数组。
+   * UI 据此渲染多轮会话；跨 PR 切换 / 重启后恢复。
+   */
+  'agent:getConversation': { request: { localId: string }; response: AgentMessage[] };
   /**
    * 批量读 AutoPilot 台账：返回各 PR 已自动评审的 recommendation（仅 decision=review 且有
    * 建议者）。PR 列表据此显示徽标，无需逐个加载会话。


### PR DESCRIPTION
## 背景

承接多轮对话（#44）的三项后续：让 Agent 能主动维护记忆/规则、按长度压缩会话记忆，并优化 AutoPilot 状态栏图标。

> 基于 #44（多轮对话）分支，待 #44 合并后本 PR diff 自动收敛为下列三项。

## 变更

### 1. 主动维护记忆 / 规则（非隐私）
- 协议新增 `remember` 动作，按目标可写文件分组：`user`→USER.md（称呼/语言/评审习惯）、`memory`→MEMORY.md（仓库长期事实）、`agents`→AGENTS.md（工作规范，仅追加）。**SOUL.md 永不写**。
- 明确隐私红线：真实身份（称呼除外）/ 邮箱电话地址 / 雇主机密 / 密钥 token 一律不记，存疑不记。
- `appendAgentNotes` 落盘到各文件「Agent 记录」区，幂等去重、append-only（不改写既有红线）。下一轮 `loadAgentContext` 现读即生效（跨会话记忆）。

### 2. 会话记忆压缩
- 存储超阈值（80000 字符）→ 把较早消息经 LLM 摘要成一条「早期对话摘要」digest、仅保留最近 6 条原文整体重写；digest 用最早时间戳排最前。best-effort，失败/未超阈值原样保留；读时仍有预算裁剪（64000 字符）兜底。

### 3. AutoPilot 状态栏机器人图标
- 启用 → 机器人图标；关闭 → 机器人 + 斜杠。保留文案与绿底强调。新增 RobotIcon / RobotOffIcon。

## 验证
- `lint` / `typecheck` / `test`（agent 41 通过，含 remember 累加 / appendAgentNotes 写入去重）/ `build` 全通过。