### PR TITLE
feat(agent): 本机 CLI 模式 Agent 编排通道走低算力档提速

### DIFF
--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/install.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/install.py
@@ -38,17 +38,29 @@ def _install_cli_chat_completion(handler_cls, bin_name) -> None:
     name = (bin_name or "").strip().lower()
     spec = _CLI_SPECS.get(name)
     exe, needs_cmd = _resolve_cli_exe(bin_name) if spec else (None, False)
-    argv = ((["cmd", "/c", exe] if needs_cmd else [exe]) + spec["flags"]) if (spec and exe) else None
+    # 命令前缀（cmd 包装 + exe）；exe 解析失败为 None。flags 每次调用按 env 组装（低算力档）。
+    cmd_prefix = (["cmd", "/c", exe] if needs_cmd else [exe]) if (spec and exe) else None
+
+    def _build_argv():
+        flags = list(spec["flags"])
+        # 低算力档：仅 Agent 编排通道经 MEEBOX_CLI_REASONING=low/minimal 开启；把 low_effort_flags
+        # 插到尾部 `-`（stdin 占位）之前、保持 `-` 在末位；无尾部 `-` 则直接追加。
+        if os.environ.get("MEEBOX_CLI_REASONING", "").strip().lower() in ("low", "minimal"):
+            extra = list(spec.get("low_effort_flags") or [])
+            if extra:
+                flags = flags[:-1] + extra + ["-"] if flags and flags[-1] == "-" else flags + extra
+        return cmd_prefix + flags
 
     async def chat_completion(self, model, system, user, temperature=0.2, img_path=None):
         if spec is None:
             raise RuntimeError(
                 f"不支持的本地 CLI 命令 '{bin_name}'（当前已适配 claude / codex）。"
             )
-        if argv is None:
+        if cmd_prefix is None:
             raise RuntimeError(
                 f"找不到本地 CLI 命令 '{bin_name}'：请确认已安装、已登录，且 '{bin_name}' 在 PATH 中。"
             )
+        argv = _build_argv()
         prompt = f"{system}\n\n\n{user}" if system else user
         # 基于 os.environ 拷贝再剔除计费 key——其余（PATH/HOME/代理变量等）原样保留。
         child_env = {k: v for k, v in os.environ.items() if k not in spec["strip_env"]}

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
@@ -5,11 +5,12 @@ from .parsers import _parse_claude_output, _parse_codex_output
 # `low_effort_flags`：低算力档要追加的 argv（仅 Agent 编排通道经 MEEBOX_CLI_REASONING 开启，
 # 见 install.py）。含尾部 `-`（stdin）的命令会把这些 flags 插到 `-` 之前，保持 `-` 在末位。
 _CLI_SPECS = {
-    # claude：-p 单轮非交互 + JSON（一段含结果与 usage）；不传 --model，用本机默认模型/登录态。
-    # claude `-p` 无推理档 flag（思考随模型默认），低算力档暂留空（按需可改 --model 提速）。
+    # claude：-p 单轮非交互 + JSON（一段含结果与 usage）；默认不传 --model，用本机默认模型/登录态。
+    # 低算力档：--model haiku（最快最省，适合编排通道的路由 / 判读 / 收尾 / 对话），与 /review 走默认
+    # 模型形成差异化；haiku 别名自动解析到当前账户可用的最新 haiku。
     "claude": {
         "flags": ["-p", "--output-format", "json"],
-        "low_effort_flags": [],
+        "low_effort_flags": ["--model", "haiku"],
         "parser": _parse_claude_output,
         "strip_env": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
     },

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
@@ -2,17 +2,23 @@
 计费 env。新增命令在此登记一套即可；renderer 侧白名单校验须同步（见 LlmProfileForm.validateProfile）。"""
 from .parsers import _parse_claude_output, _parse_codex_output
 
+# `low_effort_flags`：低算力档要追加的 argv（仅 Agent 编排通道经 MEEBOX_CLI_REASONING 开启，
+# 见 install.py）。含尾部 `-`（stdin）的命令会把这些 flags 插到 `-` 之前，保持 `-` 在末位。
 _CLI_SPECS = {
     # claude：-p 单轮非交互 + JSON（一段含结果与 usage）；不传 --model，用本机默认模型/登录态。
+    # claude `-p` 无推理档 flag（思考随模型默认），低算力档暂留空（按需可改 --model 提速）。
     "claude": {
         "flags": ["-p", "--output-format", "json"],
+        "low_effort_flags": [],
         "parser": _parse_claude_output,
         "strip_env": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
     },
     # codex：exec 非交互 + --json（JSONL 事件流）；末位 `-` 让 stdin 作完整 prompt；
     # --skip-git-repo-check 容许临时目录运行，--sandbox read-only 只读不改文件。
+    # 低算力档：-c model_reasoning_effort=minimal（codex 默认推理较重，编排通道无需，调低提速）。
     "codex": {
         "flags": ["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only", "-"],
+        "low_effort_flags": ["-c", "model_reasoning_effort=minimal"],
         "parser": _parse_codex_output,
         "strip_env": ("OPENAI_API_KEY", "CODEX_API_KEY"),
     },

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1282,6 +1282,11 @@ export function registerIpcHandlers({
       ...buildProxyEnv(bootstrap.config.proxy),
       ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
       CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
+      // Agent 编排通道（规划 / 判读 / 收尾 / 对话）是路由 + 轻量综合，非深度代码分析（那在
+      // pr-agent /review 里）。本机 CLI 模式下调低推理档（codex: model_reasoning_effort=minimal）
+      // 提速；仅作用于本 chat spawn，pr-agent 工具 run 的 env 不含此项 → /review 仍满档推理。
+      // 非 CLI 模式（API）由 CLI handler 之外的路径处理，该 env 无副作用。
+      MEEBOX_CLI_REASONING: 'low',
     };
     // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
     const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));


### PR DESCRIPTION
## 背景

本机 CLI 模式（claude / codex）下 Agent 体验偏慢。Agent 编排通道（规划 / 判读 / 收尾 / 对话）本质是**路由 + 轻量综合**，深度代码分析在 pr-agent `/review` 里——这条通道无需满档推理。

## 变更

- `withAgentChat` 在 chat 子进程的 `env` 注入 `MEEBOX_CLI_REASONING=low`。**仅作用于该 chat spawn**；pr-agent 工具 run（`/review`/`/describe`）走各自 spawn、env 不含此项 → 仍满档推理。隔离干净。
- CLI shim 据此按命令追加低算力档 flags（`install.py` 每次调用按 env 组装 argv）：
  - **codex** → `-c model_reasoning_effort=minimal`（codex 默认推理较重，提速明显）；插到尾部 `-`（stdin 占位）之前、保持 `-` 在末位。
  - **claude** `-p` 无推理档 flag（思考随模型默认），低算力档暂留空（按需可改 `--model`）。
- 非 CLI（API）模式：CLI handler 不参与，该 env 无副作用。

## 验证
- shim 语法 OK；argv 拼接经手验（codex 低档 flag 正确插在 `-` 前，codex 默认 / claude 不变）。
- `prepare:pragent` 已重新同步 shim 进 vendor，冒烟通过（pr_agent 可导入 + shim 补丁生效）。
- `typecheck` / `lint` / `build` 通过。

## 备注
- codex 的 `-c model_reasoning_effort` 配置键以实测 codex 版本为准；不支持时 codex 一般忽略未知 `-c`，退化为默认（不报错）。
- 这是「调低编排通道推理」的一半；CLI 慢的另一半是**子进程冷启动 × 轮数**，后续可经「减少轮数 + 直连 API streaming」进一步优化（见讨论）。