### PR TITLE
feat(agent): 过程化跟踪活动条（类 Claude Code）+ 后台日志 + 单步计时

### DIFF
--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -170,11 +170,13 @@ export async function runAgentPlanning(
       })) ?? session
     );
   } catch (err) {
+    // 用户停止（abort 杀掉在跑的 chat / 工具子进程 → 抛错）→ 干净的 paused 收尾，不当失败报错。
+    const aborted = deps.signal?.aborted || (err instanceof Error && err.message === '用户暂停');
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {
-        status: 'failed',
+        status: aborted ? 'paused' : 'failed',
         finishedAt: now().toISOString(),
-        terminationReason: err instanceof Error ? err.message : String(err),
+        terminationReason: aborted ? '用户暂停' : err instanceof Error ? err.message : String(err),
       })) ?? session
     );
   }

--- a/apps/desktop/src/main/agent-review.ts
+++ b/apps/desktop/src/main/agent-review.ts
@@ -45,6 +45,8 @@ export interface AgentReviewDeps {
   summaryMaxChars: number;
   /** 步骤流式回调（广播给渲染层）。 */
   onStep?: (sessionId: string, step: AgentStep) => void;
+  /** 用户停止：透传给微流程，思考 / 执行任意阶段都能立即中止（停止按钮 → agent:stop）。 */
+  signal?: AbortSignal;
 }
 
 /**
@@ -78,6 +80,7 @@ export async function runAgentReview(
           await appendAgentStep(deps.stateStore, pr.localId, step, now);
           deps.onStep?.(session.id, step);
         },
+        signal: deps.signal,
       },
       {
         context: deps.agentContext,
@@ -99,11 +102,13 @@ export async function runAgentReview(
       })) ?? session
     );
   } catch (err) {
+    // 用户停止（abort）→ 干净的 paused 收尾，不当失败报错；其余异常仍记为 failed。
+    const aborted = deps.signal?.aborted || (err instanceof Error && err.message === '用户暂停');
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {
-        status: 'failed',
+        status: aborted ? 'paused' : 'failed',
         finishedAt: now().toISOString(),
-        terminationReason: err instanceof Error ? err.message : String(err),
+        terminationReason: aborted ? '用户暂停' : err instanceof Error ? err.message : String(err),
       })) ?? session
     );
   }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -48,6 +48,7 @@ import { pickMatchingRule } from '@meebox/rules';
 import type {
   AgentRecommendationVerdict,
   AgentSession,
+  AgentStep,
   AppInfo,
   ConnectionSummary,
   IpcChannels,
@@ -1303,6 +1304,28 @@ export function registerIpcHandlers({
     }
   };
 
+  /**
+   * 每个编排步骤的统一出口：① 后台日志（工具选择 / 判读 / 收尾各落一条，便于排障与离线回看）；
+   * ② 广播给渲染层（agent:stepProgress）做过程化展示。thought / result 截断避免刷屏。
+   */
+  const logClamp = (s: string): string => (s.length > 200 ? `${s.slice(0, 199)}…` : s);
+  const emitAgentStep = (pr: StoredPullRequest, sessionId: string, step: AgentStep): void => {
+    logger.info(
+      {
+        prLocalId: pr.localId,
+        sessionId,
+        kind: step.kind,
+        tool: step.toolCall?.tool,
+        thought: step.thought ? logClamp(step.thought) : undefined,
+        result: step.result ? logClamp(step.result) : undefined,
+      },
+      'agent step',
+    );
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+    }
+  };
+
   /** 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。 */
   const runReviewForPr = (
     pr: StoredPullRequest,
@@ -1328,11 +1351,7 @@ export function registerIpcHandlers({
       toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
       maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
       summaryMaxChars: agentCfg.summary_max_chars,
-      onStep: (sessionId, step) => {
-        for (const win of BrowserWindow.getAllWindows()) {
-          win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
-        }
-      },
+      onStep: (sessionId, step) => emitAgentStep(pr, sessionId, step),
     });
   };
 
