### PR TITLE
fix(agent): 运行态按 PR 归属（不串会话）+ 思考中计时；fix(logger): 控制台代码页探测

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,11 @@
 - `openai-compatible` 经实测标记为**已验证**。
 
 ### Fixed
-- 修复 Windows 控制台中文日志显示为乱码：启动期将输出代码页对齐为 UTF-8（cp936/GBK → 65001）。
+- 修复 Windows 控制台中文日志仍显示为乱码：① dev 下 electron-vite 把 main 的 stdout 接成管道
+  （`isTTY=false`）原会跳过转码，UTF-8 字节被 CJK 控制台按 GBK/SJIS 渲染——改为 `pretty` 模式不卡
+  `isTTY`（与上色路径一致）；② 启动期探测真实活动代码页（`chcp`）替代按 locale 猜测：UTF-8 控制台
+  （65001）直出 UTF-8，CJK 代码页（cp936/cp932/cp949/cp950）转码到对应页，避免用户已 `chcp 65001`
+  切到 UTF-8 时反而把正确输出转乱。
 
 ## [0.4.0] - 2026-06-14
 

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -148,8 +148,9 @@ export function ChatPane({
   // 当前 PR 命中的规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
   const [matchedRule, setMatchedRule] = useState<MatchedRule>(null);
   const [showRulePreview, setShowRulePreview] = useState(false);
-  // Agent 运行态（自动评审微流程 / 自由规划对话）。
-  const [agentRunning, setAgentRunning] = useState(false);
+  // Agent 运行态（自动评审微流程 / 自由规划对话）：记录**哪个 PR** 在跑 + 起跑时刻（计时用）。
+  // 编排层全局单并发（一次只跑一个），但运行态 / 思考中指示按发起 PR 归属，不串到其它 PR 会话。
+  const [runningPr, setRunningPr] = useState<{ id: string; since: number } | null>(null);
   const [agentSteps, setAgentSteps] = useState<AgentStep[]>([]);
   // 多轮对话消息（用户输入 + Agent 回答），跨回合保留、由 main 落盘 conversation.json，
   // 切回该 PR 恢复。用户消息含临时 optimistic 项（提交即回显），收尾后整体以落盘版重载对齐。
@@ -216,6 +217,9 @@ export function ChatPane({
   // 用户输入 / 规则提示等组件状态被清空。localId 是稳定字符串，同 PR 刷新不触发。
   const prLocalId = pr?.localId;
   currentPrIdRef.current = prLocalId;
+  // 全局单并发：任一 PR 在跑即占用（禁止再发起）；仅「跑在当前 PR」才在本会话显示运行态 / 思考中。
+  const agentBusy = runningPr !== null;
+  const agentRunningHere = runningPr?.id === prLocalId && prLocalId !== undefined;
   useEffect(() => {
     setRuns([]);
     setHasMoreOlder(false);
@@ -370,11 +374,11 @@ export function ChatPane({
   // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经既有运行
   // 队列展示在历史里；收尾评审作为一条 assistant 消息落入多轮对话，完成后重载对话呈现。
   const handleAgentReview = async (): Promise<void> => {
-    if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
+    if (!pr || !prAgent.available || !llmConfigured || agentBusy) return;
     const startedId = pr.localId;
     setError(null);
     setAgentSteps([]);
-    setAgentRunning(true);
+    setRunningPr({ id: startedId, since: Date.now() });
     try {
       const session = await invoke('agent:run', { localId: startedId });
       await reloadConversation(startedId);
@@ -386,19 +390,19 @@ export function ChatPane({
         setError(e instanceof Error ? e.message : String(e));
       }
     } finally {
-      setAgentRunning(false);
+      setRunningPr((cur) => (cur?.id === startedId ? null : cur));
     }
   };
 
   // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。用户输入即时 optimistic 回显，
   // 收尾后以落盘对话（含用户 + 助手消息）整体对齐。
   const handleAgentAsk = async (question: string): Promise<void> => {
-    if (!pr || !prAgent.available || !llmConfigured || agentRunning) return;
+    if (!pr || !prAgent.available || !llmConfigured || agentBusy) return;
     const startedId = pr.localId;
     setError(null);
     setAgentSteps([]);
     setMessages((prev) => [...prev, { role: 'user', content: question, at: new Date().toISOString() }]);
-    setAgentRunning(true);
+    setRunningPr({ id: startedId, since: Date.now() });
     try {
       const session = await invoke('agent:ask', { localId: startedId, question });
       await reloadConversation(startedId);
@@ -410,7 +414,7 @@ export function ChatPane({
         setError(e instanceof Error ? e.message : String(e));
       }
     } finally {
-      setAgentRunning(false);
+      setRunningPr((cur) => (cur?.id === startedId ? null : cur));
     }
   };
 
@@ -444,7 +448,7 @@ export function ChatPane({
   // 并中止 Agent 编排（abort，阻止其在子任务取消后继续后续步骤）。
   const handleStopAll = (): void => {
     for (const r of myActiveRuns) void handleCancel(r.runId);
-    if (agentRunning && prLocalId) void invoke('agent:stop', { localId: prLocalId });
+    if (agentRunningHere && prLocalId) void invoke('agent:stop', { localId: prLocalId });
   };
   const handleRetry = (run: ReviewRun): void => {
     void handleRun(run.tool, run.question);
@@ -631,7 +635,7 @@ export function ChatPane({
         {/* 使用提示仅在「全无会话内容」时显示：一旦有用户输入气泡 / run / 步骤 / 收尾结果，
             或 Agent 正在运行 / 有排队任务，即隐藏，避免输入后仍残留提示。 */}
         {timeline.length === 0 &&
-          !agentRunning &&
+          !agentRunningHere &&
           !hasMyActive &&
           myWaiting.length === 0 && (
             <ChatEmpty
@@ -702,12 +706,10 @@ export function ChatPane({
           </div>
         )}
         {/* Agent 自身 LLM 调用（规划 / 判读 / 收尾）无对应 pragent run，此时队列里看不到进度 →
-            补一条「思考中」指示，避免运行期界面看似停滞。子任务运行时由 RunningView 负责进度。 */}
-        {agentRunning && !hasMyActive && myWaiting.length === 0 && (
-          <div className="chat-agent-thinking" role="status">
-            <Spinner />
-            <span>{t('chatPane.agent.thinking')}</span>
-          </div>
+            补一条「思考中」指示（带动态计时），避免运行期界面看似停滞。仅当 Agent 跑在**当前 PR**
+            才显示，不串到其它会话；子任务运行时由 RunningView 负责进度。 */}
+        {agentRunningHere && runningPr && !hasMyActive && myWaiting.length === 0 && (
+          <ThinkingIndicator since={runningPr.since} />
         )}
         {error && (
           <div className="chat-error" role="alert">
@@ -728,8 +730,10 @@ export function ChatPane({
         onAgentAsk={(q) => void handleAgentAsk(q)}
         onCancel={hasMyActive ? handleStopAll : undefined}
         onSetReviewStatus={onSetReviewStatus}
-        // 一键自动评审：图标按钮置于 `/` 命令触发器右侧
-        agentRunning={agentRunning}
+        // 一键自动评审：图标按钮置于 `/` 命令触发器右侧。busy=全局占用（禁用触发）、
+        // runningHere=跑在当前 PR（高亮 / 运行中文案）。
+        agentBusy={agentBusy}
+        agentRunningHere={agentRunningHere}
         onAgentReview={() => void handleAgentReview()}
       />
 
@@ -825,8 +829,10 @@ interface ChatInputBarProps {
   onCancel?: () => void;
   /** /approve /needswork 命令触发的 review 决断，跟 PR header 按钮共用 prs:setLocalStatus */
   onSetReviewStatus?: (status: LocalPrStatus) => void;
-  /** 自动评审是否进行中（决定图标按钮禁用 + 是否显示停止）。 */
-  agentRunning: boolean;
+  /** Agent 是否全局占用（任一 PR 在跑）：禁用本 PR 的触发（单并发）。 */
+  agentBusy: boolean;
+  /** Agent 是否跑在当前 PR：决定图标按钮高亮 + 运行中文案。 */
+  agentRunningHere: boolean;
   /** 触发一键自动评审微流程（describe→review→条件追问→总结）。 */
   onAgentReview: () => void;
 }
@@ -912,7 +918,8 @@ function ChatInputBar({
   onAgentAsk,
   onCancel,
   onSetReviewStatus,
-  agentRunning,
+  agentBusy,
+  agentRunningHere,
   onAgentReview,
 }: ChatInputBarProps) {
   const { t } = useTranslation();
@@ -1285,11 +1292,11 @@ function ChatInputBar({
         {pr && prAgent.available && (
           <button
             type="button"
-            className={`chat-cmd-trigger chat-agent-review-trigger${agentRunning ? ' active' : ''}`}
+            className={`chat-cmd-trigger chat-agent-review-trigger${agentRunningHere ? ' active' : ''}`}
             onClick={onAgentReview}
-            disabled={!llmConfigured || agentRunning}
+            disabled={!llmConfigured || agentBusy}
             title={
-              agentRunning
+              agentRunningHere
                 ? t('chatPane.agent.autoReviewRunning')
                 : t('chatPane.agent.autoReview')
             }
@@ -1342,6 +1349,24 @@ function AgentStepMarker({ step }: { step: AgentStep }) {
     <div className="chat-agent-step-marker" role="status">
       {step.result && <span className="chat-agent-step-result">{step.result}</span>}
       {step.thought && <span className="chat-agent-step-thought muted">{step.thought}</span>}
+    </div>
+  );
+}
+
+/** 「思考中」指示：spinner + 文案 + 动态计时（1s 粒度，跟 RunningView 同款 elapsed）。 */
+function ThinkingIndicator({ since }: { since: number }) {
+  const { t } = useTranslation();
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    setElapsedMs(Date.now() - since);
+    const id = setInterval(() => setElapsedMs(Date.now() - since), 1000);
+    return () => clearInterval(id);
+  }, [since]);
+  return (
+    <div className="chat-agent-thinking" role="status">
+      <Spinner />
+      <span>{t('chatPane.agent.thinking')}</span>
+      <span className="chat-agent-thinking-elapsed">{formatElapsed(elapsedMs)}</span>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -231,6 +231,10 @@
   color: $text-muted;
   font-size: $fs-sm;
 }
+.chat-agent-thinking-elapsed {
+  font-family: $font-mono;
+  font-variant-numeric: tabular-nums;
+}
 
 // Agent 自然对话回复：左对齐、带 Agent 图标的轻量包装，区别于「评审总结」卡片（无判定 / 无标题）。
 .chat-agent-reply {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,7 @@
+import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { Writable } from 'node:stream';
+import { promisify } from 'node:util';
 import iconv from 'iconv-lite';
 import pino, { type Logger, type StreamEntry } from 'pino';
 import pinoRoll from 'pino-roll';
@@ -49,7 +51,9 @@ export async function createLogger(opts: LoggerOptions): Promise<Logger> {
 
   const streams: StreamEntry[] = [{ level, stream: fileStream }];
   if (alsoStdout) {
-    streams.push({ level, stream: makeConsoleStream(pretty) });
+    // 控制台代码页只需在 stdout 开启时探一次（async，故在此 await）。
+    const codePage = await detectWindowsConsoleCodePage();
+    streams.push({ level, stream: makeConsoleStream(pretty, codePage) });
   }
   return pino({ level }, pino.multistream(streams));
 }
@@ -60,8 +64,8 @@ export async function createLogger(opts: LoggerOptions): Promise<Logger> {
  * `<ISO8601> LEVEL msg k=v k=v`（Go 风格 kv，对象/堆栈走 JSON.stringify 把换行转义掉，
  * 保证一条日志一物理行，不再被 pino-pretty 的多行对象/堆栈渲染撑断）。
  */
-function makeConsoleStream(pretty: boolean): Writable {
-  const encoding = pickWindowsConsoleEncoding();
+function makeConsoleStream(pretty: boolean, codePage: number | null): Writable {
+  const encoding = pickWindowsConsoleEncoding(pretty, codePage);
   const raw: Writable = encoding ? makeTranscodingWritable(encoding) : process.stdout;
   if (!pretty) return raw;
   // pretty 即 dev 人读模式：默认上色。不卡 isTTY——electron-vite dev 下 main 的 stdout
@@ -174,22 +178,64 @@ function makeTranscodingWritable(encoding: string): Writable {
 }
 
 /**
- * Windows + CJK locale 下推断当前控制台代码页：
- *   - zh-* → CP936 (GBK)
- *   - ja-* → CP932 (SJIS)
- *   - ko-* → CP949
- * 其它 / 非 Windows / 非 TTY (重定向到管道 / 文件) 返回 null，跳过转码。
+ * Windows 下挑选控制台转码目标编码。优先用启动时探测到的**真实活动代码页**
+ * （`codePage`，来自 detectWindowsConsoleCodePage）：
+ *   - 65001 (UTF-8)            → 返回 null，直出 UTF-8 不转码（控制台本就是 UTF-8）；
+ *   - 936/950/932/949 (CJK)    → 转码到对应代码页；
+ *   - 其它已知 ASCII 兼容页     → 返回 null，直出（中文字节本就无法正确显示，转码无益）；
+ *   - 探测失败（null）          → 回落到按 locale 启发式猜（zh→cp936 / ja→cp932 / ko→cp949）。
  *
- * 不区分简繁体（CP950 vs CP936）：开发者环境一般 GBK 即可，输出失真极少；
- * 错了用户也能从 logs/ 文件里拿到原始 UTF-8。
+ * 探测真实代码页避免了纯 locale 猜的脆弱点：用户若已 `chcp 65001` 切到 UTF-8 控制台，
+ * 再转码成 GBK 反而把正确输出搞乱——此时探测会返回 65001 → 直出 UTF-8。
+ *
+ * TTY 判定：直挂终端（isTTY=true）固然要转码；但 dev（pretty=true）下 electron-vite
+ * 把 main 的 stdout 接成管道（isTTY=false），下游仍是 CJK 代码页的终端——此时同样必须转码，
+ * 否则 UTF-8 字节被当 GBK/SJIS 渲染出乱码。故 pretty 时不卡 isTTY（与上色路径一致）；
+ * 仅打包态原始 JSON（pretty=false）保留 isTTY 守卫，让重定向到管道 / 文件的 JSON 维持 UTF-8。
+ *
+ * 不区分简繁体（CP950 vs CP936）：locale 回落分支按 zh-TW/zh-HK 区分，探测分支按真实页号精确命中。
+ * 探测/转码错了用户也能从 logs/ 文件里拿到原始 UTF-8。
  */
-function pickWindowsConsoleEncoding(): string | null {
+function pickWindowsConsoleEncoding(pretty: boolean, codePage: number | null): string | null {
   if (process.platform !== 'win32') return null;
-  if (!process.stdout.isTTY) return null;
+  if (!pretty && !process.stdout.isTTY) return null;
+  // 真实活动代码页优先。CP_MAP 命中即用；65001/其它 ASCII 兼容页落到 map 外 → 直出 UTF-8。
+  if (codePage !== null) {
+    return CP_MAP[codePage] ?? null;
+  }
+  // 探测失败：按 locale 猜。
   const locale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
   if (locale.startsWith('zh-tw') || locale.startsWith('zh-hk')) return 'cp950';
   if (locale.startsWith('zh')) return 'cp936';
   if (locale.startsWith('ja')) return 'cp932';
   if (locale.startsWith('ko')) return 'cp949';
   return null;
+}
+
+/** 需要转码的 CJK 代码页号 → iconv-lite 编码名。65001 (UTF-8) 等不在表中者直出。 */
+const CP_MAP: Record<number, string> = {
+  936: 'cp936',
+  950: 'cp950',
+  932: 'cp932',
+  949: 'cp949',
+};
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * 探测当前控制台的活动输出代码页（GetConsoleOutputCP 等价物）。跑 `chcp.com`（System32 下的
+ * 真实可执行文件）解析其输出里的页号——`chcp` 文本如「活动代码页: 936」/「Active code page: 65001」，
+ * 仅数字部分恒为 ASCII，故按当前页号无关地用正则抽数字即可。
+ *
+ * 非 Windows、命令缺失 / 超时 / 解析失败一律返回 null，由调用方回落 locale 启发式。
+ */
+async function detectWindowsConsoleCodePage(): Promise<number | null> {
+  if (process.platform !== 'win32') return null;
+  try {
+    const { stdout } = await execFileAsync('chcp.com', { timeout: 2000, windowsHide: true });
+    const m = /(\d+)/.exec(stdout);
+    return m ? Number(m[1]) : null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## 变更

### 1. Agent 运行态按 PR 归属 + 思考中计时（ChatPane）
- `agentRunning` 布尔是组件级状态，Agent 在 PR-A 执行时切到 PR-B，PR-B 也显示「思考中」——会话串台。
- 改为 `runningPr = { id, since }`：派生 `agentBusy`（任一 PR 在跑 → 全局单并发、禁用再发起）与 `agentRunningHere`（跑在**当前 PR** → 才显示运行态 / 思考中、按钮高亮、停止仅作用于本 PR）。
- 「思考中」抽成 `ThinkingIndicator`，带 1s 粒度**动态计时**（复用 RunningView 的 elapsed 模式）。

### 2. Windows 控制台代码页探测（logger）
- dev 下 electron-vite 把 main 的 stdout 接成管道（`isTTY=false`）原会跳过转码，UTF-8 字节被 CJK 控制台按 GBK/SJIS 渲染出乱码 → `pretty` 模式不卡 `isTTY`。
- 启动期探测真实活动代码页（`chcp`）替代按 locale 猜测：65001 直出 UTF-8；cp936/cp932/cp949/cp950 转码到对应页，避免用户已切 UTF-8 控制台时反而被转乱。

## 验证
- `typecheck` / `lint` / `test` / `build` 全通过。