### PR TITLE
feat(desktop): 任务队列展示仓库/PR号、运行中可取消 + 评审总结排版与配色

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1219,6 +1219,8 @@ export function registerIpcHandlers({
         info: {
           runId,
           prLocalId: pr.localId,
+          repoSlug: pr.repo.repoSlug,
+          prNumber: pr.remoteId,
           tool,
           question: tool === 'ask' ? question : undefined,
           enqueuedAt: new Date().toISOString(),

--- a/apps/desktop/src/renderer/src/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/StatusBar.tsx
@@ -341,9 +341,20 @@ function QueuePopover({
               title={t('statusBar.jumpToPr')}
             >
               <span className="statusbar-queue-tool">/{a.tool}</span>
-              <code className="statusbar-queue-pr">{a.prLocalId}</code>
+              <span className="statusbar-queue-pr">
+                {a.repoSlug} <span className="statusbar-queue-prnum">#{a.prNumber}</span>
+              </span>
             </button>
             <span className="muted statusbar-queue-state">{t('statusBar.running')}</span>
+            <button
+              type="button"
+              className="statusbar-queue-cancel"
+              onClick={() => onCancel(a.runId)}
+              title={t('statusBar.stopRunning')}
+              aria-label={t('common.cancel')}
+            >
+              ×
+            </button>
           </li>
         ))}
         {waiting.map((q) => (
@@ -356,7 +367,9 @@ function QueuePopover({
               title={t('statusBar.jumpToPr')}
             >
               <span className="statusbar-queue-tool">/{q.tool}</span>
-              <code className="statusbar-queue-pr">{q.prLocalId}</code>
+              <span className="statusbar-queue-pr">
+                {q.repoSlug} <span className="statusbar-queue-prnum">#{q.prNumber}</span>
+              </span>
             </button>
             <span className="muted statusbar-queue-state">{t('statusBar.queued')}</span>
             <button

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -703,6 +703,7 @@
     "secondsAgo_one": "vor {{count}} Sekunde",
     "secondsAgo_other": "vor {{count}} Sekunden",
     "settings": "Einstellungen",
+    "stopRunning": "Laufende Aufgabe stoppen",
     "syncing": "Synchronisieren",
     "unnamed": "(unbenannt)",
     "updateAvailableTitle": "Neue Version v{{latest}} verfügbar (aktuell v{{current}}) · klicken zum Herunterladen",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -703,6 +703,7 @@
     "secondsAgo_one": "{{count}} second ago",
     "secondsAgo_other": "{{count}} seconds ago",
     "settings": "Settings",
+    "stopRunning": "Stop the running task",
     "syncing": "Syncing",
     "unnamed": "(unnamed)",
     "updateAvailableTitle": "New version v{{latest}} available (current v{{current}}) · click to download",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -685,6 +685,7 @@
     "running": "実行中",
     "secondsAgo_other": "{{count}} 秒前",
     "settings": "設定",
+    "stopRunning": "実行中のタスクを停止",
     "syncing": "同期中",
     "unnamed": "(名称なし)",
     "updateAvailableTitle": "新しいバージョン v{{latest}} が利用可能です（現在 v{{current}}）· クリックでダウンロード",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -685,6 +685,7 @@
     "running": "运行中",
     "secondsAgo_other": "{{count}} 秒前",
     "settings": "设置",
+    "stopRunning": "停止运行中的任务",
     "syncing": "同步中",
     "unnamed": "(未命名)",
     "updateAvailableTitle": "发现新版本 v{{latest}}（当前 v{{current}}）· 点击前往下载",

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -145,6 +145,17 @@
   justify-content: space-between;
   gap: $space-3;
   margin-bottom: $space-3;
+
+  // 标题做成实色 chip（与「代码反馈 / 工作量」等卡片标签同款），右侧判定为描边 chip，成对。
+  strong {
+    flex-shrink: 0;
+    padding: 2px $space-3;
+    border-radius: $radius-sm;
+    background: $color-accent;
+    color: $text-on-accent;
+    font-size: $fs-sm;
+    font-weight: 600;
+  }
 }
 // 判定徽标：描边色 chip（边框 + 文字同色，随判定变色），比纯文字更醒目、与卡片标题成对。
 .chat-agent-verdict {

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -146,7 +146,12 @@
   gap: $space-3;
   margin-bottom: $space-3;
 }
+// 判定徽标：描边色 chip（边框 + 文字同色，随判定变色），比纯文字更醒目、与卡片标题成对。
 .chat-agent-verdict {
+  flex-shrink: 0;
+  padding: 1px $space-2;
+  border-radius: $radius-sm;
+  border: 1px solid currentColor;
   font-size: $fs-sm;
   font-weight: 600;
   white-space: nowrap;
@@ -165,6 +170,21 @@
   margin: 0 0 $space-3;
   font-size: $fs-md;
   color: $text-body;
+}
+// 评审总结 / 对话回复内的 markdown 章节标题（## 摘要 等）压到不超过卡片标题（评审总结）字号，
+// 避免章节标题比卡片标题还大、层级倒置。组合类选择器提升特异性以盖过 markdown.scss 的默认 h 字号。
+.markdown.chat-agent-summary-text,
+.markdown.chat-agent-reply-body {
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-size: $fs-md;
+    margin: $space-3 0 $space-1;
+  }
+  > :first-child {
+    margin-top: 0;
+  }
 }
 // 建议理由：markdown 渲染但保持次要灰（覆盖 .markdown 默认正文色）。
 .chat-agent-summary-reason {

--- a/apps/desktop/src/renderer/src/styles/statusbar.scss
+++ b/apps/desktop/src/renderer/src/styles/statusbar.scss
@@ -41,7 +41,7 @@
   color: $text-on-accent;
 }
 
-// AutoPilot 开关 chip：机器人图标（开）/ 斜杠机器人（关）+ 文案；默认中性，启用时绿底强调
+// AutoPilot 开关 chip：机器人图标（开）/ 斜杠机器人（关）+ 文案；默认中性，启用时蓝底强调
 .statusbar-chip-autopilot {
   cursor: pointer;
   gap: $space-2;
@@ -51,7 +51,7 @@
   }
 
   &.is-on {
-    background: $color-success;
+    background: $color-accent;
     color: $text-on-accent;
   }
 }
@@ -266,7 +266,6 @@ button.statusbar-pragent-chip {
   flex-shrink: 0;
 }
 .statusbar-queue-pr {
-  font-family: $font-mono;
   font-size: $fs-xs;
   color: $text-muted;
   background: transparent;
@@ -275,6 +274,9 @@ button.statusbar-pragent-chip {
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+.statusbar-queue-prnum {
+  font-family: $font-mono;
 }
 .statusbar-queue-state {
   font-size: $fs-xs;

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -95,6 +95,9 @@ export interface PragentRunProgressEvent {
 export interface PragentRunInfo {
   runId: string;
   prLocalId: string;
+  /** 仓库 slug 与 PR 号（队列展示用，避免只显示 localId hash）。 */
+  repoSlug: string;
+  prNumber: string;
   tool: ReviewRunTool;
   question?: string;
   /** 入队时间，ISO */


### PR DESCRIPTION
## 变更

依据交互反馈的一组 UI 打磨：

### 任务队列弹窗
- 每条任务显示「仓库 slug + #PR号」替代 localId hash（`PragentRunInfo` 增 `repoSlug` / `prNumber`，主进程入队时填充）。
- **运行中**任务也可取消：列表项右侧加 ×（走 `pragent:cancel` 中止），不再只能取消排队中的。

### 状态栏 AutoPilot
- 启用态由绿底改为蓝底（`$color-accent`），与「成功 / 已通过」的绿色语义区分。

### 评审总结卡片
- 卡片内 markdown 章节标题（`## 摘要` / `关键发现` / `建议`）字号压到 `$fs-md`，不再比卡片标题「评审总结」还大、层级倒置。
- 判定（建议通过 / 修改 / 人工复核）由纯文字改为**描边色 chip**（边框 + 文字同色随判定变色）。

## 验证
- `lint` / `typecheck` / `test` / `build` 全通过。