@@ -1348,7 +1367,12 @@ export function registerIpcHandlers({
       const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
+      logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
       const session = await withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
+      logger.info(
+        { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
+        'agent review done',
+      );
       // 手动一键评审计入多轮对话（作为一条 assistant 评审消息）；AutoPilot 背景评审不计（走 1476
       // 的 runReviewForPr，不经此处）。无文本 / 失败不记。
       if (session.status === 'done' && session.summary) {
@@ -1422,10 +1446,24 @@ export function registerIpcHandlers({
       });
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
+      logger.info(
+        { prLocalId: pr.localId, request: logClamp(req.question) },
+        'agent chat start (planning)',
+      );
       try {
-        return await withAgentChat((chat) =>
+        const session = await withAgentChat((chat) =>
           runPlanningForPr(pr, req.question, agentContext, chat, ac.signal),
         );
+        logger.info(
+          {
+            prLocalId: pr.localId,
+            status: session.status,
+            steps: session.stepCount,
+            terminationReason: session.terminationReason,
+          },
+          'agent chat done',
+        );
+        return session;
       } finally {
         agentControllers.delete(pr.localId);
       }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1274,8 +1274,12 @@ export function registerIpcHandlers({
     user: string;
   }) => Promise<{ text: string; usage?: TokenUsage }>;
 
-  /** 设置 LLM env + 临时 chat cwd + chat 函数，运行 fn，收尾清理临时目录。 */
-  const withAgentChat = async <T>(fn: (chat: AgentChat) => Promise<T>): Promise<T> => {
+  /** 设置 LLM env + 临时 chat cwd + chat 函数，运行 fn，收尾清理临时目录。
+   *  signal：用户停止时 abort → 杀掉在跑的 LLM chat 子进程，让思考阶段也能立即中止（不必等模型返回）。 */
+  const withAgentChat = async <T>(
+    fn: (chat: AgentChat) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> => {
     const bridge = getPrAgentBridge();
     if (!bridge) throw new Error(t('prAgent.notReadyDetail'));
     // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。
@@ -1294,7 +1298,7 @@ export function registerIpcHandlers({
     const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
     try {
       const chat: AgentChat = async ({ system, user }) => {
-        const r = await bridge.chat({ system, user, env, cwd: chatCwd });
+        const r = await bridge.chat({ system, user, env, cwd: chatCwd, signal });
         const acc: UsageAcc = { prompt: 0, completion: 0, total: 0, calls: 0, any: false };
         for (const line of (r.stderr ?? '').split('\n')) accumulateUsageSentinel(line, acc);
         return { text: r.stdout.trim(), usage: finalizeUsage(acc) };
@@ -1379,8 +1383,9 @@ export function registerIpcHandlers({
       agentControllers.set(pr.localId, ac);
       logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
       try {
-        const session = await withAgentChat((chat) =>
-          runReviewForPr(pr, agentContext, chat, ac.signal),
+        const session = await withAgentChat(
+          (chat) => runReviewForPr(pr, agentContext, chat, ac.signal),
+          ac.signal,
         );
         logger.info(
           { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
@@ -1458,8 +1463,9 @@ export function registerIpcHandlers({
       // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
       logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
       try {
-        const session = await withAgentChat((chat) =>
-          runPlanningForPr(pr, req.question, agentContext, chat, ac.signal),
+        const session = await withAgentChat(
+          (chat) => runPlanningForPr(pr, req.question, agentContext, chat, ac.signal),
+          ac.signal,
         );
         logger.info(
           {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -41,6 +41,7 @@ import {
   getAgentSession,
   clearAgentSession,
   getAgentConversation,
+  getAgentTranscript,
   appendAgentMessage,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
@@ -1308,7 +1309,8 @@ export function registerIpcHandlers({
    * 每个编排步骤的统一出口：① 后台日志（工具选择 / 判读 / 收尾各落一条，便于排障与离线回看）；
    * ② 广播给渲染层（agent:stepProgress）做过程化展示。thought / result 截断避免刷屏。
    */
-  const logClamp = (s: string): string => (s.length > 200 ? `${s.slice(0, 199)}…` : s);
+  // 后台日志只留骨架（kind / tool / 用时）：thought 与 result（含用户输入 / 总结正文）不入日志，
+  // 避免刷屏 + 泄漏内容；完整步骤已落 transcript.json，需要时从那里回看。
   const emitAgentStep = (pr: StoredPullRequest, sessionId: string, step: AgentStep): void => {
     logger.info(
       {
@@ -1316,8 +1318,7 @@ export function registerIpcHandlers({
         sessionId,
         kind: step.kind,
         tool: step.toolCall?.tool,
-        thought: step.thought ? logClamp(step.thought) : undefined,
-        result: step.result ? logClamp(step.result) : undefined,
+        thinkMs: step.thinkMs,
       },
       'agent step',
     );
@@ -1442,10 +1443,8 @@ export function registerIpcHandlers({
       });
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
-      logger.info(
-        { prLocalId: pr.localId, request: logClamp(req.question) },
-        'agent chat start (planning)',
-      );
+      // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
+      logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
       try {
         const session = await withAgentChat((chat) =>
           runPlanningForPr(pr, req.question, agentContext, chat, ac.signal),
@@ -1492,6 +1491,15 @@ export function registerIpcHandlers({
       req: IpcChannels['agent:getConversation']['request'],
     ): Promise<IpcChannels['agent:getConversation']['response']> =>
       getAgentConversation(stateStore, req.localId),
+  );
+
+  ipcMain.handle(
+    'agent:getTranscript',
+    async (
+      _evt,
+      req: IpcChannels['agent:getTranscript']['request'],
+    ): Promise<IpcChannels['agent:getTranscript']['response']> =>
+      getAgentTranscript(stateStore, req.localId),
   );
 
   // === AutoPilot 调度（见 docs/arch/06-agent.md「AutoPilot」）===

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1413,11 +1413,7 @@ export function registerIpcHandlers({
       language: getMainLanguage(),
       maxSteps: agentCfg.max_steps,
       signal,
-      onStep: (sessionId, step) => {
-        for (const win of BrowserWindow.getAllWindows()) {
-          win.webContents.send('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
-        }
-      },
+      onStep: (sessionId, step) => emitAgentStep(pr, sessionId, step),
       // 持久化 Agent 主动记下的非隐私条目到当前 Agent 目录的各可写文件（USER/MEMORY/AGENTS）；
       // SOUL.md 永不写。下一轮 loadAgentContext 现读即生效（跨会话记忆）。
       recordMemory: async (notes) => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -461,6 +461,13 @@ export function registerIpcHandlers({
     const err = await shell.openPath(bootstrap.paths.configFile);
     if (err) throw new Error(`failed to open config.yaml: ${err}`);
   });
+  ipcMain.handle('app:openAgentDir', async (): Promise<void> => {
+    // 当前生效的 Agent 目录（用户配置优先，否则默认 ~/.code-meeseeks/agent）；先确保存在再打开。
+    const dir = effectiveAgentDir();
+    await fs.mkdir(dir, { recursive: true }).catch(() => undefined);
+    const err = await shell.openPath(dir);
+    if (err) throw new Error(`failed to open agent dir: ${err}`);
+  });
   ipcMain.handle('app:openDevTools', (evt) => {
     evt.sender.openDevTools({ mode: 'detach' });
   });

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1327,11 +1327,16 @@ export function registerIpcHandlers({
     }
   };
 
+  // 编排 Agent（手动评审 agent:run + 自由规划 agent:ask）每 PR 至多一个在跑，AbortController 供
+  // agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
+  const agentControllers = new Map<string, AbortController>();
+
   /** 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。 */
   const runReviewForPr = (
     pr: StoredPullRequest,
     agentContext: AgentContext,
     chat: AgentChat,
+    signal?: AbortSignal,
   ): Promise<AgentSession> => {
     const agentCfg = bootstrap.config.agent;
     const matchedRule = pickMatchingRule(agentContext.rules, {
@@ -1353,6 +1358,7 @@ export function registerIpcHandlers({
       maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
       summaryMaxChars: agentCfg.summary_max_chars,
       onStep: (sessionId, step) => emitAgentStep(pr, sessionId, step),
+      signal,
     });
   };
 
@@ -1368,27 +1374,33 @@ export function registerIpcHandlers({
       const agentContext = await loadAgentContext(effectiveAgentDir(), {
         onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
       });
+      // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
+      const ac = new AbortController();
+      agentControllers.set(pr.localId, ac);
       logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
-      const session = await withAgentChat((chat) => runReviewForPr(pr, agentContext, chat));
-      logger.info(
-        { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
-        'agent review done',
-      );
-      // 手动一键评审计入多轮对话（作为一条 assistant 评审消息）；AutoPilot 背景评审不计（走 1476
-      // 的 runReviewForPr，不经此处）。无文本 / 失败不记。
-      if (session.status === 'done' && session.summary) {
-        await appendAgentMessage(stateStore, pr.localId, {
-          role: 'assistant',
-          content: session.summary,
-          recommendation: session.recommendation,
-        });
+      try {
+        const session = await withAgentChat((chat) =>
+          runReviewForPr(pr, agentContext, chat, ac.signal),
+        );
+        logger.info(
+          { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
+          'agent review done',
+        );
+        // 手动一键评审计入多轮对话（作为一条 assistant 评审消息）；AutoPilot 背景评审不计（不经此处）。
+        // 仅成功收尾才记：失败 / 用户停止（paused）不落消息。
+        if (session.status === 'done' && session.summary) {
+          await appendAgentMessage(stateStore, pr.localId, {
+            role: 'assistant',
+            content: session.summary,
+            recommendation: session.recommendation,
+          });
+        }
+        return session;
+      } finally {
+        agentControllers.delete(pr.localId);
       }
-      return session;
     },
   );
-
-  // 自由规划 Agent（自然语言入口）：每 PR 至多一个在跑，AbortController 供 agent:stop 暂停。
-  const agentControllers = new Map<string, AbortController>();
 
   const runPlanningForPr = (
     pr: StoredPullRequest,

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -218,6 +218,25 @@ export function ChatPane({
   // 全局单并发：任一 PR 在跑即占用（禁止再发起）；仅「跑在当前 PR」才在本会话显示运行态 / 思考中。
   const agentBusy = runningPr !== null;
   const agentRunningHere = runningPr?.id === prLocalId && prLocalId !== undefined;
+  // 「思考中」实时计时的锚点：取「最近一次活动结束」——{本 PR run 起点, 末个思考步 at, 末个完成 run
+  // 的结束时刻} 三者最晚者。锚到持久数据（runningPr 跨 PR 切换不清、run 历史会重载）而非组件挂载，
+  // 故切走再切回不清零；用 run 结束而非步骤记录时刻，避免把工具执行时间算进当前思考。
+  const thinkingSince = useMemo(() => {
+    const cands: number[] = [];
+    if (runningPr && runningPr.id === prLocalId) cands.push(runningPr.since);
+    const lastStepAt = agentSteps[agentSteps.length - 1]?.at;
+    if (lastStepAt) {
+      const ms = new Date(lastStepAt).getTime();
+      if (Number.isFinite(ms)) cands.push(ms);
+    }
+    const lastRun = visibleRuns[visibleRuns.length - 1];
+    const lastRunEnd = lastRun?.finishedAt ?? lastRun?.startedAt;
+    if (lastRunEnd) {
+      const ms = new Date(lastRunEnd).getTime();
+      if (Number.isFinite(ms)) cands.push(ms);
+    }
+    return cands.length ? Math.max(...cands) : Date.now();
+  }, [runningPr, prLocalId, agentSteps, visibleRuns]);
   useEffect(() => {
     setRuns([]);
     setHasMoreOlder(false);
@@ -231,11 +250,13 @@ export function ChatPane({
     void (async () => {
       try {
         // listRuns 默认返回 newest-first；这里只拉最新一页 (RUNS_PAGE_SIZE)。
-        // 同时拉已落盘的多轮对话：把会话消息恢复到其 PR，跨切换 / 重启不丢失。
-        const [list, rule, conversation] = await Promise.all([
+        // 同时拉已落盘的多轮对话 + 过程步骤（transcript）：把会话恢复到其 PR，跨切换 / 重启不丢失，
+        // 过程化跟踪的思考步骤也随之恢复（步骤随产生增量落盘）。
+        const [list, rule, conversation, transcript] = await Promise.all([
           invoke('pragent:listRuns', { localId: prLocalId, limit: RUNS_PAGE_SIZE }),
           invoke('rules:matchForPr', { localId: prLocalId, tool: 'review' }),
           invoke('agent:getConversation', { localId: prLocalId }),
+          invoke('agent:getTranscript', { localId: prLocalId }),
         ]);
         if (cancelled) return;
         // 反转为升序 (chat 习惯)，UI 直接读 runs 即可
@@ -243,6 +264,7 @@ export function ChatPane({
         setHasMoreOlder(list.length === RUNS_PAGE_SIZE);
         setMatchedRule(rule);
         setMessages(conversation);
+        setAgentSteps(transcript);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -705,8 +727,11 @@ export function ChatPane({
         )}
         {/* 过程化跟踪（类 Claude Code）：已完成的思考步骤已按时间穿插进上面的时间线（AgentStepRow），
             此处只在 Agent 自身 LLM 正在推理（无 pr-agent 工具 run 占用 / 排队）时补一条实时「思考中」
-            指示——等待工具调用不算思考。计时随指示挂载从零起算，即当前这步的思考时长。 */}
-        {agentRunningHere && !hasMyActive && myWaiting.length === 0 && <ThinkingLive />}
+            指示——等待工具调用不算思考。计时锚定到「最近一次活动结束」（run 起点 / 末步 / 末个完成
+            run 的结束时刻取最晚者）而非组件挂载——切换 PR 再切回不会清零（runningPr 与 run 历史持久）。 */}
+        {agentRunningHere && !hasMyActive && myWaiting.length === 0 && (
+          <ThinkingLive since={thinkingSince} />
+        )}
         {error && (
           <div className="chat-error" role="alert">
             <strong>{t('chatPane.errorPrefix')}</strong>
@@ -724,7 +749,7 @@ export function ChatPane({
         runningTool={myActiveRuns[myActiveRuns.length - 1]?.tool ?? null}
         onRun={(t, q) => void handleRun(t, q)}
         onAgentAsk={(q) => void handleAgentAsk(q)}
-        onCancel={hasMyActive ? handleStopAll : undefined}
+        onCancel={hasMyActive || agentRunningHere ? handleStopAll : undefined}
         onSetReviewStatus={onSetReviewStatus}
         // 一键自动评审：图标按钮置于 `/` 命令触发器右侧。busy=全局占用（禁用触发）、
         // runningHere=跑在当前 PR（高亮 / 运行中文案）。
@@ -948,8 +973,9 @@ function ChatInputBar({
   const cmdMenuRef = useRef<HTMLDivElement | null>(null);
 
   // 队列模型：仅 !pr / pr-agent 未就绪 时禁用 input。activeRun / busyOnOtherPr
-  // 不再阻塞新提交 (会排队 by main)
-  const running = runningTool !== null;
+  // 不再阻塞新提交 (会排队 by main)。running 决定是否渲染 stop 按钮：除活动工具 run 外，
+  // Agent 自身执行阶段（思考 / 编排，无工具 run 占用）也算「运行中」，以便随时取消。
+  const running = runningTool !== null || agentRunningHere;
   // LLM 未配置时一并禁用：即便 pr-agent 运行时就绪，没有模型也无法发起调用
   const disabled = !pr || !prAgent.available || !llmConfigured;
   // stop 按钮点过后等 main 回 queueChanged 才会改变状态；中间这段时间二次点击
@@ -1351,17 +1377,21 @@ function ChatInputBar({
  */
 function AgentStepRow({ step }: { step: AgentStep }) {
   const { t } = useTranslation();
+  // 首行始终带 bullet 标记：有思考计时 → 「已思考 xx s」；无计时（如微流程固定派发步）→ 用思考内容
+  // 当首行，保证每一步都可见、都有分段标记，绝不渲染成空行。
+  const hasTime = step.thinkMs != null;
+  const headText = hasTime
+    ? t('chatPane.agent.thoughtFor', { time: formatElapsed(step.thinkMs ?? 0) })
+    : step.thought;
   return (
     <div className="chat-agent-step" role="note">
-      {step.thinkMs != null && (
-        <div className="chat-agent-step-head">
-          <span className="chat-agent-step-bullet" aria-hidden>
-            •
-          </span>
-          <span>{t('chatPane.agent.thoughtFor', { time: formatElapsed(step.thinkMs) })}</span>
-        </div>
-      )}
-      {step.thought && <div className="chat-agent-step-body">{step.thought}</div>}
+      <div className="chat-agent-step-head">
+        <span className="chat-agent-step-bullet" aria-hidden>
+          •
+        </span>
+        {headText && <span>{headText}</span>}
+      </div>
+      {hasTime && step.thought && <div className="chat-agent-step-body">{step.thought}</div>}
       {step.kind === 'judge' && step.result && (
         <div className="chat-agent-step-body muted">{step.result}</div>
       )}
@@ -1370,13 +1400,13 @@ function AgentStepRow({ step }: { step: AgentStep }) {
 }
 
 /**
- * 实时「思考中」指示：仅在 Agent 自身 LLM 正在推理（无工具 run 占用 / 排队）时挂载。计时随挂载
- * 从零起算 = 当前这步的思考时长（非总任务累计）；下一步产生 / 转入工具执行即卸载、计时归零。
+ * 实时「思考中」指示：仅在 Agent 自身 LLM 正在推理（无工具 run 占用 / 排队）时挂载。计时锚定到传入的
+ * `since`（最近一次活动结束时刻，由父级从持久数据算出），而非组件挂载——切走再切回不清零；新一步产生
+ * 后 since 前移 → 计时回到当前步从零起算（仍是单步思考时长，非总累计）。
  * 首行布局与已完成步骤对齐：spinner 充当进行中的 bullet 标记，「思考中」后紧贴计时。
  */
-function ThinkingLive() {
+function ThinkingLive({ since }: { since: number }) {
   const { t } = useTranslation();
-  const startRef = useRef<number>(Date.now());
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000);
@@ -1387,7 +1417,7 @@ function ThinkingLive() {
       <div className="chat-agent-step-head">
         <Spinner />
         <span>
-          {t('chatPane.agent.thinking')} {formatElapsed(Math.max(0, now - startRef.current))}
+          {t('chatPane.agent.thinking')} {formatElapsed(Math.max(0, now - since))}
         </span>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -693,16 +693,21 @@ export function ChatPane({
             {t('chatPane.concurrencyReached', { n: maxConcurrency })}
           </div>
         )}
-        {/* 过程化跟踪：Agent 的逐步工具选择 / 判读 / 收尾 + 计时（类 Claude Code）。仅当 Agent
-            跑在**当前 PR** 或本轮已有步骤时显示，不串到其它会话。计时按**单个步骤**——当前思考
-            从上一步结束起算，每步完成后冻结各自用时。 */}
-        {(agentRunningHere || agentSteps.length > 0) && (
-          <AgentActivity
-            steps={agentSteps}
-            running={agentRunningHere}
-            since={runningPr && runningPr.id === prLocalId ? runningPr.since : null}
-          />
-        )}
+        {/* 过程化跟踪：Agent 逐步工具选择 / 判读 / 收尾 + 单步计时（类 Claude Code），仅作用于当前
+            PR。「思考中」只在 Agent 自身 LLM 在跑（无 pr-agent 工具 run 占用）时出现——等待工具调用
+            不算思考；已有步骤时也列出过程，便于回看。 */}
+        {(() => {
+          const thinking = agentRunningHere && !hasMyActive && myWaiting.length === 0;
+          return (
+            (agentSteps.length > 0 || thinking) && (
+              <AgentActivity
+                steps={agentSteps}
+                since={runningPr && runningPr.id === prLocalId ? runningPr.since : null}
+                thinking={thinking}
+              />
+            )
+          );
+        })()}
         {error && (
           <div className="chat-error" role="alert">
             <strong>{t('chatPane.errorPrefix')}</strong>
@@ -1347,26 +1352,28 @@ function stepLabel(step: AgentStep, t: TFunction): string {
 }
 
 /**
- * 过程化跟踪（类 Claude Code）：把 Agent 的逐步工具选择 / 判读 / 收尾流式列出，配**单步**计时——
- * 当前思考从「上一步结束」起算（非总任务累计）；每步完成后用各自时长冻结。可折叠。
+ * 过程化跟踪（类 Claude Code）：把 Agent 已完成的步骤按时间顺序列出（工具选择 / 判读 / 收尾），
+ * 末尾在 Agent 自身 LLM 思考时补一条带计时的「思考中」行。计时按**单个步骤**——每步用各自时长
+ * （上一步结束→本步），当前思考从上一步结束起算，绝非总任务累计。
+ * `thinking`：Agent 自身 LLM 正在跑（无 pr-agent 工具 run 占用）——工具执行的进度/计时由 run 卡片
+ * 负责，故工具步骤这里不再重复计时，只列出选择。
  */
 function AgentActivity({
   steps,
-  running,
   since,
+  thinking,
 }: {
   steps: AgentStep[];
-  running: boolean;
   since: number | null;
+  thinking: boolean;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(true);
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    if (!running) return;
+    if (!thinking) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [running]);
+  }, [thinking]);
 
   const stamps = steps.map((s) => (s.at ? new Date(s.at).getTime() : null));
   const stepMs = (i: number): number | null => {
@@ -1374,41 +1381,30 @@ function AgentActivity({
     const start = i > 0 ? stamps[i - 1] : since;
     return end != null && start != null ? Math.max(0, end - start) : null;
   };
-  // 当前思考：从最后一步结束（无步骤则从 since）到现在。
   const lastStamp = stamps.length ? stamps[stamps.length - 1] : since;
-  const liveMs = running && lastStamp != null ? Math.max(0, now - lastStamp) : 0;
+  const liveMs = thinking && lastStamp != null ? Math.max(0, now - lastStamp) : 0;
 
   return (
     <div className="chat-agent-activity" role="status">
-      <button
-        type="button"
-        className="chat-agent-activity-head"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-      >
-        {running ? <Spinner /> : <ChevronIcon className={open ? 'rot' : ''} />}
-        <span className="chat-agent-activity-title">
-          {running
-            ? t('chatPane.agent.thinking')
-            : t('chatPane.agent.activityDone', { n: steps.length })}
-        </span>
-        {running && <span className="chat-agent-activity-time">{formatElapsed(liveMs)}</span>}
-      </button>
-      {open && steps.length > 0 && (
-        <ol className="chat-agent-activity-list">
-          {steps.map((s, i) => (
-            <li key={i} className="chat-agent-activity-item">
-              <span className="chat-agent-activity-kind">{stepLabel(s, t)}</span>
-              {s.thought && <span className="chat-agent-activity-thought">{s.thought}</span>}
-              {s.kind === 'judge' && s.result && (
-                <span className="chat-agent-activity-result muted">{s.result}</span>
-              )}
-              {stepMs(i) != null && (
-                <span className="chat-agent-activity-time">{formatElapsed(stepMs(i)!)}</span>
-              )}
-            </li>
-          ))}
-        </ol>
+      {steps.map((s, i) => (
+        <div key={i} className="chat-agent-activity-item">
+          <span className="chat-agent-activity-kind">{stepLabel(s, t)}</span>
+          {s.thought && <span className="chat-agent-activity-thought">{s.thought}</span>}
+          {s.kind === 'judge' && s.result && (
+            <span className="chat-agent-activity-result muted">{s.result}</span>
+          )}
+          {/* 工具步骤的耗时由 run 卡片展示（并行更准）；这里只给推理步骤（判读 / 收尾）计时。 */}
+          {s.kind !== 'tool' && stepMs(i) != null && (
+            <span className="chat-agent-activity-time">{formatElapsed(stepMs(i)!)}</span>
+          )}
+        </div>
+      ))}
+      {thinking && (
+        <div className="chat-agent-activity-item chat-agent-activity-live">
+          <Spinner />
+          <span className="chat-agent-activity-thought">{t('chatPane.agent.thinking')}</span>
+          <span className="chat-agent-activity-time">{formatElapsed(liveMs)}</span>
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -190,15 +190,6 @@ export function ChatPane({
       step: null as AgentStep | null,
       message: null as AgentMessage | null,
     }));
-    const stepEntries = agentSteps
-      .filter((s) => s.kind === 'judge')
-      .map((s, i) => ({
-        key: `step-${i}-${s.at ?? ''}`,
-        time: s.at ?? '',
-        run: null,
-        step: s,
-        message: null as AgentMessage | null,
-      }));
     const msgEntries = messages.map((m, i) => ({
       key: `msg-${i}-${m.at}`,
       time: m.at,
@@ -206,10 +197,9 @@ export function ChatPane({
       step: null as AgentStep | null,
       message: m,
     }));
-    return [...runEntries, ...stepEntries, ...msgEntries].sort((a, b) =>
-      a.time.localeCompare(b.time),
-    );
-  }, [visibleRuns, agentSteps, messages]);
+    // Agent 过程步骤不再逐条入时间线——统一交给底部「过程化跟踪」活动条（AgentActivity）呈现。
+    return [...runEntries, ...msgEntries].sort((a, b) => a.time.localeCompare(b.time));
+  }, [visibleRuns, messages]);
 
   // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
   // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
@@ -668,8 +658,6 @@ export function ChatPane({
               onRejectFinding={handleRejectFinding}
               onNavigateToFinding={handleNavigateToFinding}
             />
-          ) : entry.step ? (
-            <AgentStepMarker key={entry.key} step={entry.step} />
           ) : entry.message ? (
             <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
@@ -705,11 +693,15 @@ export function ChatPane({
             {t('chatPane.concurrencyReached', { n: maxConcurrency })}
           </div>
         )}
-        {/* Agent 自身 LLM 调用（规划 / 判读 / 收尾）无对应 pragent run，此时队列里看不到进度 →
-            补一条「思考中」指示（带动态计时），避免运行期界面看似停滞。仅当 Agent 跑在**当前 PR**
-            才显示，不串到其它会话；子任务运行时由 RunningView 负责进度。 */}
-        {agentRunningHere && runningPr && !hasMyActive && myWaiting.length === 0 && (
-          <ThinkingIndicator since={runningPr.since} />
+        {/* 过程化跟踪：Agent 的逐步工具选择 / 判读 / 收尾 + 计时（类 Claude Code）。仅当 Agent
+            跑在**当前 PR** 或本轮已有步骤时显示，不串到其它会话。计时按**单个步骤**——当前思考
+            从上一步结束起算，每步完成后冻结各自用时。 */}
+        {(agentRunningHere || agentSteps.length > 0) && (
+          <AgentActivity
+            steps={agentSteps}
+            running={agentRunningHere}
+            since={runningPr && runningPr.id === prLocalId ? runningPr.since : null}
+          />
         )}
         {error && (
           <div className="chat-error" role="alert">
@@ -1347,33 +1339,77 @@ function ChatInputBar({
   );
 }
 
-/**
- * Agent 元步骤内联标记：在时间线中按自然时间顺序穿插展示的决策节点（如 judge 判读）。
- * 工具步骤由 run 卡片代表、收尾 plan 由「评审总结」卡片代表，均不走此标记（见时间线归并）。
- */
-function AgentStepMarker({ step }: { step: AgentStep }) {
-  return (
-    <div className="chat-agent-step-marker" role="status">
-      {step.result && <span className="chat-agent-step-result">{step.result}</span>}
-      {step.thought && <span className="chat-agent-step-thought muted">{step.thought}</span>}
-    </div>
-  );
+/** 一个编排步骤的展示标签：工具步骤显示所选工具名，judge → 判读，plan → 收尾。 */
+function stepLabel(step: AgentStep, t: TFunction): string {
+  if (step.toolCall?.tool) return step.toolCall.tool;
+  if (step.kind === 'judge') return t('chatPane.agent.stepJudge');
+  return t('chatPane.agent.stepPlan');
 }
 
-/** 「思考中」指示：spinner + 文案 + 动态计时（1s 粒度，跟 RunningView 同款 elapsed）。 */
-function ThinkingIndicator({ since }: { since: number }) {
+/**
+ * 过程化跟踪（类 Claude Code）：把 Agent 的逐步工具选择 / 判读 / 收尾流式列出，配**单步**计时——
+ * 当前思考从「上一步结束」起算（非总任务累计）；每步完成后用各自时长冻结。可折叠。
+ */
+function AgentActivity({
+  steps,
+  running,
+  since,
+}: {
+  steps: AgentStep[];
+  running: boolean;
+  since: number | null;
+}) {
   const { t } = useTranslation();
-  const [elapsedMs, setElapsedMs] = useState(0);
+  const [open, setOpen] = useState(true);
+  const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    setElapsedMs(Date.now() - since);
-    const id = setInterval(() => setElapsedMs(Date.now() - since), 1000);
+    if (!running) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [since]);
+  }, [running]);
+
+  const stamps = steps.map((s) => (s.at ? new Date(s.at).getTime() : null));
+  const stepMs = (i: number): number | null => {
+    const end = stamps[i];
+    const start = i > 0 ? stamps[i - 1] : since;
+    return end != null && start != null ? Math.max(0, end - start) : null;
+  };
+  // 当前思考：从最后一步结束（无步骤则从 since）到现在。
+  const lastStamp = stamps.length ? stamps[stamps.length - 1] : since;
+  const liveMs = running && lastStamp != null ? Math.max(0, now - lastStamp) : 0;
+
   return (
-    <div className="chat-agent-thinking" role="status">
-      <Spinner />
-      <span>{t('chatPane.agent.thinking')}</span>
-      <span className="chat-agent-thinking-elapsed">{formatElapsed(elapsedMs)}</span>
+    <div className="chat-agent-activity" role="status">
+      <button
+        type="button"
+        className="chat-agent-activity-head"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {running ? <Spinner /> : <ChevronIcon className={open ? 'rot' : ''} />}
+        <span className="chat-agent-activity-title">
+          {running
+            ? t('chatPane.agent.thinking')
+            : t('chatPane.agent.activityDone', { n: steps.length })}
+        </span>
+        {running && <span className="chat-agent-activity-time">{formatElapsed(liveMs)}</span>}
+      </button>
+      {open && steps.length > 0 && (
+        <ol className="chat-agent-activity-list">
+          {steps.map((s, i) => (
+            <li key={i} className="chat-agent-activity-item">
+              <span className="chat-agent-activity-kind">{stepLabel(s, t)}</span>
+              {s.thought && <span className="chat-agent-activity-thought">{s.thought}</span>}
+              {s.kind === 'judge' && s.result && (
+                <span className="chat-agent-activity-result muted">{s.result}</span>
+              )}
+              {stepMs(i) != null && (
+                <span className="chat-agent-activity-time">{formatElapsed(stepMs(i)!)}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -179,15 +179,22 @@ export function ChatPane({
   const myActiveIdSet = new Set(myActiveRuns.map((a) => a.runId));
   const visibleRuns = hasMyActive ? runs.filter((r) => !myActiveIdSet.has(r.id)) : runs;
 
-  // 历史时间线：把 run 卡片与 Agent 的元步骤按时间归并，让过程性步骤按自然时间顺序
-  // 穿插展示（而非堆在末尾）。工具步骤（describe/review/ask）已由 run 卡片代表、不重复；
-  // 收尾 plan 即「评审总结」卡片、不重复 → 仅保留判读（judge）这类决策节点作为内联标记。
+  // 历史时间线：把 run 卡片、Agent 的思考步骤、对话消息按时间归并，让过程性步骤按自然时间顺序
+  // 穿插展示（而非堆在末尾）。类 Claude Code「先思考→定步骤→执行步骤」：思考步骤（plan/judge）
+  // 是工具选择的前因，排在所选工具的 run 卡片之前；工具执行的进度 / 计时由 run 卡片承载，不重复。
   const timeline = useMemo(() => {
     const runEntries = visibleRuns.map((r) => ({
       key: `run-${r.id}`,
       time: r.startedAt,
       run: r as ReviewRun | null,
       step: null as AgentStep | null,
+      message: null as AgentMessage | null,
+    }));
+    const stepEntries = agentSteps.map((s, i) => ({
+      key: `step-${i}-${s.at ?? ''}`,
+      time: s.at ?? '',
+      run: null,
+      step: s as AgentStep | null,
       message: null as AgentMessage | null,
     }));
     const msgEntries = messages.map((m, i) => ({
@@ -197,9 +204,10 @@ export function ChatPane({
       step: null as AgentStep | null,
       message: m,
     }));
-    // Agent 过程步骤不再逐条入时间线——统一交给底部「过程化跟踪」活动条（AgentActivity）呈现。
-    return [...runEntries, ...msgEntries].sort((a, b) => a.time.localeCompare(b.time));
-  }, [visibleRuns, messages]);
+    return [...runEntries, ...stepEntries, ...msgEntries].sort((a, b) =>
+      a.time.localeCompare(b.time),
+    );
+  }, [visibleRuns, agentSteps, messages]);
 
   // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
   // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
@@ -658,6 +666,8 @@ export function ChatPane({
               onRejectFinding={handleRejectFinding}
               onNavigateToFinding={handleNavigateToFinding}
             />
+          ) : entry.step ? (
+            <AgentStepRow key={entry.key} step={entry.step} />
           ) : entry.message ? (
             <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
@@ -693,21 +703,10 @@ export function ChatPane({
             {t('chatPane.concurrencyReached', { n: maxConcurrency })}
           </div>
         )}
-        {/* 过程化跟踪：Agent 逐步工具选择 / 判读 / 收尾 + 单步计时（类 Claude Code），仅作用于当前
-            PR。「思考中」只在 Agent 自身 LLM 在跑（无 pr-agent 工具 run 占用）时出现——等待工具调用
-            不算思考；已有步骤时也列出过程，便于回看。 */}
-        {(() => {
-          const thinking = agentRunningHere && !hasMyActive && myWaiting.length === 0;
-          return (
-            (agentSteps.length > 0 || thinking) && (
-              <AgentActivity
-                steps={agentSteps}
-                since={runningPr && runningPr.id === prLocalId ? runningPr.since : null}
-                thinking={thinking}
-              />
-            )
-          );
-        })()}
+        {/* 过程化跟踪（类 Claude Code）：已完成的思考步骤已按时间穿插进上面的时间线（AgentStepRow），
+            此处只在 Agent 自身 LLM 正在推理（无 pr-agent 工具 run 占用 / 排队）时补一条实时「思考中」
+            指示——等待工具调用不算思考。计时随指示挂载从零起算，即当前这步的思考时长。 */}
+        {agentRunningHere && !hasMyActive && myWaiting.length === 0 && <ThinkingLive />}
         {error && (
           <div className="chat-error" role="alert">
             <strong>{t('chatPane.errorPrefix')}</strong>
@@ -1344,68 +1343,53 @@ function ChatInputBar({
   );
 }
 
-/** 一个编排步骤的展示标签：工具步骤显示所选工具名，judge → 判读，plan → 收尾。 */
-function stepLabel(step: AgentStep, t: TFunction): string {
-  if (step.toolCall?.tool) return step.toolCall.tool;
-  if (step.kind === 'judge') return t('chatPane.agent.stepJudge');
-  return t('chatPane.agent.stepPlan');
+/**
+ * 内联思考步骤（类 Claude Code「先思考→定步骤→执行步骤」）：穿插在时间线里、排在所选工具的 run
+ * 卡片之前。两行展示——首行带 bullet 标记的「已思考 xx s」（单步思考耗时，非总累计），次行另起展示
+ * 步骤结果（思考内容 / 判读结论）。不展示选了哪个工具（由随后的 run 卡片体现）；工具执行的进度 /
+ * 计时也归 run 卡片。
+ */
+function AgentStepRow({ step }: { step: AgentStep }) {
+  const { t } = useTranslation();
+  return (
+    <div className="chat-agent-step" role="note">
+      {step.thinkMs != null && (
+        <div className="chat-agent-step-head">
+          <span className="chat-agent-step-bullet" aria-hidden>
+            •
+          </span>
+          <span>{t('chatPane.agent.thoughtFor', { time: formatElapsed(step.thinkMs) })}</span>
+        </div>
+      )}
+      {step.thought && <div className="chat-agent-step-body">{step.thought}</div>}
+      {step.kind === 'judge' && step.result && (
+        <div className="chat-agent-step-body muted">{step.result}</div>
+      )}
+    </div>
+  );
 }
 
 /**
- * 过程化跟踪（类 Claude Code）：把 Agent 已完成的步骤按时间顺序列出（工具选择 / 判读 / 收尾），
- * 末尾在 Agent 自身 LLM 思考时补一条带计时的「思考中」行。计时按**单个步骤**——每步用各自时长
- * （上一步结束→本步），当前思考从上一步结束起算，绝非总任务累计。
- * `thinking`：Agent 自身 LLM 正在跑（无 pr-agent 工具 run 占用）——工具执行的进度/计时由 run 卡片
- * 负责，故工具步骤这里不再重复计时，只列出选择。
+ * 实时「思考中」指示：仅在 Agent 自身 LLM 正在推理（无工具 run 占用 / 排队）时挂载。计时随挂载
+ * 从零起算 = 当前这步的思考时长（非总任务累计）；下一步产生 / 转入工具执行即卸载、计时归零。
+ * 首行布局与已完成步骤对齐：spinner 充当进行中的 bullet 标记，「思考中」后紧贴计时。
  */
-function AgentActivity({
-  steps,
-  since,
-  thinking,
-}: {
-  steps: AgentStep[];
-  since: number | null;
-  thinking: boolean;
-}) {
+function ThinkingLive() {
   const { t } = useTranslation();
+  const startRef = useRef<number>(Date.now());
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    if (!thinking) return;
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
-  }, [thinking]);
-
-  const stamps = steps.map((s) => (s.at ? new Date(s.at).getTime() : null));
-  const stepMs = (i: number): number | null => {
-    const end = stamps[i];
-    const start = i > 0 ? stamps[i - 1] : since;
-    return end != null && start != null ? Math.max(0, end - start) : null;
-  };
-  const lastStamp = stamps.length ? stamps[stamps.length - 1] : since;
-  const liveMs = thinking && lastStamp != null ? Math.max(0, now - lastStamp) : 0;
-
+  }, []);
   return (
-    <div className="chat-agent-activity" role="status">
-      {steps.map((s, i) => (
-        <div key={i} className="chat-agent-activity-item">
-          <span className="chat-agent-activity-kind">{stepLabel(s, t)}</span>
-          {s.thought && <span className="chat-agent-activity-thought">{s.thought}</span>}
-          {s.kind === 'judge' && s.result && (
-            <span className="chat-agent-activity-result muted">{s.result}</span>
-          )}
-          {/* 工具步骤的耗时由 run 卡片展示（并行更准）；这里只给推理步骤（判读 / 收尾）计时。 */}
-          {s.kind !== 'tool' && stepMs(i) != null && (
-            <span className="chat-agent-activity-time">{formatElapsed(stepMs(i)!)}</span>
-          )}
-        </div>
-      ))}
-      {thinking && (
-        <div className="chat-agent-activity-item chat-agent-activity-live">
-          <Spinner />
-          <span className="chat-agent-activity-thought">{t('chatPane.agent.thinking')}</span>
-          <span className="chat-agent-activity-time">{formatElapsed(liveMs)}</span>
-        </div>
-      )}
+    <div className="chat-agent-step" role="status">
+      <div className="chat-agent-step-head">
+        <Spinner />
+        <span>
+          {t('chatPane.agent.thinking')} {formatElapsed(Math.max(0, now - startRef.current))}
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -1465,6 +1465,33 @@ function Md({ children }: { children: string }) {
 }
 
 /**
+ * 代码路径折行优化：在分隔符 `/` 与连接符 `.` `_` `-` 之后插入 <wbr> 软断点，配合 CSS
+ * `word-break: normal`，让长路径优先按这些字符折断（而非从单词中间断开），保证可读性。
+ */
+function BreakablePath({ path }: { path: string }) {
+  const parts = path.split(/(?<=[/._-])/);
+  const nodes: ReactNode[] = [];
+  parts.forEach((p, i) => {
+    nodes.push(p);
+    if (i < parts.length - 1) nodes.push(<wbr key={`wbr-${i}`} />);
+  });
+  return <>{nodes}</>;
+}
+
+/** 行内 markdown：用于标题等单行文本，渲染内联代码 / 强调，去掉块级 <p> 包裹保持行内排版。 */
+function MdInline({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={REMOTE_REHYPE_PLUGINS}
+      components={{ p: ({ children }) => <>{children}</> }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+/**
  * 一条多轮对话消息的展示：用户 → 右对齐气泡；助手评审类（带 recommendation）→「评审总结」卡片 +
  * 判定徽标；助手对话类（无 recommendation）→ 左对齐专属对话回复包装。
  */
@@ -2237,7 +2264,9 @@ function FindingCard({
           <span className={`chat-finding-cat chat-finding-cat-${key}`}>{label}</span>
         )}
         {showTitle && translatedTitle && !collapsed && (
-          <h4 className="chat-finding-title">{translatedTitle}</h4>
+          <h4 className="chat-finding-title">
+            <MdInline>{translatedTitle}</MdInline>
+          </h4>
         )}
         {/* 已拒绝才出现的展开 / 收起切换：chevron 图标，收起态指右、展开态转下，纯图标交互 */}
         {isRejected && (
@@ -2261,7 +2290,9 @@ function FindingCard({
               onClick={onNavigate}
               title={t('chatPane.anchorJumpTitle')}
             >
-              <code>{finding.anchor.path}</code>
+              <code>
+                <BreakablePath path={finding.anchor.path} />
+              </code>
               <span>
                 :{finding.anchor.startLine}
                 {finding.anchor.endLine && finding.anchor.endLine !== finding.anchor.startLine
@@ -2271,7 +2302,9 @@ function FindingCard({
             </button>
           ) : (
             <>
-              <code>{finding.anchor.path}</code>
+              <code>
+                <BreakablePath path={finding.anchor.path} />
+              </code>
               {finding.anchor.startLine && (
                 <span>
                   :{finding.anchor.startLine}

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -179,35 +179,50 @@ export function ChatPane({
   const myActiveIdSet = new Set(myActiveRuns.map((a) => a.runId));
   const visibleRuns = hasMyActive ? runs.filter((r) => !myActiveIdSet.has(r.id)) : runs;
 
-  // 历史时间线：把 run 卡片、Agent 的思考步骤、对话消息按时间归并，让过程性步骤按自然时间顺序
-  // 穿插展示（而非堆在末尾）。类 Claude Code「先思考→定步骤→执行步骤」：思考步骤（plan/judge）
-  // 是工具选择的前因，排在所选工具的 run 卡片之前；工具执行的进度 / 计时由 run 卡片承载，不重复。
+  // 历史时间线：把已完成 run、正在执行的 run、Agent 思考步骤、对话消息统一按**启动时间**归并排序，
+  // 顺序固定——即便后启动的任务先完成，也排在先启动（仍在执行）的任务下方，不因完成先后跳序。
+  // 类 Claude Code「先思考→定步骤→执行步骤」：思考步骤（plan/judge）是工具选择的前因，排在所选工具的
+  // run 卡片之前；工具执行的进度 / 计时由 run 卡片承载，不重复。排队中（未启动）的任务不入此列，另置末尾。
+  type ActiveRun = (typeof myActiveRuns)[number];
   const timeline = useMemo(() => {
-    const runEntries = visibleRuns.map((r) => ({
-      key: `run-${r.id}`,
-      time: r.startedAt,
-      run: r as ReviewRun | null,
+    const ms = (iso: string | null | undefined): number => {
+      const n = iso ? new Date(iso).getTime() : NaN;
+      return Number.isFinite(n) ? n : 0;
+    };
+    const base = {
+      run: null as ReviewRun | null,
+      active: null as ActiveRun | null,
       step: null as AgentStep | null,
       message: null as AgentMessage | null,
+    };
+    const runEntries = visibleRuns.map((r) => ({
+      ...base,
+      key: `run-${r.id}`,
+      sortTime: ms(r.startedAt),
+      run: r as ReviewRun | null,
+    }));
+    const activeEntries = myActiveRuns.map((a) => ({
+      ...base,
+      key: `active-${a.runId}`,
+      sortTime: ms(a.startedAt ?? a.enqueuedAt),
+      active: a,
     }));
     const stepEntries = agentSteps.map((s, i) => ({
+      ...base,
       key: `step-${i}-${s.at ?? ''}`,
-      time: s.at ?? '',
-      run: null,
+      sortTime: ms(s.at),
       step: s as AgentStep | null,
-      message: null as AgentMessage | null,
     }));
     const msgEntries = messages.map((m, i) => ({
+      ...base,
       key: `msg-${i}-${m.at}`,
-      time: m.at,
-      run: null,
-      step: null as AgentStep | null,
+      sortTime: ms(m.at),
       message: m,
     }));
-    return [...runEntries, ...stepEntries, ...msgEntries].sort((a, b) =>
-      a.time.localeCompare(b.time),
+    return [...runEntries, ...activeEntries, ...stepEntries, ...msgEntries].sort(
+      (a, b) => a.sortTime - b.sortTime,
     );
-  }, [visibleRuns, agentSteps, messages]);
+  }, [visibleRuns, myActiveRuns, agentSteps, messages]);
 
   // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
   // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
@@ -688,26 +703,25 @@ export function ChatPane({
               onRejectFinding={handleRejectFinding}
               onNavigateToFinding={handleNavigateToFinding}
             />
+          ) : entry.active ? (
+            // 正在跑：进度条 + 实时 stdout 流，按启动时间穿插在时间线里（startedAt 入队时为 null、
+            // 起跑时设值，fallback enqueuedAt）。prAgent 未就绪时不渲染。
+            prAgent.available ? (
+              <RunningView
+                key={entry.key}
+                tool={entry.active.tool}
+                runId={entry.active.runId}
+                lines={linesByRunId.get(entry.active.runId) ?? []}
+                startedAt={new Date(entry.active.startedAt ?? entry.active.enqueuedAt).getTime()}
+                model={currentLlmModel ?? null}
+              />
+            ) : null
           ) : entry.step ? (
             <AgentStepRow key={entry.key} step={entry.step} />
           ) : entry.message ? (
             <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
         )}
-        {/* 正在跑（可并发多条）：每条一个进度条 + 实时 stdout 流，贴在历史末尾。
-            startedAt 入队时为 null，executeRun 真正起跑时设值；窗口非常短一般看不到
-            — fallback 到 enqueuedAt */}
-        {prAgent.available &&
-          myActiveRuns.map((r) => (
-            <RunningView
-              key={r.runId}
-              tool={r.tool}
-              runId={r.runId}
-              lines={linesByRunId.get(r.runId) ?? []}
-              startedAt={new Date(r.startedAt ?? r.enqueuedAt).getTime()}
-              model={currentLlmModel ?? null}
-            />
-          ))}
         {/* 本 PR 排队中的任务：贴在运行中之后，按队列顺序展示，可单条取消 */}
         {myWaiting.map((w, i) => (
           <QueuedView

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -598,10 +598,11 @@ export function SettingsModal({
                 便于直接查看 / 编辑文件）。放在标题行而非配置行，避免与下方的目录选择按钮混淆。 */}
             <div className="modal-section-head">
               <h4>{t('settings.agentDirTitle')}</h4>
-              {/* 文案按钮（非图标）：与下方的目录「选择」图标按钮区分开，避免混淆。 */}
+              {/* 文案按钮（非图标）：与下方的目录「选择」图标按钮区分开，避免混淆。尺寸与其它区块标题行
+                  的操作按钮（添加连接 / 添加配置 / 代理配置）一致，统一用 btn-sm。 */}
               <button
                 type="button"
-                className="btn btn-primary"
+                className="btn btn-primary btn-sm"
                 onClick={() => void invoke('app:openAgentDir', undefined)}
                 title={t('settings.openAgentDir')}
               >

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -594,7 +594,20 @@ export function SettingsModal({
           </section>
 
           <section className="modal-section">
-            <h4>{t('settings.agentDirTitle')}</h4>
+            {/* 标题行：左侧标题 + 右侧蓝色「打开当前目录」按钮（在系统文件管理器打开生效的 Agent 目录，
+                便于直接查看 / 编辑文件）。放在标题行而非配置行，避免与下方的目录选择按钮混淆。 */}
+            <div className="modal-section-head">
+              <h4>{t('settings.agentDirTitle')}</h4>
+              {/* 文案按钮（非图标）：与下方的目录「选择」图标按钮区分开，避免混淆。 */}
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => void invoke('app:openAgentDir', undefined)}
+                title={t('settings.openAgentDir')}
+              >
+                {t('settings.openAgentDir')}
+              </button>
+            </div>
             <p className="muted" style={{ margin: '0 0 8px' }}>
               {t('settings.agentDirHint')}
             </p>

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -130,7 +130,7 @@
     "statusRunning": "Läuft",
     "statusSucceeded": "Fertig",
     "stopAria": "Stoppen",
-    "stopTitle": "Aktuellen PR-Agent-Lauf beenden (SIGKILL)",
+    "stopTitle": "Ausführung stoppen",
     "tokensTitle": "Eingabe (prompt) {{prompt}} · Ausgabe (completion) {{completion}} Tokens",
     "unknownCommand": "Unbekannter Befehl {{head}}; unterstützt: {{cmds}}",
     "userQuestionAria": "Benutzerfrage",

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -15,9 +15,12 @@
   },
   "chatPane": {
     "agent": {
+      "activityDone": "Fertig · {{n}} Schritte",
       "autoReview": "Auto-Review",
       "autoReviewRunning": "Wird geprüft…",
       "failed": "Agent-Review fehlgeschlagen",
+      "stepJudge": "Bewertung",
+      "stepPlan": "Abschluss",
       "summaryTitle": "Prüfzusammenfassung",
       "thinking": "Denkt nach…",
       "verdictApprove": "Sieht gut aus",

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -18,10 +18,9 @@
       "autoReview": "Auto-Review",
       "autoReviewRunning": "Wird geprüft…",
       "failed": "Agent-Review fehlgeschlagen",
-      "stepJudge": "Bewertung",
-      "stepPlan": "Abschluss",
       "summaryTitle": "Prüfzusammenfassung",
       "thinking": "Denkt nach…",
+      "thoughtFor": "{{time}} nachgedacht",
       "verdictApprove": "Sieht gut aus",
       "verdictManualReview": "Manuelle Prüfung",
       "verdictNeedsWork": "Nachbesserung nötig"

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -596,6 +596,7 @@
     "llmHint": "Das aktive Profil bestimmt, welches Modell PR Agent aufruft.",
     "llmProfileFallback": "Profil {{id}}",
     "llmTitle": "LLM-Modelle",
+    "openAgentDir": "Aktuelles Verzeichnis öffnen",
     "openDevTools": "DevTools öffnen",
     "openDevToolsTitle": "Electron DevTools öffnen (separates Fenster)",
     "opening": "Öffne…",

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -556,7 +556,7 @@
     "addConnectionTitle": "Verbindung hinzufügen",
     "addLlmProfile": "+ Profil hinzufügen",
     "addLlmTitle": "LLM-Modell hinzufügen",
-    "agentDirHint": "Enthält SOUL.md / AGENTS.md / MEMORY.md / USER.md und einen rules/-Unterordner (Review-Regeln).",
+    "agentDirHint": "Speicherort für Persona, Gedächtnis und Review-Regeln des Agents; bleibt über Sitzungen erhalten und ist teamweit teilbar.",
     "agentDirPlaceholder": "Optional; z. B. ~/code/team-agent",
     "agentDirTitle": "Agent-Verzeichnis",
     "appRoot": "App-Root",

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -15,7 +15,6 @@
   },
   "chatPane": {
     "agent": {
-      "activityDone": "Fertig · {{n}} Schritte",
       "autoReview": "Auto-Review",
       "autoReviewRunning": "Wird geprüft…",
       "failed": "Agent-Review fehlgeschlagen",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -18,10 +18,9 @@
       "autoReview": "Auto Review",
       "autoReviewRunning": "Reviewing…",
       "failed": "Agent review failed",
-      "stepJudge": "judge",
-      "stepPlan": "wrap-up",
       "summaryTitle": "Review Summary",
       "thinking": "Thinking…",
+      "thoughtFor": "Thought for {{time}}",
       "verdictApprove": "Looks good",
       "verdictManualReview": "Manual review",
       "verdictNeedsWork": "Needs work"

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -15,7 +15,6 @@
   },
   "chatPane": {
     "agent": {
-      "activityDone": "Done · {{n}} steps",
       "autoReview": "Auto Review",
       "autoReviewRunning": "Reviewing…",
       "failed": "Agent review failed",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -130,7 +130,7 @@
     "statusRunning": "Running",
     "statusSucceeded": "Done",
     "stopAria": "Stop",
-    "stopTitle": "Terminate the current PR Agent run (SIGKILL)",
+    "stopTitle": "Stop execution",
     "tokensTitle": "Input (prompt) {{prompt}} · Output (completion) {{completion}} tokens",
     "unknownCommand": "Unknown command {{head}}; supported: {{cmds}}",
     "userQuestionAria": "User question",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -596,6 +596,7 @@
     "llmHint": "The active profile determines which model PR Agent calls.",
     "llmProfileFallback": "Profile {{id}}",
     "llmTitle": "LLM Models",
+    "openAgentDir": "Open current directory",
     "openDevTools": "Open DevTools",
     "openDevToolsTitle": "Open Electron DevTools (detached window)",
     "opening": "Opening…",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -556,7 +556,7 @@
     "addConnectionTitle": "Add Connection",
     "addLlmProfile": "+ Add Profile",
     "addLlmTitle": "Add LLM Model",
-    "agentDirHint": "Holds SOUL.md / AGENTS.md / MEMORY.md / USER.md and a rules/ subdir (review rules).",
+    "agentDirHint": "Holds the agent's persona, memory, and review rules; persists across sessions and can be shared by a team.",
     "agentDirPlaceholder": "Optional; e.g. ~/code/team-agent",
     "agentDirTitle": "Agent Directory",
     "appRoot": "App Root",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -15,9 +15,12 @@
   },
   "chatPane": {
     "agent": {
+      "activityDone": "Done · {{n}} steps",
       "autoReview": "Auto Review",
       "autoReviewRunning": "Reviewing…",
       "failed": "Agent review failed",
+      "stepJudge": "judge",
+      "stepPlan": "wrap-up",
       "summaryTitle": "Review Summary",
       "thinking": "Thinking…",
       "verdictApprove": "Looks good",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -15,7 +15,6 @@
   },
   "chatPane": {
     "agent": {
-      "activityDone": "完了 · {{n}} ステップ",
       "autoReview": "自動レビュー",
       "autoReviewRunning": "レビュー中…",
       "failed": "Agent レビューに失敗しました",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -18,10 +18,9 @@
       "autoReview": "自動レビュー",
       "autoReviewRunning": "レビュー中…",
       "failed": "Agent レビューに失敗しました",
-      "stepJudge": "判定",
-      "stepPlan": "まとめ",
       "summaryTitle": "レビュー総括",
       "thinking": "思考中…",
+      "thoughtFor": "{{time}} 思考",
       "verdictApprove": "問題なし",
       "verdictManualReview": "手動レビュー推奨",
       "verdictNeedsWork": "要修正"

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -15,9 +15,12 @@
   },
   "chatPane": {
     "agent": {
+      "activityDone": "完了 · {{n}} ステップ",
       "autoReview": "自動レビュー",
       "autoReviewRunning": "レビュー中…",
       "failed": "Agent レビューに失敗しました",
+      "stepJudge": "判定",
+      "stepPlan": "まとめ",
       "summaryTitle": "レビュー総括",
       "thinking": "思考中…",
       "verdictApprove": "問題なし",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -581,6 +581,7 @@
     "llmHint": "アクティブなプロファイルが、PR Agent の呼び出すモデルを決定します。",
     "llmProfileFallback": "プロファイル {{id}}",
     "llmTitle": "LLM モデル",
+    "openAgentDir": "現在のディレクトリを開く",
     "openDevTools": "DevTools を開く",
     "openDevToolsTitle": "Electron DevTools を開く（分離ウィンドウ）",
     "opening": "オープン中…",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -541,7 +541,7 @@
     "addConnectionTitle": "接続を追加",
     "addLlmProfile": "+ プロファイルを追加",
     "addLlmTitle": "LLM モデルを追加",
-    "agentDirHint": "SOUL.md / AGENTS.md / MEMORY.md / USER.md と rules/ サブディレクトリ（レビュールール）を格納します。",
+    "agentDirHint": "Agent の人格・記憶・レビュールールの保存先。セッションをまたいで保持され、チームで共有できます。",
     "agentDirPlaceholder": "任意；例：~/code/team-agent",
     "agentDirTitle": "Agent ディレクトリ",
     "appRoot": "アプリルート",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -130,7 +130,7 @@
     "statusRunning": "実行中",
     "statusSucceeded": "完了",
     "stopAria": "停止",
-    "stopTitle": "現在の PR Agent 実行を強制終了 (SIGKILL)",
+    "stopTitle": "実行を停止",
     "tokensTitle": "入力(prompt) {{prompt}} · 出力(completion) {{completion}} トークン",
     "unknownCommand": "不明なコマンド {{head}}。サポート対象：{{cmds}}",
     "userQuestionAria": "ユーザーの質問",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -130,7 +130,7 @@
     "statusRunning": "运行中",
     "statusSucceeded": "完成",
     "stopAria": "停止",
-    "stopTitle": "终止当前 PR Agent 调用 (SIGKILL)",
+    "stopTitle": "停止执行",
     "tokensTitle": "输入(prompt) {{prompt}} · 输出(completion) {{completion}} tokens",
     "unknownCommand": "未知命令 {{head}}；支持：{{cmds}}",
     "userQuestionAria": "用户提问",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -15,7 +15,6 @@
   },
   "chatPane": {
     "agent": {
-      "activityDone": "已完成 · {{n}} 步",
       "autoReview": "自动评审",
       "autoReviewRunning": "评审中…",
       "failed": "Agent 评审失败",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -581,6 +581,7 @@
     "llmHint": "选择活跃配置决定 PR Agent 调用哪个模型。",
     "llmProfileFallback": "配置 {{id}}",
     "llmTitle": "LLM 模型",
+    "openAgentDir": "打开当前目录",
     "openDevTools": "打开 DevTools",
     "openDevToolsTitle": "打开 Electron 开发者工具（分离窗口）",
     "opening": "打开中…",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -18,10 +18,9 @@
       "autoReview": "自动评审",
       "autoReviewRunning": "评审中…",
       "failed": "Agent 评审失败",
-      "stepJudge": "判读",
-      "stepPlan": "收尾",
       "summaryTitle": "评审总结",
       "thinking": "思考中…",
+      "thoughtFor": "已思考 {{time}}",
       "verdictApprove": "建议通过",
       "verdictManualReview": "建议人工复核",
       "verdictNeedsWork": "建议修改"

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -15,9 +15,12 @@
   },
   "chatPane": {
     "agent": {
+      "activityDone": "已完成 · {{n}} 步",
       "autoReview": "自动评审",
       "autoReviewRunning": "评审中…",
       "failed": "Agent 评审失败",
+      "stepJudge": "判读",
+      "stepPlan": "收尾",
       "summaryTitle": "评审总结",
       "thinking": "思考中…",
       "verdictApprove": "建议通过",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -541,7 +541,7 @@
     "addConnectionTitle": "新增连接",
     "addLlmProfile": "+ 添加配置",
     "addLlmTitle": "新增 LLM 模型",
-    "agentDirHint": "存放 SOUL.md / AGENTS.md / MEMORY.md / USER.md 与 rules/ 子目录（评审规则）。",
+    "agentDirHint": "存放 Agent 的人设、记忆与评审规则；跨会话持久，可团队共享。",
     "agentDirPlaceholder": "可选；如 ~/code/team-agent",
     "agentDirTitle": "Agent 目录",
     "appRoot": "应用根",

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -226,24 +226,27 @@
 // 首行 + 另起的步骤结果次行。无底色 / 无边框（思考态不加蓝色背景）；实时「思考中」首行以 spinner 充当
 // 进行中的 bullet，计时紧贴提示之后。
 .chat-agent-step {
-  margin: $space-2 $space-6;
+  margin: $space-2 $space-6 $space-2 $space-1; // 左缩进收到最小，让 bullet 视觉尽量靠前
   font-size: $fs-sm;
 }
 // 首行：bullet / spinner 标记 + 「已思考 / 思考中 xx s」提示，计时紧贴文本（不撑开到行尾）。
+// bullet 占固定列宽、与文案间留 gap 间距；正文按「列宽 + gap」缩进，保证首行文案与正文左对齐。
 .chat-agent-step-head {
   display: flex;
   align-items: center;
-  gap: $space-2;
+  gap: $space-3; // bullet 与文案之间的留白
   color: $text-muted;
 }
 .chat-agent-step-bullet {
+  flex: 0 0 $space-3; // 固定 bullet 列宽，文本对齐的基准
   color: $color-info;
+  font-size: $fs-md; // 略大，标记更醒目
   line-height: 1;
 }
-// 次行：步骤结果（思考内容 / 判读结论），缩进对齐到首行文本之下。
+// 次行：步骤结果（思考内容 / 判读结论），缩进到首行文案的左缘（= bullet 列宽 + gap）对齐。
 .chat-agent-step-body {
   margin-top: $space-1;
-  padding-left: $space-4;
+  padding-left: $space-3 + $space-3;
   color: $text-body;
   word-break: break-word;
 

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -222,18 +222,67 @@
   word-break: break-word;
 }
 
-// Agent 自身 LLM 调用（规划 / 判读 / 收尾）期间的「思考中」指示：spinner + 文案。
-.chat-agent-thinking {
+// 过程化跟踪（类 Claude Code）：可折叠活动条 + 逐步列表 + 单步计时。左侧强调色竖条与 run 卡片区分。
+.chat-agent-activity {
   margin: $space-3 $space-6;
+  border-left: 2px solid $color-accent;
+  background: $color-accent-bg-fade;
+  border-radius: 0 $radius-sm $radius-sm 0;
+}
+.chat-agent-activity-head {
   display: flex;
   align-items: center;
   gap: $space-3;
+  width: 100%;
+  padding: $space-2 $space-4;
+  background: transparent;
+  border: none;
   color: $text-muted;
   font-size: $fs-sm;
+  text-align: left;
+  cursor: pointer;
+
+  .rot {
+    transform: rotate(90deg); // chevron ▸ → ▾（展开态）
+  }
 }
-.chat-agent-thinking-elapsed {
+.chat-agent-activity-title {
+  flex: 1;
+  min-width: 0;
+}
+.chat-agent-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 $space-4 $space-2 $space-6;
+  display: flex;
+  flex-direction: column;
+  gap: $space-2;
+}
+.chat-agent-activity-item {
+  display: flex;
+  align-items: baseline;
+  gap: $space-3;
+  font-size: $fs-sm;
+}
+.chat-agent-activity-kind {
+  font-family: $font-mono;
+  color: $color-info;
+  flex-shrink: 0;
+}
+.chat-agent-activity-thought {
+  flex: 1;
+  min-width: 0;
+  color: $text-body;
+  word-break: break-word;
+}
+.chat-agent-activity-result {
+  flex-shrink: 0;
+}
+.chat-agent-activity-time {
   font-family: $font-mono;
   font-variant-numeric: tabular-nums;
+  color: $text-muted;
+  flex-shrink: 0;
 }
 
 // Agent 自然对话回复：左对齐、带 Agent 图标的轻量包装，区别于「评审总结」卡片（无判定 / 无标题）。
@@ -258,28 +307,6 @@
   min-width: 0;
 }
 
-// Agent 元步骤内联标记：在时间线中按自然时间顺序穿插的决策节点（judge 判读）。
-// 左侧一道强调色竖条，与 run 卡片区分但保持同一缩进。
-.chat-agent-step-marker {
-  margin: $space-3 $space-6;
-  padding: $space-2 $space-4;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: $space-3;
-  font-size: $fs-sm;
-  border-left: 2px solid $color-accent;
-  background: $color-accent-bg-fade;
-  border-radius: 0 $radius-sm $radius-sm 0;
-}
-.chat-agent-step-thought {
-  color: $text-body;
-}
-.chat-agent-step-result {
-  font-weight: 600;
-  color: $color-info;
-  white-space: pre-wrap;
-}
 
 // === 空态 ===
 .chat-empty {

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -918,8 +918,11 @@
     border-radius: $radius-sm;
     font-family: $font-mono;
     color: $text-body;
-    // path 单段太长 (含 / 路径) 时允许在任意字符断行，不让单 code 块撑爆容器
-    word-break: break-all;
+    // 长路径优先按分隔符 / 连接符折断（BreakablePath 在 / . _ - 后插了 <wbr> 软断点）：
+    // word-break:normal 让浏览器只在这些软断点（及空格 / CJK）处折行，保证可读性；overflow-wrap:anywhere
+    // 仅作兜底——单个分段仍超宽时才允许任意断开，且让 code 作为 flex item 能正常收缩不撑爆容器。
+    word-break: normal;
+    overflow-wrap: anywhere;
     min-width: 0;
   }
 }

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -222,43 +222,34 @@
   word-break: break-word;
 }
 
-// 过程化跟踪（类 Claude Code）：纯文本逐步列表 + 单步计时，按时间顺序。无底色 / 无边框（思考态
-// 不加蓝色背景）；末尾思考中行带 spinner + 实时单步计时。
-.chat-agent-activity {
-  margin: $space-3 $space-6;
-  display: flex;
-  flex-direction: column;
-  gap: $space-2;
-}
-.chat-agent-activity-item {
-  display: flex;
-  align-items: baseline;
-  gap: $space-3;
+// 过程化跟踪（类 Claude Code）：思考步骤按时间穿插进时间线。两行——带 bullet 标记的「已思考 xx s」
+// 首行 + 另起的步骤结果次行。无底色 / 无边框（思考态不加蓝色背景）；实时「思考中」首行以 spinner 充当
+// 进行中的 bullet，计时紧贴提示之后。
+.chat-agent-step {
+  margin: $space-2 $space-6;
   font-size: $fs-sm;
+}
+// 首行：bullet / spinner 标记 + 「已思考 / 思考中 xx s」提示，计时紧贴文本（不撑开到行尾）。
+.chat-agent-step-head {
+  display: flex;
+  align-items: center;
+  gap: $space-2;
   color: $text-muted;
 }
-.chat-agent-activity-live {
-  align-items: center; // spinner 与文字垂直居中
-}
-.chat-agent-activity-kind {
-  font-family: $font-mono;
+.chat-agent-step-bullet {
   color: $color-info;
-  flex-shrink: 0;
+  line-height: 1;
 }
-.chat-agent-activity-thought {
-  flex: 1;
-  min-width: 0;
+// 次行：步骤结果（思考内容 / 判读结论），缩进对齐到首行文本之下。
+.chat-agent-step-body {
+  margin-top: $space-1;
+  padding-left: $space-4;
   color: $text-body;
   word-break: break-word;
-}
-.chat-agent-activity-result {
-  flex-shrink: 0;
-}
-.chat-agent-activity-time {
-  font-family: $font-mono;
-  font-variant-numeric: tabular-nums;
-  color: $text-muted;
-  flex-shrink: 0;
+
+  &.muted {
+    color: $text-muted;
+  }
 }
 
 // Agent 自然对话回复：左对齐、带 Agent 图标的轻量包装，区别于「评审总结」卡片（无判定 / 无标题）。

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -222,38 +222,10 @@
   word-break: break-word;
 }
 
-// 过程化跟踪（类 Claude Code）：可折叠活动条 + 逐步列表 + 单步计时。左侧强调色竖条与 run 卡片区分。
+// 过程化跟踪（类 Claude Code）：纯文本逐步列表 + 单步计时，按时间顺序。无底色 / 无边框（思考态
+// 不加蓝色背景）；末尾思考中行带 spinner + 实时单步计时。
 .chat-agent-activity {
   margin: $space-3 $space-6;
-  border-left: 2px solid $color-accent;
-  background: $color-accent-bg-fade;
-  border-radius: 0 $radius-sm $radius-sm 0;
-}
-.chat-agent-activity-head {
-  display: flex;
-  align-items: center;
-  gap: $space-3;
-  width: 100%;
-  padding: $space-2 $space-4;
-  background: transparent;
-  border: none;
-  color: $text-muted;
-  font-size: $fs-sm;
-  text-align: left;
-  cursor: pointer;
-
-  .rot {
-    transform: rotate(90deg); // chevron ▸ → ▾（展开态）
-  }
-}
-.chat-agent-activity-title {
-  flex: 1;
-  min-width: 0;
-}
-.chat-agent-activity-list {
-  list-style: none;
-  margin: 0;
-  padding: 0 $space-4 $space-2 $space-6;
   display: flex;
   flex-direction: column;
   gap: $space-2;
@@ -263,6 +235,10 @@
   align-items: baseline;
   gap: $space-3;
   font-size: $fs-sm;
+  color: $text-muted;
+}
+.chat-agent-activity-live {
+  align-items: center; // spinner 与文字垂直居中
 }
 .chat-agent-activity-kind {
   font-family: $font-mono;

--- a/apps/desktop/src/renderer/src/styles/modal.scss
+++ b/apps/desktop/src/renderer/src/styles/modal.scss
@@ -369,8 +369,8 @@ select.settings-input {
   display: flex;
   flex-direction: column;
   gap: $space-3;
-  // 最多展示约 4 行，超出滚动
-  max-height: 236px;
+  // 最多展示约 4.5 行：露出半行提示下方还有内容、可滚动，避免漏看（4 行整高会被误以为到底）
+  max-height: 266px;
   overflow-y: auto;
 }
 .llm-profile-row {

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -148,8 +148,9 @@ export async function runReviewMicroflow(
   let usage: TokenUsage = {};
 
   const record = async (step: AgentStep): Promise<void> => {
-    steps.push(step);
-    await deps.onStep?.(step);
+    const stamped = { ...step, at: step.at ?? new Date().toISOString() };
+    steps.push(stamped);
+    await deps.onStep?.(stamped);
   };
 
   // base system context（工具目录留空：微流程不暴露自由工具选择）
@@ -164,17 +165,24 @@ export async function runReviewMicroflow(
   // 1. describe + review（固定两步，并行——彼此独立、都只读 PR，无先后依赖；
   //    实际并发度受运行队列 max_concurrency 约束，串行执行时结果同样正确）。
   //    错开 100~200ms 起跑，避免两个工具同一瞬间齐发。
+  //    类 Claude Code：先把所选步骤作为一步流式出去（思考在前），工具执行的进度 / 计时由 run 卡片承载，
+  //    不再为每个工具补记 tool 步，避免决策被堆到结果之后。
+  await record({
+    kind: 'plan',
+    thought: '生成 PR 描述与审查发现',
+    toolCall: { tool: 'describe、review' },
+  });
   const [describe, review] = await runStaggered(
     [{ tool: 'describe' as const }, { tool: 'review' as const }],
     (c) => deps.runTool(c),
   );
   usage = addUsage(usage, describe.usage);
-  await record({ kind: 'tool', toolCall: { tool: '/describe' }, result: clamp(describe.text, 400) });
   usage = addUsage(usage, review.usage);
-  await record({ kind: 'tool', toolCall: { tool: '/review' }, result: clamp(review.text, 400) });
 
   // 2. 仅严重问题条件性追问
+  const judgeStart = Date.now();
   const judge = await deps.chat({ system, user: judgePrompt(review.text, maxAsks) });
+  const judgeMs = Date.now() - judgeStart;
   usage = addUsage(usage, judge.usage);
   const verdict = extractJson<{ severe?: boolean; questions?: string[] }>(judge.text);
   const questions = verdict?.severe ? (verdict.questions ?? []).slice(0, maxAsks) : [];
@@ -182,6 +190,7 @@ export async function runReviewMicroflow(
     kind: 'judge',
     thought: '判断是否存在需追问的严重问题',
     result: questions.length ? `严重，追问 ${String(questions.length)} 个` : '无严重问题，不追问',
+    thinkMs: judgeMs,
   });
 
   const askResults: string[] = [];
@@ -189,18 +198,15 @@ export async function runReviewMicroflow(
     const ask = await deps.runTool({ tool: 'ask', question: q });
     usage = addUsage(usage, ask.usage);
     askResults.push(`Q: ${q}\nA: ${ask.text}`);
-    await record({
-      kind: 'tool',
-      toolCall: { tool: '/ask', args: { question: q } },
-      result: clamp(ask.text, 300),
-    });
   }
 
   // 3. 收尾总结 + 建议
+  const sumStart = Date.now();
   const sum = await deps.chat({
     system,
     user: summaryPrompt(describe.text, review.text, askResults, summaryMax),
   });
+  const sumMs = Date.now() - sumStart;
   usage = addUsage(usage, sum.usage);
   const parsed = extractJson<{
     summary?: string;
@@ -215,7 +221,12 @@ export async function runReviewMicroflow(
             typeof parsed.recommendation.reason === 'string' ? parsed.recommendation.reason : '',
         }
       : { verdict: 'manual_review', reason: '无法解析建议，转人工复核' };
-  await record({ kind: 'plan', thought: '收尾总结', result: summary });
+  await record({
+    kind: 'plan',
+    thought: '综合描述与审查发现，生成评审总结',
+    result: summary,
+    thinkMs: sumMs,
+  });
 
   return { steps, summary, recommendation, tokenUsage: usage };
 }

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -77,22 +77,97 @@ function clamp(s: string, max: number): string {
   return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
 }
 
-/** 从 LLM 文本里抽第一个 JSON 对象（容 ```json``` 围栏 + 裸文本），失败返回 null。 */
+/** 把 JSON 串字面量内部未转义的裸控制符（换行/回车/制表）补转义。LLM 常把多行 markdown 原样塞进
+ *  字符串值而不转义换行，使 JSON.parse 失败——这一步修复该常见错误（不改字符串外的结构）。 */
+function escapeRawControlInStrings(s: string): string {
+  let out = '';
+  let inStr = false;
+  let escaped = false;
+  for (const ch of s) {
+    if (escaped) {
+      out += ch;
+      escaped = false;
+    } else if (ch === '\\') {
+      out += ch;
+      escaped = true;
+    } else if (ch === '"') {
+      inStr = !inStr;
+      out += ch;
+    } else if (inStr && (ch === '\n' || ch === '\r' || ch === '\t')) {
+      out += ch === '\n' ? '\\n' : ch === '\r' ? '\\r' : '\\t';
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+/** 从 LLM 文本里抽第一个 JSON 对象（容 ```json``` 围栏 + 裸文本），失败返回 null。
+ *  对每个候选先按原样解析，失败再补转义裸换行重试，兜住模型多行字符串不转义的常见情况。 */
 export function extractJson<T>(text: string): T | null {
   const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
   for (const c of [fence?.[1], text]) {
     if (!c) continue;
     const start = c.indexOf('{');
     const end = c.lastIndexOf('}');
-    if (start >= 0 && end > start) {
+    if (start < 0 || end <= start) continue;
+    const slice = c.slice(start, end + 1);
+    for (const candidate of [slice, escapeRawControlInStrings(slice)]) {
       try {
-        return JSON.parse(c.slice(start, end + 1)) as T;
+        return JSON.parse(candidate) as T;
       } catch {
-        /* 试下一个候选 */
+        /* 试下一个候选 / 下一种转义 */
       }
     }
   }
   return null;
+}
+
+/**
+ * 去掉模型误并入 summary / final 末尾的判定 JSON（```json {...}``` 围栏或裸对象，仅当含
+ * recommendation/verdict 字样才删），避免原始 JSON 暴露给用户。recommendation 走独立字段渲染为判定徽标。
+ */
+export function stripTrailingJson(s: string): string {
+  let out = s.trimEnd();
+  // 末尾围栏代码块（```json {...}```）
+  out = out
+    .replace(/\s*```(?:json)?\s*\{[\s\S]*?\}\s*```\s*$/i, (m) =>
+      /"(?:recommendation|verdict)"\s*:/.test(m) ? '' : m,
+    )
+    .trimEnd();
+  // 末尾裸 JSON 对象：以末尾 } 为锚按花括号配平反找到匹配的起始 {，界定整个尾部对象（非最内层 {）。
+  if (out.endsWith('}')) {
+    let depth = 0;
+    let start = -1;
+    for (let i = out.length - 1; i >= 0; i--) {
+      const ch = out[i];
+      if (ch === '}') depth++;
+      else if (ch === '{' && --depth === 0) {
+        start = i;
+        break;
+      }
+    }
+    if (start >= 0 && /"(?:recommendation|verdict)"\s*:/.test(out.slice(start))) {
+      out = out.slice(0, start).trimEnd();
+    }
+  }
+  return out;
+}
+
+/**
+ * 兜底打捞人类可读散文：当 JSON 动作解析失败（截断 / 引号未转义等无法恢复时），从原始文本里用宽松
+ * 正则捞出 `final` / `summary` 字段值并反转义，绝不把原始 JSON 动作丢给用户当回答。捞不到才退回原文。
+ */
+export function salvageProse(raw: string): string {
+  const m = raw.match(/"(?:final|summary)"\s*:\s*"((?:\\.|[^"\\])*)"?/);
+  if (m?.[1]) {
+    try {
+      return JSON.parse(`"${m[1]}"`) as string;
+    } catch {
+      return m[1];
+    }
+  }
+  return raw.trim();
 }
 
 function judgePrompt(reviewText: string, maxAsks: number): string {
@@ -109,19 +184,42 @@ function judgePrompt(reviewText: string, maxAsks: number): string {
   ].join('\n');
 }
 
+/** 评审总结的统一三段式骨架标题（按语言本地化，缺省回落英文）：固定结构 → 输出稳定、可预期。
+ *  顺序固定为 概述 / 关键发现 / 建议。 */
+const SUMMARY_SECTIONS: Record<string, readonly [string, string, string]> = {
+  'zh-CN': ['摘要', '关键发现', '建议'],
+  'en-US': ['Summary', 'Key findings', 'Suggestions'],
+  'ja-JP': ['概要', '主な指摘', '提案'],
+  'de-DE': ['Zusammenfassung', 'Wichtige Erkenntnisse', 'Empfehlungen'],
+};
+export function summarySections(language?: string): readonly [string, string, string] {
+  return SUMMARY_SECTIONS[language ?? 'en-US'] ?? SUMMARY_SECTIONS['en-US']!;
+}
+
 function summaryPrompt(
   describeText: string,
   reviewText: string,
   askResults: string[],
   maxChars: number,
+  sections: readonly [string, string, string],
 ): string {
+  const [overview, findings, suggestions] = sections;
   return [
-    'Write a STRICTLY short closing summary of this pre-review for the human reviewer',
-    `(at most ${String(maxChars)} characters; compress, do not truncate key points).`,
-    'Include the key points, risks, and a non-binding recommendation.',
-    'Format for readability: use newlines (\\n) to separate sections; lead with the core change,',
-    'then list each key risk on its own line prefixed with "- ". Keep lines short.',
+    'Write a closing review summary for the human reviewer, in the SAME LANGUAGE as the review findings',
+    `(at most ${String(maxChars)} characters; compress, never truncate key points).`,
+    'Use EXACTLY this markdown skeleton — these three "## " sections, in this order, and nothing else.',
+    'Keep each line short; put every finding / suggestion on its own "- " bullet:',
     '',
+    `## ${overview}`,
+    '<one short paragraph: the core change and overall risk level>',
+    `## ${findings}`,
+    '<each key finding or risk on its own "- " bullet; if genuinely none, write a single line saying so>',
+    `## ${suggestions}`,
+    '<each actionable suggestion on its own "- " bullet>',
+    '',
+    'Put that markdown (with literal \\n newlines) into "summary"; give a separate non-binding recommendation.',
+    'NEVER repeat the recommendation / verdict inside "summary" itself (no trailing JSON block) — it goes',
+    'ONLY in the separate "recommendation" field.',
     'Reply with JSON only:',
     '{"summary": string, "recommendation": {"verdict": "approve"|"needs_work"|"manual_review", "reason": string}}',
     '',
@@ -204,7 +302,13 @@ export async function runReviewMicroflow(
   const sumStart = Date.now();
   const sum = await deps.chat({
     system,
-    user: summaryPrompt(describe.text, review.text, askResults, summaryMax),
+    user: summaryPrompt(
+      describe.text,
+      review.text,
+      askResults,
+      summaryMax,
+      summarySections(input.language),
+    ),
   });
   const sumMs = Date.now() - sumStart;
   usage = addUsage(usage, sum.usage);
@@ -212,7 +316,8 @@ export async function runReviewMicroflow(
     summary?: string;
     recommendation?: { verdict?: unknown; reason?: unknown };
   }>(sum.text);
-  const summary = clamp(parsed?.summary ?? sum.text, summaryMax);
+  // 解析失败兜底：从原始文本捞 summary 散文；再剥掉模型误并入末尾的判定 JSON，绝不把原始 JSON 展示给用户。
+  const summary = clamp(stripTrailingJson(parsed?.summary ?? salvageProse(sum.text)), summaryMax);
   const recommendation: AgentRecommendation =
     parsed?.recommendation && isVerdict(parsed.recommendation.verdict)
       ? {

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -34,6 +34,8 @@ export interface ReviewOrchestratorDeps {
   chat(input: { system: string; user: string }): Promise<ToolText>;
   /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
   onStep?(step: AgentStep): void | Promise<void>;
+  /** 用户停止：每步边界检查，已 abort 即抛 `用户暂停` 中止微流程（思考阶段也能立即终止）。 */
+  signal?: AbortSignal;
 }
 
 export interface ReviewOrchestratorInput {
@@ -251,6 +253,11 @@ export async function runReviewMicroflow(
     await deps.onStep?.(stamped);
   };
 
+  // 用户停止：每个步骤边界检查，已 abort 即抛 `用户暂停`（思考阶段也能立即中止，不必等当前工具跑完）。
+  const checkAbort = (): void => {
+    if (deps.signal?.aborted) throw new Error('用户暂停');
+  };
+
   // base system context（工具目录留空：微流程不暴露自由工具选择）
   const system = assembleSystemContext({
     context: input.context,
@@ -265,6 +272,7 @@ export async function runReviewMicroflow(
   //    错开 100~200ms 起跑，避免两个工具同一瞬间齐发。
   //    类 Claude Code：先把所选步骤作为一步流式出去（思考在前），工具执行的进度 / 计时由 run 卡片承载，
   //    不再为每个工具补记 tool 步，避免决策被堆到结果之后。
+  checkAbort();
   await record({
     kind: 'plan',
     thought: '生成 PR 描述与审查发现',
@@ -278,6 +286,7 @@ export async function runReviewMicroflow(
   usage = addUsage(usage, review.usage);
 
   // 2. 仅严重问题条件性追问
+  checkAbort();
   const judgeStart = Date.now();
   const judge = await deps.chat({ system, user: judgePrompt(review.text, maxAsks) });
   const judgeMs = Date.now() - judgeStart;
@@ -293,12 +302,14 @@ export async function runReviewMicroflow(
 
   const askResults: string[] = [];
   for (const q of questions) {
+    checkAbort();
     const ask = await deps.runTool({ tool: 'ask', question: q });
     usage = addUsage(usage, ask.usage);
     askResults.push(`Q: ${q}\nA: ${ask.text}`);
   }
 
   // 3. 收尾总结 + 建议
+  checkAbort();
   const sumStart = Date.now();
   const sum = await deps.chat({
     system,

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -214,8 +214,9 @@ export async function runPlanningAgent(
   })}\n\n---\n\n# Protocol\n\n${PROTOCOL}`;
 
   const record = async (step: AgentStep): Promise<void> => {
-    steps.push(step);
-    await deps.onStep?.(step);
+    const stamped = { ...step, at: step.at ?? new Date().toISOString() };
+    steps.push(stamped);
+    await deps.onStep?.(stamped);
   };
 
   // 既往多轮对话注入规划上下文（按预算裁剪），让 Agent 跨轮记住交流；仅供规划 LLM 参考，
@@ -238,7 +239,10 @@ export async function runPlanningAgent(
       .filter(Boolean)
       .join('\n');
 
+    // 计本轮 LLM 推理耗时（单步思考时长，类 Claude Code 的「Thought for Ns」），系到该决策步上。
+    const thinkStart = Date.now();
     const r = await deps.chat({ system, user });
+    const thinkMs = Date.now() - thinkStart;
     usage = addUsage(usage, r.usage);
     const action = extractJson<PlannerAction>(r.text);
     // 累加本动作携带的记忆（任何动作都可附 remember）。
@@ -249,12 +253,12 @@ export async function runPlanningAgent(
     // 无法解析 / 既无 tool(s) 又无 final → 当作收尾（原文兜底）。
     if (!action || (!hasCalls && !action.final)) {
       const finalText = action?.final ?? r.text.trim();
-      await record({ kind: 'plan', thought: action?.thought, result: finalText });
+      await record({ kind: 'plan', thought: action?.thought, result: finalText, thinkMs });
       return { steps, finalText, tokenUsage: usage, memories };
     }
 
     if (action.final && !hasCalls) {
-      await record({ kind: 'plan', thought: action.thought, result: action.final });
+      await record({ kind: 'plan', thought: action.thought, result: action.final, thinkMs });
       return {
         steps,
         finalText: action.final,
@@ -283,18 +287,19 @@ export async function runPlanningAgent(
     }
     if (!allowed.length) continue; // 全被拒 → 回喂后下一轮重选
 
-    // 并行分发允许的工具（多选时同时跑，实际并发受运行队列约束）；相互错开 100~200ms 起跑，
-    // 避免同一瞬间齐发。thought 只系在首条，避免重复。
+    // 类 Claude Code：先把本轮思考与所选步骤作为一步流式出去（思考是工具选择的前因），随后才执行工具。
+    // 工具执行的进度 / 计时由 run 卡片承载，这里不再为每个工具补记 tool 步，避免决策被堆到结果之后。
+    await record({
+      kind: 'plan',
+      thought: action.thought,
+      toolCall: { tool: allowed.map((c) => c.tool).join('、') },
+      thinkMs,
+    });
+
+    // 并行分发允许的工具（多选时同时跑，实际并发受运行队列约束）；相互错开 100~200ms 起跑，避免同一瞬间齐发。
     const ran = await runStaggered(allowed, async (c) => ({ c, res: await deps.runTool(c) }));
-    for (let k = 0; k < ran.length; k++) {
-      const { c, res } = ran[k]!;
+    for (const { c, res } of ran) {
       usage = addUsage(usage, res.usage);
-      await record({
-        kind: 'tool',
-        thought: k === 0 ? action.thought : undefined,
-        toolCall: { tool: c.tool, args: c.question ? { question: c.question } : undefined },
-        result: clamp(res.text, 400),
-      });
       history.push(
         `Called ${c.tool}${c.question ? ` ("${c.question}")` : ''} → ${clamp(res.text, 600)}`,
       );

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -253,6 +253,10 @@ export async function runPlanningAgent(
     const thinkStart = Date.now();
     const r = await deps.chat({ system, user });
     const thinkMs = Date.now() - thinkStart;
+    // 思考刚结束就发现已被停止 → 立即收尾，不再据此动作分发工具（停止在思考阶段也即时生效）。
+    if (deps.signal?.aborted) {
+      return { steps, finalText: '', tokenUsage: usage, memories, terminationReason: '用户暂停' };
+    }
     usage = addUsage(usage, r.usage);
     const action = extractJson<PlannerAction>(r.text);
     // 累加本动作携带的记忆（任何动作都可附 remember）。

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -8,7 +8,7 @@ import type {
   ToolCatalogEntry,
 } from '@meebox/shared';
 import { assembleSystemContext, type AssemblePrMeta } from './assemble.js';
-import { extractJson } from './orchestrator.js';
+import { extractJson, salvageProse, stripTrailingJson, summarySections } from './orchestrator.js';
 import { runStaggered } from './stagger.js';
 import { assertToolAllowed } from './tool-catalog.js';
 import type { AgentContext } from './types.js';
@@ -163,37 +163,47 @@ function buildConversationContext(history: readonly AgentMessage[]): string {
   return lines.reverse().join('\n');
 }
 
-const PROTOCOL = [
-  'Each turn, reply with JSON ONLY for the next action:',
-  '- One tool:   {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
-  '- Several read-only tools AT ONCE (run in parallel, at most 3): {"thought": "...", "tools": ["/describe", "/review"]}',
-  '- Finish:     {"thought": "...", "final": "<your answer to the user>"}',
-  'Only call tools listed under "Available tools" that are NOT disabled. Prefer few precise steps,',
-  'but when the request needs multiple independent read-only tools (e.g. summary AND review), call',
-  'them together via "tools" so they run in parallel instead of one per turn. Use "tool"+"question"',
-  'for /ask (single only).',
-  'Closing a CODE REVIEW: when your final answer reviews this PR, you MUST follow this fixed shape —',
-  'format "final" as markdown with these sections in order: "## 摘要" (PR summary), "## 关键发现"',
-  '(must-fix / concerns as a bulleted list, empty-safe), "## 建议" (next steps); AND include a',
-  '"recommendation" object: {"verdict": "approve"|"needs_work"|"manual_review", "reason": "<one line>"}.',
-  'verdict is non-binding (no write action). Omit "recommendation" for non-review answers.',
-  'Memory: persist useful, stable, NON-private facts across sessions via a "remember" object on your',
-  'action, grouped by target file (short notes in the user\'s language):',
-  '  {"remember": {"user": ["称呼: Kyle"], "memory": ["repo uses g-<id> for gray apps"], "agents": ["..."]}}',
-  '- user   → the person you talk to: preferred 称呼, language, review/working habits & preferences.',
-  '- memory → durable knowledge about this project / repo (facts that help future reviews).',
-  '- agents → working norms / review conventions you should keep following (append-only).',
-  'NEVER record private or sensitive data: real identity beyond a chosen 称呼, email / phone / address,',
-  'employer-confidential specifics, secrets / tokens. When unsure whether something is private, do NOT',
-  'record it. Only remember when there is something genuinely worth persisting — omit otherwise.',
-  'Conversation & scope:',
-  '- Natural conversation is fine: greet, say who you are, ask a clarifying question — answer directly',
-  '  in "final" without calling tools.',
-  '- Your domain is reviewing THIS PR (describing it, reviewing its changes, answering questions about',
-  '  them). Politely DECLINE in "final" any task OUTSIDE that domain (unrelated coding, general/off-topic',
-  '  requests) — do NOT call tools for it.',
-  '- For a PR-related request with no clearly fitting tool, default to /ask with a focused question.',
-].join('\n');
+function buildProtocol(sections: readonly [string, string, string]): string {
+  const [overview, findings, suggestions] = sections;
+  return [
+    'Each turn, reply with JSON ONLY for the next action:',
+    '- One tool:   {"thought": "...", "tool": "/review", "question": "<only for /ask>"}',
+    '- Several read-only tools AT ONCE (run in parallel, at most 3): {"thought": "...", "tools": ["/describe", "/review"]}',
+    '- Finish:     {"thought": "...", "final": "<your answer to the user>"}',
+    'Only call tools listed under "Available tools" that are NOT disabled. Prefer few precise steps,',
+    'but when the request needs multiple independent read-only tools (e.g. summary AND review), call',
+    'them together via "tools" so they run in parallel instead of one per turn. Use "tool"+"question"',
+    'for /ask (single only).',
+    'Closing a CODE REVIEW: when your final answer reviews this PR, you MUST follow this fixed shape —',
+    `format "final" as markdown with these sections in order: "## ${overview}" (PR summary), "## ${findings}"`,
+    `(must-fix / concerns as a bulleted list, empty-safe), "## ${suggestions}" (next steps); AND include a`,
+    '"recommendation" object: {"verdict": "approve"|"needs_work"|"manual_review", "reason": "<one line>"}.',
+    'verdict is non-binding (no write action). Omit "recommendation" for non-review answers.',
+    'NEVER repeat the recommendation / verdict inside "final" itself (no trailing JSON block) — it goes',
+    'ONLY in the separate "recommendation" field.',
+    'Memory: persisting is RARE and OPT-IN. Most turns have NOTHING to remember — then OMIT "remember"',
+    'entirely. Use a "remember" object only for a fact that will matter ACROSS MANY FUTURE, UNRELATED',
+    'reviews, grouped by target file (short notes in the user\'s language):',
+    '  {"remember": {"user": ["称呼: Kyle"], "memory": ["repo uses g-<id> for gray apps"], "agents": ["..."]}}',
+    '- user   → the person you talk to: preferred 称呼, language, lasting review/working preferences.',
+    '- memory → durable PROJECT facts (stable architecture / conventions / IDs that outlive any one PR).',
+    '- agents → general working norms you should always follow (e.g. reply language, review order).',
+    'HARD BAR — do NOT record findings or heuristics tied to THIS PR or a specific feature / module /',
+    'symbol: e.g. "评审涉及 X 时重点核对 Y", "注意 fn() 对数字 ID 误判". Those are this review\'s OUTPUT,',
+    'not durable rules — putting them in agents/memory pollutes future behavior. If a note names a specific',
+    'function / field / feature / scenario, it is a finding, NOT a memory — keep it in the review, omit here.',
+    'When in doubt, do NOT record. Over a whole session you should rarely write more than a note or two.',
+    'NEVER record private or sensitive data: real identity beyond a chosen 称呼, email / phone / address,',
+    'employer-confidential specifics, secrets / tokens. When unsure whether something is private, do NOT record.',
+    'Conversation & scope:',
+    '- Natural conversation is fine: greet, say who you are, ask a clarifying question — answer directly',
+    '  in "final" without calling tools.',
+    '- Your domain is reviewing THIS PR (describing it, reviewing its changes, answering questions about',
+    '  them). Politely DECLINE in "final" any task OUTSIDE that domain (unrelated coding, general/off-topic',
+    '  requests) — do NOT call tools for it.',
+    '- For a PR-related request with no clearly fitting tool, default to /ask with a focused question.',
+  ].join('\n');
+}
 
 export async function runPlanningAgent(
   deps: PlanningDeps,
@@ -211,7 +221,7 @@ export async function runPlanningAgent(
     toolCatalog: input.toolCatalog,
     matchedRule: input.matchedRule,
     language: input.language,
-  })}\n\n---\n\n# Protocol\n\n${PROTOCOL}`;
+  })}\n\n---\n\n# Protocol\n\n${buildProtocol(summarySections(input.language))}`;
 
   const record = async (step: AgentStep): Promise<void> => {
     const stamped = { ...step, at: step.at ?? new Date().toISOString() };
@@ -250,18 +260,20 @@ export async function runPlanningAgent(
 
     const hasCalls = Boolean(action?.tool) || Boolean(action?.tools?.length);
 
-    // 无法解析 / 既无 tool(s) 又无 final → 当作收尾（原文兜底）。
+    // 无法解析 / 既无 tool(s) 又无 final → 当作收尾。兜底从原始文本打捞散文，绝不把原始 JSON 动作丢给用户。
     if (!action || (!hasCalls && !action.final)) {
-      const finalText = action?.final ?? r.text.trim();
+      const finalText = action?.final ?? salvageProse(r.text);
       await record({ kind: 'plan', thought: action?.thought, result: finalText, thinkMs });
       return { steps, finalText, tokenUsage: usage, memories };
     }
 
     if (action.final && !hasCalls) {
-      await record({ kind: 'plan', thought: action.thought, result: action.final, thinkMs });
+      // 剥掉模型误并入 final 末尾的判定 JSON（recommendation 走独立字段渲染为判定徽标）。
+      const finalText = stripTrailingJson(action.final);
+      await record({ kind: 'plan', thought: action.thought, result: finalText, thinkMs });
       return {
         steps,
-        finalText: action.final,
+        finalText,
         tokenUsage: usage,
         recommendation: parseRecommendation(action.recommendation),
         memories,

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { extractJson, runReviewMicroflow } from '../src/orchestrator.js';
+import {
+  extractJson,
+  runReviewMicroflow,
+  salvageProse,
+  stripTrailingJson,
+} from '../src/orchestrator.js';
 import type { ReviewOrchestratorDeps } from '../src/orchestrator.js';
 import type { AgentContext } from '../src/types.js';
 
@@ -34,6 +39,41 @@ describe('extractJson', () => {
     expect(extractJson<{ a: number }>('```json\n{"a":1}\n```')).toEqual({ a: 1 });
     expect(extractJson<{ a: number }>('noise {"a":2} tail')).toEqual({ a: 2 });
     expect(extractJson('no json here')).toBeNull();
+  });
+
+  it('recovers JSON with unescaped raw newlines inside string values', () => {
+    // 模型常把多行 markdown 原样塞进字符串值、不转义换行——补转义后应能解析。
+    const raw = '{"final": "## 摘要\n\n第一行\n第二行", "recommendation": {"verdict": "needs_work"}}';
+    const parsed = extractJson<{ final: string; recommendation: { verdict: string } }>(raw);
+    expect(parsed?.final).toBe('## 摘要\n\n第一行\n第二行');
+    expect(parsed?.recommendation.verdict).toBe('needs_work');
+  });
+});
+
+describe('salvageProse', () => {
+  it('extracts the final/summary prose from an unparseable JSON action', () => {
+    // 截断（无闭合 } / 引号）时仍捞出散文，绝不把原始 JSON 丢给用户。
+    const truncated = '{"thought":"t","final":"## 摘要\\n\\n本 PR 修复了空值崩溃';
+    expect(salvageProse(truncated)).toBe('## 摘要\n\n本 PR 修复了空值崩溃');
+    expect(salvageProse('{"summary":"all good"}')).toBe('all good');
+  });
+
+  it('falls back to trimmed raw text when no prose field is present', () => {
+    expect(salvageProse('  just text  ')).toBe('just text');
+  });
+});
+
+describe('stripTrailingJson', () => {
+  it('strips a trailing recommendation JSON block the model wrongly appended', () => {
+    const fenced = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n```json\n{"recommendation": {"verdict": "needs_work"}}\n```';
+    expect(stripTrailingJson(fenced)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
+    const bare = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n{\n  "recommendation": {"verdict": "approve"}\n}';
+    expect(stripTrailingJson(bare)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
+  });
+
+  it('leaves legitimate trailing JSON / braces untouched', () => {
+    const code = '说明：配置形如 `{ "port": 8080 }`，按需调整。';
+    expect(stripTrailingJson(code)).toBe(code);
   });
 });
 

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -48,7 +48,9 @@ describe('runReviewMicroflow', () => {
     const r = await runReviewMicroflow(deps, { context, pr });
 
     expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review']);
-    expect(r.steps.map((s) => s.kind)).toEqual(['tool', 'tool', 'judge', 'plan']);
+    // 类 Claude Code：一条思考步（plan，承载 describe+review 选择）→ judge → 收尾 plan；
+    // describe/review/ask 的执行由 run 卡片代表、不再补记 tool 步。
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'judge', 'plan']);
     expect(r.summary).toBe('all good');
     expect(r.recommendation).toEqual({ verdict: 'approve', reason: 'no issues' });
     // usage accumulated: 2 tools (10 each) + 2 chats (5 each) = 30
@@ -66,8 +68,7 @@ describe('runReviewMicroflow', () => {
     const r = await runReviewMicroflow(deps, { context, pr, maxFollowupAsks: 2 });
 
     const askCalls = toolCalls.filter((c) => c.tool === 'ask');
-    expect(askCalls.map((c) => c.question)).toEqual(['q1', 'q2']); // capped at 2
-    expect(r.steps.filter((s) => s.toolCall?.tool === '/ask')).toHaveLength(2);
+    expect(askCalls.map((c) => c.question)).toEqual(['q1', 'q2']); // capped at 2（执行经 runTool / run 卡片）
     expect(r.recommendation.verdict).toBe('needs_work');
   });
 
@@ -100,6 +101,6 @@ describe('runReviewMicroflow', () => {
       seen.push(step.kind);
     };
     await runReviewMicroflow(deps, { context, pr });
-    expect(seen).toEqual(['tool', 'tool', 'judge', 'plan']);
+    expect(seen).toEqual(['plan', 'judge', 'plan']);
   });
 });

--- a/packages/agent/tests/planner.test.ts
+++ b/packages/agent/tests/planner.test.ts
@@ -43,7 +43,9 @@ describe('runPlanningAgent', () => {
     });
     expect(toolCalls.map((c) => c.tool)).toEqual(['/review']);
     expect(r.finalText).toBe('LGTM');
-    expect(r.steps.map((s) => s.kind)).toEqual(['tool', 'plan']);
+    // 类 Claude Code：每回合一条思考步（plan）承载本轮工具选择；工具执行由 run 卡片代表、不再补记 tool 步。
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'plan']);
+    expect(r.steps[0]?.toolCall?.tool).toBe('/review');
     expect(r.tokenUsage.totalTokens).toBe(20); // 2 chat(5) + 1 tool(10)
   });
 
@@ -59,8 +61,9 @@ describe('runPlanningAgent', () => {
       userRequest: 'summary and review',
     });
     expect(toolCalls.map((c) => c.tool)).toEqual(['/describe', '/review']);
-    // 两个工具步骤 + 收尾 plan
-    expect(r.steps.map((s) => s.kind)).toEqual(['tool', 'tool', 'plan']);
+    // 一条思考步（plan，承载并行所选工具）+ 收尾 plan；工具执行由 run 卡片代表。
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'plan']);
+    expect(r.steps[0]?.toolCall?.tool).toBe('/describe、/review');
     expect(r.finalText).toBe('done');
   });
 

--- a/packages/poller/src/parse-output.ts
+++ b/packages/poller/src/parse-output.ts
@@ -179,12 +179,31 @@ function mapSectionKey(displayTitle: string): PrDocSectionKey | undefined {
  *   pr-agent 把问题回显在答案文本里是冗余的
  */
 const SKIP_TITLES = new Set(['user description']);
-const SKIP_TITLES_ASK = new Set(['question', 'questions', '问题']);
+const ASK_QUESTION_HEADERS = new Set(['ask', 'question', 'questions', '问题', '提问']);
+const ASK_ANSWER_HEADERS = new Set(['answer', 'answers', '回答', '答案', '解答']);
+
+/**
+ * /ask 输出里的结构性表头判别：pr-agent 把「Ask ❓」「回答:」这类标题段回显出来，对 UI 是冗余的
+ * （提问已在上方气泡展示、答案紧跟其下）。先剥首尾的 emoji / 标点 / 空格再按集合匹配。
+ */
+function askHeaderKind(title: string): 'question' | 'answer' | null {
+  const t = normalizeTitle(title)
+    .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '')
+    .toLowerCase();
+  if (ASK_QUESTION_HEADERS.has(t)) return 'question';
+  if (ASK_ANSWER_HEADERS.has(t)) return 'answer';
+  return null;
+}
 
 function shouldSkipSection(sec: Section, tool: ReviewRunTool): boolean {
   const t = normalizeTitle(sec.title).toLowerCase();
   if (SKIP_TITLES.has(t)) return true;
-  if (tool === 'ask' && SKIP_TITLES_ASK.has(t)) return true;
+  if (tool === 'ask') {
+    const kind = askHeaderKind(sec.title);
+    // 「Ask ❓」等问题回显段整段剔除；空的「回答」表头段（仅标题无正文）同样剔除。
+    if (kind === 'question') return true;
+    if (kind === 'answer' && !trimNoise(sec.body).trim()) return true;
+  }
   // title 含内部分支名 (e.g., "meebox/head" / "meebox/head 🔍" / "## meebox/head")
   if (INTERNAL_BRANCH_RE.test(t)) return true;
   // trimNoise 把首尾的 HR / 分支名 leak 剥掉后，body 空 = 整段都是噪音
@@ -500,8 +519,11 @@ function inferAnchorFromIssueText(text: string): FindingAnchor | undefined {
 export function sectionToFinding(sec: Section, index: number, tool: ReviewRunTool): Finding {
   const id = `${tool}-${String(index).padStart(3, '0')}`;
   const body = trimNoise(sec.body);
-  const displayTitle = normalizeTitle(sec.title) || undefined;
-  const mappedKey = displayTitle ? mapSectionKey(displayTitle) : undefined;
+  const rawTitle = normalizeTitle(sec.title) || undefined;
+  const mappedKey = rawTitle ? mapSectionKey(rawTitle) : undefined;
+  // /ask：带正文的「回答 / Answer」表头是冗余的（其下就是答案正文）→ 清掉标题只留正文。
+  const displayTitle =
+    tool === 'ask' && askHeaderKind(sec.title) === 'answer' ? undefined : rawTitle;
 
   // pr-agent 0.36.0 review 输出形如 (pr-agent 自定义 prompt 或非 LocalGitProvider 时)：
   //   **File:** src/foo.ts

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -44,6 +44,9 @@ export interface AgentStep {
   result?: string;
   /** 步骤产生时间（ISO）。 */
   at?: string;
+  /** 本步思考（产生该决策的单次 LLM 推理）耗时（毫秒）；类 Claude Code 的「Thought for Ns」单步计时。
+   *  仅推理类步骤（plan/judge）有值；固定派发（如微流程的 describe/review 选择）无 LLM 思考则缺省。 */
+  thinkMs?: number;
 }
 
 export type AgentRecommendationVerdict = 'approve' | 'needs_work' | 'manual_review';

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -161,6 +161,8 @@ export interface IpcChannels {
   'app:prAgentStatus': { request: void; response: PrAgentStatus };
   /** 调 Electron shell.openPath 让 OS 默认编辑器打开 config.yaml */
   'app:openConfigFile': { request: void; response: void };
+  /** 调 shell.openPath 在系统文件管理器打开当前生效的 Agent 目录（不存在则先建）。 */
+  'app:openAgentDir': { request: void; response: void };
   /** 打开 Electron DevTools（分离窗口） */
   'app:openDevTools': { request: void; response: void };
   /** 手动检测版本更新（设置页「检查更新」）。仅检测 + 返回结果，不下载 / 安装。 */

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -436,6 +436,11 @@ export interface IpcChannels {
    */
   'agent:getConversation': { request: { localId: string }; response: AgentMessage[] };
   /**
+   * 读取指定 PR 已落盘的 Agent 过程步骤（transcript，按时间升序）；无则空数组。
+   * UI 据此恢复「过程化跟踪」的思考步骤——跨 PR 切换 / 重启后不丢失（步骤随产生增量落盘）。
+   */
+  'agent:getTranscript': { request: { localId: string }; response: AgentStep[] };
+  /**
    * 批量读 AutoPilot 台账：返回各 PR 已自动评审的 recommendation（仅 decision=review 且有
    * 建议者）。PR 列表据此显示徽标，无需逐个加载会话。
    */


### PR DESCRIPTION
## 背景

针对三点反馈：① 看不到 Agent 的思考 / 工具选择与过程输出；② agent 对话执行缺后台日志；③ 计时显示的是总任务累计而非单个步骤（如「思考中 3m 19s」）。目标是类 Claude Code 的「Thought for Ns + 逐步骤」过程化跟踪。

## 变更

### UI：过程化跟踪活动条（AgentActivity）
- 把 Agent 的逐步**工具选择 / 判读 / 收尾**流式列成**可折叠活动条**，取代原先只显示 judge 的内联标记 + 裸「思考中」指示。
- 每条：步骤标签（`/describe`·`/review`·判读·收尾）+ 思考摘要 +（judge 结论）+ **单步用时**。
- 计时改为**按单个步骤**——当前思考从「上一步结束」起算、每步完成后各自冻结，不再累计总任务时长。
- 仅作用于**当前 PR**（不串会话）；过程步骤从时间线移除、统一收进活动条。

### 后台日志
- 每个编排步骤经 `emitAgentStep` 统一落一条 `agent step`（kind / tool / thought / result，截断防刷屏）。
- `agent:run` / `agent:ask` 各加 start / done 日志（status / steps / 终止原因）。

## 验证
- `typecheck` / `lint` / `build` 通过。四语 i18n 同步（activityDone / stepJudge / stepPlan）。

## 已知后续（非本 PR）
- 活动条 live-only（PR 切走重置，不随会话持久化）；如需「Thought for Ns」长期留存，可后续加载 transcript。
- 并行多工具步骤（describe+review 同时 Promise.all）各自 per-step 用时近似（后完成者 ≈ 0），墙钟落在首条。