### PR TITLE
feat(desktop): 收敛重型组件加载抖动，统一延迟 loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   `http://localhost:11434/v1`）：Ollama 自带 OpenAI 兼容端点，走此路径更标准稳健。旧 `ollama` 配置
   加载时**自动迁移**为 `openai-compatible` 并补足 `/v1`，存量无感升级。
 - `openai-compatible` 经实测标记为**已验证**。
+- **重型组件加载抖动收敛**：切换 PR / 文件时，diff（Monaco）、聊天会话内容等重型区域在
+  异步初始化完成前统一盖一层居中 loading，就绪后一次性 reveal，消除「空白 → 内容弹出 → 折叠跳一下」
+  的多段重排。loading 延迟显示（>150ms 才出现）——本地缓存命中的快切换零闪烁，仅真慢场景才落到
+  loading。Monaco 区域特别处理：从挂载第一帧即盖遮罩、并等折叠（hideUnchangedRegions）布局 paint
+  稳定后才揭开，遮罩底色与编辑器一致、揭开无缝。
 
 ### Fixed
 - 修复 Windows 控制台中文日志仍显示为乱码：① dev 下 electron-vite 把 main 的 stdout 接成管道

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -33,6 +33,7 @@ import {
   TrashIcon,
 } from './icons';
 import { ConfirmModal } from './ConfirmModal';
+import { PaneLoading } from './Loading';
 import { mermaidComponents } from './markdownMermaid';
 import { REMOTE_REHYPE_PLUGINS } from '../markdown';
 import { useChatRunStore } from '../stores/chat-run-store';
@@ -145,6 +146,9 @@ export function ChatPane({
   const [runs, setRuns] = useState<ReviewRun[]>([]);
   const [hasMoreOlder, setHasMoreOlder] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  // 切 PR 时初次拉取（runs / 规则 / 会话 / transcript）在飞标志：期间盖延迟 loading，
+  // 避免「清空 → 空白 → 内容 pop-in」的抖动。延迟显示让快路径（缓存命中）零闪烁。
+  const [loadingSession, setLoadingSession] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // 当前 PR 命中的规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
   const [matchedRule, setMatchedRule] = useState<MatchedRule>(null);
@@ -262,8 +266,10 @@ export function ChatPane({
     setMatchedRule(null);
     setAgentSteps([]);
     setMessages([]);
+    setLoadingSession(false);
     if (!prLocalId) return;
     let cancelled = false;
+    setLoadingSession(true);
     void (async () => {
       try {
         // listRuns 默认返回 newest-first；这里只拉最新一页 (RUNS_PAGE_SIZE)。
@@ -284,6 +290,8 @@ export function ChatPane({
         setAgentSteps(transcript);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoadingSession(false);
       }
     })();
     return () => {
@@ -394,7 +402,10 @@ export function ChatPane({
     if (!pr || !prAgent.available || !llmConfigured) return;
     // 去重（即时反馈）：同一 PR 同一工具已在执行 / 排队 → 阻止重复触发（main 端亦有
     // 权威校验兜底）。/ask 每次问题不同，不限制。
-    if (tool !== 'ask' && (myActiveRuns.some((r) => r.tool === tool) || myWaiting.some((w) => w.tool === tool))) {
+    if (
+      tool !== 'ask' &&
+      (myActiveRuns.some((r) => r.tool === tool) || myWaiting.some((w) => w.tool === tool))
+    ) {
       setError(t('chatPane.duplicateRun', { tool }));
       return;
     }
@@ -452,7 +463,10 @@ export function ChatPane({
     const startedId = pr.localId;
     setError(null);
     setAgentSteps([]);
-    setMessages((prev) => [...prev, { role: 'user', content: question, at: new Date().toISOString() }]);
+    setMessages((prev) => [
+      ...prev,
+      { role: 'user', content: question, at: new Date().toISOString() },
+    ]);
     setRunningPrs((m) => new Map(m).set(startedId, Date.now()));
     try {
       const session = await invoke('agent:ask', { localId: startedId, question });
@@ -529,10 +543,7 @@ export function ChatPane({
 
   const handleJumpToDraft = async (finding: Finding, run: ReviewRun): Promise<void> => {
     if (!pr) return;
-    if (
-      !finding.anchor ||
-      typeof finding.anchor.startLine !== 'number'
-    ) {
+    if (!finding.anchor || typeof finding.anchor.startLine !== 'number') {
       return; // 没 anchor 行号 → 没法变 inline，按钮本不该出现，兜底
     }
     const startLine = finding.anchor.startLine;
@@ -687,9 +698,13 @@ export function ChatPane({
       )}
 
       <div className="chat-pane-body" ref={bodyRef}>
+        {/* 初次拉取会话期间盖延迟 loading（>150ms 才显），遮住「清空 → 内容 pop-in」抖动；
+            加载完成才落到下方的真实空态，避免空 PR 误显 loading。 */}
+        {loadingSession && <PaneLoading />}
         {/* 使用提示仅在「全无会话内容」时显示：一旦有用户输入气泡 / run / 步骤 / 收尾结果，
             或 Agent 正在运行 / 有排队任务，即隐藏，避免输入后仍残留提示。 */}
-        {timeline.length === 0 &&
+        {!loadingSession &&
+          timeline.length === 0 &&
           !agentRunningHere &&
           !hasMyActive &&
           myWaiting.length === 0 && (
@@ -838,13 +853,37 @@ type CommandSpec =
 // 分组顺序：pr-agent 工具 → 分隔线 → review 决断
 const COMMANDS: ReadonlyArray<CommandSpec> = [
   // pr-agent
-  { kind: 'pragent', name: 'review', label: '/review', descKey: 'chatPane.cmdReviewDesc', insertAs: '/review' },
-  { kind: 'pragent', name: 'describe', label: '/describe', descKey: 'chatPane.cmdDescribeDesc', insertAs: '/describe' },
+  {
+    kind: 'pragent',
+    name: 'review',
+    label: '/review',
+    descKey: 'chatPane.cmdReviewDesc',
+    insertAs: '/review',
+  },
+  {
+    kind: 'pragent',
+    name: 'describe',
+    label: '/describe',
+    descKey: 'chatPane.cmdDescribeDesc',
+    insertAs: '/describe',
+  },
   // /improve：shim 强制 gfm_markdown=True 后，improve 走「汇总建议 → publish_comment →
   // review.md」路径（非 committable，inline 模式仍不可用），parse-output 按
   // generate_summarized_suggestions 的 <details> 模板解析出带重要度评分的 finding。
-  { kind: 'pragent', name: 'improve', label: '/improve', descKey: 'chatPane.cmdImproveDesc', insertAs: '/improve' },
-  { kind: 'pragent', name: 'ask', label: '/ask', descKey: 'chatPane.cmdAskDesc', insertAs: '/ask ' },
+  {
+    kind: 'pragent',
+    name: 'improve',
+    label: '/improve',
+    descKey: 'chatPane.cmdImproveDesc',
+    insertAs: '/improve',
+  },
+  {
+    kind: 'pragent',
+    name: 'ask',
+    label: '/ask',
+    descKey: 'chatPane.cmdAskDesc',
+    insertAs: '/ask ',
+  },
   // review 决断 (跟 PR header 按钮共用 prs:setLocalStatus，写 Bitbucket reviewer status)
   {
     kind: 'review-action',
@@ -1019,10 +1058,7 @@ function ChatInputBar({
   const trimmed = input.trim();
   // `/` 开头 + 命令名还没敲完整 (没空格) → 显示候选；已为当前 input dismiss 过则隐藏
   const showAutocomplete =
-    !disabled &&
-    dismissedFor !== input &&
-    input.startsWith('/') &&
-    !input.includes(' ');
+    !disabled && dismissedFor !== input && input.startsWith('/') && !input.includes(' ');
   const filtered = showAutocomplete
     ? COMMANDS.filter((c) => c.label.startsWith(input.split(' ')[0] ?? ''))
     : [];
@@ -1305,66 +1341,68 @@ function ChatInputBar({
           disabled={disabled}
           rows={2}
           aria-label={t('chatPane.inputAria')}
-          style={textareaHeightPx !== null ? { height: `${String(textareaHeightPx)}px` } : undefined}
+          style={
+            textareaHeightPx !== null ? { height: `${String(textareaHeightPx)}px` } : undefined
+          }
         />
       </div>
       {parseError && <div className="chat-input-error">{parseError}</div>}
       <div className="chat-pane-input-row">
         <div className="chat-cmd-group">
-        <div className="chat-cmd-bar" ref={cmdMenuRef}>
-          <button
-            type="button"
-            className={`chat-cmd-trigger${cmdMenuOpen ? ' active' : ''}`}
-            onClick={() => setCmdMenuOpen((v) => !v)}
-            disabled={disabled}
-            aria-haspopup="menu"
-            aria-expanded={cmdMenuOpen}
-            title={t('chatPane.cmdTriggerTitle')}
-          >
-            /
-          </button>
-          {cmdMenuOpen && (
-            <ul className="chat-cmd-menu" role="menu">
-              {COMMANDS.map((c, i) => {
-                const prev = COMMANDS[i - 1];
-                // pragent → review-action 边界插一道分隔线
-                const needDivider = prev !== undefined && prev.kind !== c.kind;
-                return (
-                  <li key={c.name} className={needDivider ? 'chat-cmd-menu-group' : undefined}>
-                    <button
-                      type="button"
-                      className="chat-cmd-suggest-item"
-                      onClick={() => handleInsertCommand(c)}
-                      role="menuitem"
-                    >
-                      <code>{c.label}</code>
-                      <span className="muted">{t(c.descKey)}</span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-        {/* 自动评审：图标按钮紧贴 `/` 命令触发器右侧。仅 pr-agent 就绪时出现，LLM 未配置 / 本 PR 评审
+          <div className="chat-cmd-bar" ref={cmdMenuRef}>
+            <button
+              type="button"
+              className={`chat-cmd-trigger${cmdMenuOpen ? ' active' : ''}`}
+              onClick={() => setCmdMenuOpen((v) => !v)}
+              disabled={disabled}
+              aria-haspopup="menu"
+              aria-expanded={cmdMenuOpen}
+              title={t('chatPane.cmdTriggerTitle')}
+            >
+              /
+            </button>
+            {cmdMenuOpen && (
+              <ul className="chat-cmd-menu" role="menu">
+                {COMMANDS.map((c, i) => {
+                  const prev = COMMANDS[i - 1];
+                  // pragent → review-action 边界插一道分隔线
+                  const needDivider = prev !== undefined && prev.kind !== c.kind;
+                  return (
+                    <li key={c.name} className={needDivider ? 'chat-cmd-menu-group' : undefined}>
+                      <button
+                        type="button"
+                        className="chat-cmd-suggest-item"
+                        onClick={() => handleInsertCommand(c)}
+                        role="menuitem"
+                      >
+                        <code>{c.label}</code>
+                        <span className="muted">{t(c.descKey)}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+          {/* 自动评审：图标按钮紧贴 `/` 命令触发器右侧。仅 pr-agent 就绪时出现，LLM 未配置 / 本 PR 评审
             进行中则禁用触发（其它 PR 在跑不禁用——可并发 / 排队）。停止统一由发送区的停止按钮负责（取消
             进行中的子任务即终止流程），不再单独提供 Agent 停止按钮，避免两个语义重叠的停止入口。 */}
-        {pr && prAgent.available && (
-          <button
-            type="button"
-            className={`chat-cmd-trigger chat-agent-review-trigger${agentRunningHere ? ' active' : ''}`}
-            onClick={onAgentReview}
-            disabled={!llmConfigured || agentRunningHere}
-            title={
-              agentRunningHere
-                ? t('chatPane.agent.autoReviewRunning')
-                : t('chatPane.agent.autoReview')
-            }
-            aria-label={t('chatPane.agent.autoReview')}
-          >
-            <AutoReviewIcon />
-          </button>
-        )}
+          {pr && prAgent.available && (
+            <button
+              type="button"
+              className={`chat-cmd-trigger chat-agent-review-trigger${agentRunningHere ? ' active' : ''}`}
+              onClick={onAgentReview}
+              disabled={!llmConfigured || agentRunningHere}
+              title={
+                agentRunningHere
+                  ? t('chatPane.agent.autoReviewRunning')
+                  : t('chatPane.agent.autoReview')
+              }
+              aria-label={t('chatPane.agent.autoReview')}
+            >
+              <AutoReviewIcon />
+            </button>
+          )}
         </div>
         {/* 队列模型下 send 永远在 (新提交进队列)；本 PR active 时 stop 紧贴 send 左侧。
             包到一个 group 里避免 input-row 的 space-between 把 stop 推到中央 */}
@@ -1595,10 +1633,10 @@ function RulePreviewModal({
           </div>
           <div className="markdown" style={{ marginTop: 12 }}>
             <ReactMarkdown
-            remarkPlugins={[remarkGfm, remarkBreaks]}
-            rehypePlugins={REMOTE_REHYPE_PLUGINS}
-            components={mermaidComponents}
-          >
+              remarkPlugins={[remarkGfm, remarkBreaks]}
+              rehypePlugins={REMOTE_REHYPE_PLUGINS}
+              components={mermaidComponents}
+            >
               {rule.instructions}
             </ReactMarkdown>
           </div>
@@ -1620,7 +1658,8 @@ function inferPhase(lines: ReadonlyArray<string>, t: TFunction): string {
   // 从后往前找最近的命中标志，越靠后的标志代表更"晚"的阶段
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i]!;
-    if (/returning full diff|tokens?\s*[:：]\s*\d+/i.test(line)) return t('chatPane.phaseWaitingLlm');
+    if (/returning full diff|tokens?\s*[:：]\s*\d+/i.test(line))
+      return t('chatPane.phaseWaitingLlm');
     if (/answering a pr question|reviewing pr|generating a pr description/i.test(line))
       return t('chatPane.phaseAssemblingPrompt');
     if (/pr main language/i.test(line)) return t('chatPane.phaseParsingDiff');
@@ -1674,7 +1713,10 @@ function RunningView({
           {runStatusLabel('running', t)}
         </span>
         {model && (
-          <span className="chat-run-chip chat-run-model" title={t('chatPane.modelTitle', { model })}>
+          <span
+            className="chat-run-chip chat-run-model"
+            title={t('chatPane.modelTitle', { model })}
+          >
             {model}
           </span>
         )}
@@ -1850,7 +1892,9 @@ function RunResultView({
                   : t('chatPane.runFailed')}
             {/* llm-error 时 exitCode 是 0 (pr-agent 自己 catch 了)，显示出来反而
                 让用户误以为没出错，所以跳过 */}
-            {run.exitCode != null && !isCancelled && run.errorReason !== 'llm-error' &&
+            {run.exitCode != null &&
+              !isCancelled &&
+              run.errorReason !== 'llm-error' &&
               ` · exit ${String(run.exitCode)}`}
           </strong>
           {canRetry && (
@@ -1889,9 +1933,7 @@ function RunResultView({
             // FindingCard 据此显示状态 chip + 跳转/拒绝按钮行为分支
             const relatedDraft = drafts.find(
               (d) =>
-                d.source !== undefined &&
-                d.source.runId === run.id &&
-                d.source.findingId === f.id,
+                d.source !== undefined && d.source.runId === run.id && d.source.findingId === f.id,
             );
             return (
               <FindingCard
@@ -1906,9 +1948,7 @@ function RunResultView({
           })}
         </ul>
       ) : run.status === 'succeeded' ? (
-        <div className="chat-finding-empty muted">
-          {t('chatPane.noFindings')}
-        </div>
+        <div className="chat-finding-empty muted">{t('chatPane.noFindings')}</div>
       ) : null}
     </div>
   );
@@ -2078,7 +2118,10 @@ function RunMeta({ run }: { run: ReviewRun }) {
       {/* 模型 chip 取代运行时策略 chip — strategy 是部署细节用户不
           关心，model 是真正影响 review 质量的变量 */}
       {run.model && (
-        <span className="chat-run-chip chat-run-model" title={t('chatPane.modelTitle', { model: run.model })}>
+        <span
+          className="chat-run-chip chat-run-model"
+          title={t('chatPane.modelTitle', { model: run.model })}
+        >
           {run.model}
         </span>
       )}
@@ -2288,9 +2331,7 @@ function FindingCard({
     >
       <header className="chat-finding-head">
         {/* 已知 sectionKey 用中文标签 chip；general / 未知不显示，避免 UI 噪音 */}
-        {label && (
-          <span className={`chat-finding-cat chat-finding-cat-${key}`}>{label}</span>
-        )}
+        {label && <span className={`chat-finding-cat chat-finding-cat-${key}`}>{label}</span>}
         {showTitle && translatedTitle && !collapsed && (
           <h4 className="chat-finding-title">
             <MdInline>{translatedTitle}</MdInline>
@@ -2506,4 +2547,3 @@ function Bullet({ children }: { children: ReactNode }) {
 function Spinner() {
   return <span className="spinner" aria-hidden="true" />;
 }
-

--- a/apps/desktop/src/renderer/src/components/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/DiffView.tsx
@@ -35,6 +35,7 @@ import { CommentReplyEditor } from './CommentReplyEditor';
 import { ConfirmModal } from './ConfirmModal';
 import { DiffSearchPanel } from './DiffSearchPanel';
 import { FileTree } from './FileTree';
+import { PaneLoading } from './Loading';
 import { FileTreeIcon, SearchIcon } from './icons';
 import { languageFor } from '../utils/language';
 
@@ -253,10 +254,7 @@ export function DiffView({
     const startWidth = fileListWidth;
     const onMove = (ev: MouseEvent): void => {
       const dx = ev.clientX - startX;
-      const next = Math.min(
-        DIFF_FILE_LIST_MAX,
-        Math.max(DIFF_FILE_LIST_MIN, startWidth + dx),
-      );
+      const next = Math.min(DIFF_FILE_LIST_MAX, Math.max(DIFF_FILE_LIST_MIN, startWidth + dx));
       setFileListWidth(next);
     };
     const onUp = (): void => {
@@ -272,9 +270,7 @@ export function DiffView({
   };
   // 用 state 而非 ref：onMount 异步触发，必须靠 state 变更触发后续 useEffect
   // 重新运行 decorations 应用逻辑。
-  const [diffEditor, setDiffEditor] = useState<MonacoEditor.IStandaloneDiffEditor | null>(
-    null,
-  );
+  const [diffEditor, setDiffEditor] = useState<MonacoEditor.IStandaloneDiffEditor | null>(null);
 
   // 订阅 sync:progress 并按当前 PR 所属 repo 过滤
   const repoKeySuffix = `/${pr.repo.projectKey}/${pr.repo.repoSlug}`;
@@ -367,20 +363,17 @@ export function DiffView({
   // (典型场景：hover '+' 创建后立即 trigger，drafts store 异步更新)。fn 不在 map
   // 时把 id 加 pending；registerEditTrigger 时如果发现自己 pending 立即 fire
   const pendingTriggersRef = useRef<Set<string>>(new Set());
-  const registerEditTrigger = useCallback(
-    (draftId: string, fn: (() => void) | null): void => {
-      if (fn) {
-        editTriggerFnsRef.current.set(draftId, fn);
-        if (pendingTriggersRef.current.has(draftId)) {
-          pendingTriggersRef.current.delete(draftId);
-          fn();
-        }
-      } else {
-        editTriggerFnsRef.current.delete(draftId);
+  const registerEditTrigger = useCallback((draftId: string, fn: (() => void) | null): void => {
+    if (fn) {
+      editTriggerFnsRef.current.set(draftId, fn);
+      if (pendingTriggersRef.current.has(draftId)) {
+        pendingTriggersRef.current.delete(draftId);
+        fn();
       }
-    },
-    [],
-  );
+    } else {
+      editTriggerFnsRef.current.delete(draftId);
+    }
+  }, []);
   const triggerAutoEdit = (draftId: string): void => {
     const fn = editTriggerFnsRef.current.get(draftId);
     if (fn) {
@@ -459,9 +452,7 @@ export function DiffView({
     if (!files) return m;
     for (const f of files) {
       const n = comments.filter(
-        (c) =>
-          c.anchor &&
-          (c.anchor.path === f.path || (f.oldPath && c.anchor.path === f.oldPath)),
+        (c) => c.anchor && (c.anchor.path === f.path || (f.oldPath && c.anchor.path === f.oldPath)),
       ).length;
       if (n > 0) m.set(f.path, n);
     }
@@ -475,13 +466,10 @@ export function DiffView({
   const draftCountByPath = useMemo(() => {
     const m = new Map<string, number>();
     if (!files || !drafts) return m;
-    const publishable = drafts.filter(
-      (d) => d.status === 'pending' || d.status === 'edited',
-    );
+    const publishable = drafts.filter((d) => d.status === 'pending' || d.status === 'edited');
     for (const f of files) {
       const n = publishable.filter(
-        (d) =>
-          d.anchor.path === f.path || (f.oldPath && d.anchor.path === f.oldPath),
+        (d) => d.anchor.path === f.path || (f.oldPath && d.anchor.path === f.oldPath),
       ).length;
       if (n > 0) m.set(f.path, n);
     }
@@ -767,7 +755,10 @@ export function DiffView({
     if (renderSideBySide) {
       addZonesFor(originalEditor, oldByLine);
     } else if (oldByLine.size > 0) {
-      addZonesFor(modifiedEditor, remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine));
+      addZonesFor(
+        modifiedEditor,
+        remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine),
+      );
     }
     addZonesFor(modifiedEditor, newByLine);
 
@@ -1075,7 +1066,10 @@ export function DiffView({
     if (renderSideBySide) {
       addZonesFor(originalEditor, oldByLine);
     } else if (oldByLine.size > 0) {
-      addZonesFor(modifiedEditor, remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine));
+      addZonesFor(
+        modifiedEditor,
+        remapOldByLineToModified(diffEditor.getLineChanges() ?? [], oldByLine),
+      );
     }
     addZonesFor(modifiedEditor, newByLine);
 
@@ -1177,13 +1171,11 @@ export function DiffView({
       const lineChanges = diffEditor.getLineChanges() ?? [];
       return lineChanges.map((c) => ({
         original:
-          c.originalEndLineNumber >= c.originalStartLineNumber &&
-          c.originalEndLineNumber > 0
+          c.originalEndLineNumber >= c.originalStartLineNumber && c.originalEndLineNumber > 0
             ? { start: c.originalStartLineNumber, end: c.originalEndLineNumber }
             : null,
         modified:
-          c.modifiedEndLineNumber >= c.modifiedStartLineNumber &&
-          c.modifiedEndLineNumber > 0
+          c.modifiedEndLineNumber >= c.modifiedStartLineNumber && c.modifiedEndLineNumber > 0
             ? { start: c.modifiedStartLineNumber, end: c.modifiedEndLineNumber }
             : null,
       }));
@@ -1298,7 +1290,9 @@ export function DiffView({
       // 用 selected.path 跟 pendingScroll 的 anchor.path 关联间接判断
     }
     const editor =
-      pendingScroll.side === 'old' ? diffEditor.getOriginalEditor() : diffEditor.getModifiedEditor();
+      pendingScroll.side === 'old'
+        ? diffEditor.getOriginalEditor()
+        : diffEditor.getModifiedEditor();
 
     let highlightTimer: ReturnType<typeof setTimeout> | undefined;
     let revealed = false;
@@ -1390,8 +1384,14 @@ export function DiffView({
             type="button"
             className="diff-file-list-search-btn"
             onClick={() => setSidebarMode((m) => (m === 'search' ? 'tree' : 'search'))}
-            title={sidebarMode === 'search' ? t('diffView.backToFileTree') : t('diffView.searchChangesTitle')}
-            aria-label={sidebarMode === 'search' ? t('diffView.backToFileTree') : t('diffView.searchAria')}
+            title={
+              sidebarMode === 'search'
+                ? t('diffView.backToFileTree')
+                : t('diffView.searchChangesTitle')
+            }
+            aria-label={
+              sidebarMode === 'search' ? t('diffView.backToFileTree') : t('diffView.searchAria')
+            }
           >
             {sidebarMode === 'search' ? <FileTreeIcon /> : <SearchIcon />}
           </button>
@@ -1448,7 +1448,9 @@ export function DiffView({
           <BackendErrorBanner
             err={blameError}
             scope={
-              selected ? t('diffView.blameFailedNamed', { path: selected.path }) : t('diffView.blameFailed')
+              selected
+                ? t('diffView.blameFailedNamed', { path: selected.path })
+                : t('diffView.blameFailed')
             }
             onDismiss={() => setBlameError(null)}
           />
@@ -1544,9 +1546,7 @@ function DraftZoneList({
   // PublishReviewModal 的批量路径共用同一份 main 端逻辑 (anchor 映射 / posted
   // 回写 / force-refresh 评论 / 失败收集都一致)，行为可预测，未来改任一处不会
   // 让两条路径分叉
-  const onPublish = async (
-    draftId: string,
-  ): Promise<{ ok: boolean; error?: string }> => {
+  const onPublish = async (draftId: string): Promise<{ ok: boolean; error?: string }> => {
     const resp = await invoke('drafts:publishBatch', {
       localId: prLocalId,
       draftIds: [draftId],
@@ -1558,10 +1558,7 @@ function DraftZoneList({
   return (
     <div className="draft-zone-list">
       {drafts.map((d, i) => (
-        <div
-          key={d.id}
-          className={`draft-zone-item${i > 0 ? ' draft-zone-item-divider' : ''}`}
-        >
+        <div key={d.id} className={`draft-zone-item${i > 0 ? ' draft-zone-item-divider' : ''}`}>
           <DraftZone
             draft={d}
             hardBreaks={hardBreaks}
@@ -1896,7 +1893,9 @@ function SyncProgress({ progress }: { progress: SyncProgressEvent | null }) {
     );
   }
   const label =
-    progress.phase === 'start' ? progress.message ?? t('diffView.preparingSync') : progress.stage ?? t('diffView.syncing');
+    progress.phase === 'start'
+      ? (progress.message ?? t('diffView.preparingSync'))
+      : (progress.stage ?? t('diffView.syncing'));
   const pct =
     progress.percent !== undefined && Number.isFinite(progress.percent) ? progress.percent : null;
   return (
@@ -2201,7 +2200,6 @@ function fileKey(f: DiffChangedFile): string {
   return `${f.oldPath ?? ''}|${f.path}`;
 }
 
-
 function DiffPane({
   file,
   content,
@@ -2220,6 +2218,31 @@ function DiffPane({
   onMount: (editor: MonacoEditor.IStandaloneDiffEditor) => void;
 }) {
   const { t } = useTranslation();
+  // Monaco 挂载后 diff 还要异步计算 + hideUnchangedRegions 折叠才稳定（见上文 reveal 逻辑），
+  // 期间编辑器是「空 → 跳一下」的重排。在它之上盖一层 overlay loading，首次 onDidUpdateDiff
+  // （或挂载即已算完）后卸载，遮住这段抖动一次性 reveal。DiffPane 按 file path keyed →
+  // 切文件自然 remount，diffReady 随之复位。
+  const [diffReady, setDiffReady] = useState(false);
+  const handleMount = useCallback(
+    (editor: MonacoEditor.IStandaloneDiffEditor) => {
+      onMount(editor);
+      // diff 算完触发 onDidUpdateDiff，但 hideUnchangedRegions 折叠的布局还要再 paint
+      // 一两帧才稳定 → 不在事件里立即揭开（否则露出折叠那一跳），略等 80ms 让折叠 paint
+      // 完成、overlay 一直盖着，再一次性 reveal。
+      const reveal = (): void => {
+        window.setTimeout(() => setDiffReady(true), 80);
+      };
+      if (editor.getLineChanges() != null) {
+        reveal();
+        return;
+      }
+      const d = editor.onDidUpdateDiff(() => {
+        d.dispose();
+        reveal();
+      });
+    },
+    [onMount],
+  );
   if (loading || !content) {
     return (
       <div className="diff-empty">
@@ -2236,50 +2259,50 @@ function DiffPane({
     return <div className="diff-binary">{t('diffView.binaryNotRendered')}</div>;
   }
   return (
-    <DiffEditor
-      height="100%"
-      language={languageFor(file.path)}
-      original={content.base.content}
-      modified={content.head.content}
-      onMount={onMount}
-      className={
-        [
-          showBlame ? 'diff-editor-with-blame' : '',
-          showWhitespace ? 'diff-editor-show-eol' : '',
-        ]
-          .filter(Boolean)
-          .join(' ') || undefined
-      }
-      options={{
-        readOnly: true,
-        renderSideBySide,
-        minimap: { enabled: false },
-        fontSize: editorFontSize(14),
-        scrollBeyondLastLine: false,
-        renderOverviewRuler: false,
-        // 显式开 glyph margin，给行内评论标记留位置
-        glyphMargin: true,
-        // 空白字符可视化：toolbar 按钮控制；'all' 时空格显示 · / Tab 显示 →
-        renderWhitespace: showWhitespace ? 'all' : 'none',
-        // GitHub 风格折叠：未变更段缩成可展开占位行
-        hideUnchangedRegions: {
-          enabled: true,
-          contextLineCount: 10,
-          minimumLineCount: 5,
-          revealLineCount: 20,
-        },
-        // 关掉依赖 ts.worker 的高级特性（diff review 不需要），同时消掉
-        // `Missing requestHandler` 噪音。hover 保留给 blame / 评论装饰用。
-        inlayHints: { enabled: 'off' },
-        quickSuggestions: false,
-        suggestOnTriggerCharacters: false,
-        parameterHints: { enabled: false },
-        codeLens: false,
-        stickyScroll: { enabled: false },
-        occurrencesHighlight: 'off',
-      }}
-      theme="vs-dark"
-    />
+    <div className="diff-pane-editor">
+      {!diffReady && <PaneLoading overlay delayMs={0} />}
+      <DiffEditor
+        height="100%"
+        language={languageFor(file.path)}
+        original={content.base.content}
+        modified={content.head.content}
+        onMount={handleMount}
+        className={
+          [showBlame ? 'diff-editor-with-blame' : '', showWhitespace ? 'diff-editor-show-eol' : '']
+            .filter(Boolean)
+            .join(' ') || undefined
+        }
+        options={{
+          readOnly: true,
+          renderSideBySide,
+          minimap: { enabled: false },
+          fontSize: editorFontSize(14),
+          scrollBeyondLastLine: false,
+          renderOverviewRuler: false,
+          // 显式开 glyph margin，给行内评论标记留位置
+          glyphMargin: true,
+          // 空白字符可视化：toolbar 按钮控制；'all' 时空格显示 · / Tab 显示 →
+          renderWhitespace: showWhitespace ? 'all' : 'none',
+          // GitHub 风格折叠：未变更段缩成可展开占位行
+          hideUnchangedRegions: {
+            enabled: true,
+            contextLineCount: 10,
+            minimumLineCount: 5,
+            revealLineCount: 20,
+          },
+          // 关掉依赖 ts.worker 的高级特性（diff review 不需要），同时消掉
+          // `Missing requestHandler` 噪音。hover 保留给 blame / 评论装饰用。
+          inlayHints: { enabled: 'off' },
+          quickSuggestions: false,
+          suggestOnTriggerCharacters: false,
+          parameterHints: { enabled: false },
+          codeLens: false,
+          stickyScroll: { enabled: false },
+          occurrencesHighlight: 'off',
+        }}
+        theme="vs-dark"
+      />
+    </div>
   );
 }
 
@@ -2299,5 +2322,3 @@ function renderHoverMd(comments: PrComment[]): string {
     })
     .join('\n\n---\n\n');
 }
-
-

--- a/apps/desktop/src/renderer/src/components/Loading.tsx
+++ b/apps/desktop/src/renderer/src/components/Loading.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * 延迟显示的居中 loading：组件挂载后 delayMs 内不出现，超过才显 spinner。
+ *
+ * 重型组件（Monaco、ChatPane 内容、diff 文件树）在 async init 完成前先渲染空骨架、
+ * 各段 ready 时间错开 → 多次布局跳变（可感知抖动）。本组件在 init 期间盖住该区域，
+ * ready 后由调用方卸载它即可一次性 reveal。
+ *
+ * **延迟显示**是关键：桌面端切 PR 多在 150ms 内命中本地缓存，快路径下本组件挂载即
+ * 很快被卸载、spinner 从不出现 → 零闪烁；只有真慢的场景（Monaco 冷挂载 / 大 diff）
+ * 才落到 spinner。复用既有 `.spinner` 视觉，不引入新语言。
+ */
+export function PaneLoading({
+  delayMs = 150,
+  label,
+  overlay = false,
+}: {
+  delayMs?: number;
+  label?: string;
+  /** 绝对定位铺满父容器（父需 position:relative），用于盖在 Monaco 编辑器之上。 */
+  overlay?: boolean;
+}) {
+  // delayMs<=0：确定要盖（如 Monaco overlay），第 0 帧即显，不走延迟。
+  const [show, setShow] = useState(delayMs <= 0);
+  useEffect(() => {
+    if (delayMs <= 0) return;
+    const id = setTimeout(() => setShow(true), delayMs);
+    return () => clearTimeout(id);
+  }, [delayMs]);
+  if (!show) return null;
+  return (
+    <div
+      className={overlay ? 'pane-loading pane-loading-overlay' : 'pane-loading'}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="spinner" aria-hidden="true" />
+      {label ? <span className="muted">{label}</span> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/MainPane.tsx
+++ b/apps/desktop/src/renderer/src/components/MainPane.tsx
@@ -14,6 +14,7 @@ import { CommitsPanel } from './CommitsPanel';
 // 不阻塞窗口首帧 / PR 列表 / 首启向导。
 const DiffView = lazy(() => import('./DiffView').then((m) => ({ default: m.DiffView })));
 import { DraftsPanel } from './DraftsPanel';
+import { PaneLoading } from './Loading';
 import { PrInfoView } from './PrInfoView';
 import { PublishReviewModal } from './PublishReviewModal';
 import {
@@ -265,7 +266,8 @@ export function MainPane({
                 aria-busy={merging}
                 title={t('mainPane.mergeTitle')}
               >
-                <PullRequestIcon size={14} /> {merging ? t('mainPane.merging') : t('mainPane.merge')}
+                <PullRequestIcon size={14} />{' '}
+                {merging ? t('mainPane.merging') : t('mainPane.merge')}
               </button>
             )}
             {reviewAllowed('approved') && (
@@ -273,9 +275,7 @@ export function MainPane({
                 className={`btn btn-sm review-action review-action-approve ${pr.localStatus === 'approved' ? 'active' : ''}`}
                 type="button"
                 disabled={isOwnPr}
-                onClick={() =>
-                  onSetStatus(pr.localStatus === 'approved' ? 'pending' : 'approved')
-                }
+                onClick={() => onSetStatus(pr.localStatus === 'approved' ? 'pending' : 'approved')}
                 title={
                   ownPrReason ??
                   (pr.localStatus === 'approved'
@@ -329,7 +329,10 @@ export function MainPane({
         >
           {t('mainPane.tabComments')}
           {commentCount !== null && commentCount > 0 && (
-            <span className="pr-tab-badge" aria-label={t('mainPane.commentCountAria', { count: commentCount })}>
+            <span
+              className="pr-tab-badge"
+              aria-label={t('mainPane.commentCountAria', { count: commentCount })}
+            >
               {commentCount}
             </span>
           )}
@@ -366,7 +369,10 @@ export function MainPane({
         >
           {t('mainPane.tabCommits')}
           {commitCount !== null && commitCount > 0 && (
-            <span className="pr-tab-badge" aria-label={t('mainPane.commitCountAria', { count: commitCount })}>
+            <span
+              className="pr-tab-badge"
+              aria-label={t('mainPane.commitCountAria', { count: commitCount })}
+            >
               {commitCount}
             </span>
           )}
@@ -400,7 +406,11 @@ export function MainPane({
             >
               <PersonIcon /> {t('mainPane.blame')}
             </button>
-            <div className="diff-mode-toggle" role="tablist" aria-label={t('mainPane.diffModeAria')}>
+            <div
+              className="diff-mode-toggle"
+              role="tablist"
+              aria-label={t('mainPane.diffModeAria')}
+            >
               <button
                 type="button"
                 className={renderSideBySide ? 'active' : ''}
@@ -425,7 +435,7 @@ export function MainPane({
       </nav>
       <div className="pr-tab-content">
         {tab === 'diff' && (
-          <Suspense fallback={<div className="pane-loading muted">{t('mainPane.loadingEditor')}</div>}>
+          <Suspense fallback={<PaneLoading label={t('mainPane.loadingEditor')} />}>
             <DiffView
               pr={pr}
               renderSideBySide={renderSideBySide}

--- a/apps/desktop/src/renderer/src/styles/diff.scss
+++ b/apps/desktop/src/renderer/src/styles/diff.scss
@@ -79,6 +79,13 @@
   }
 }
 
+// Monaco 编辑器外壳：position:relative 作为 diff 就绪前 overlay loading 的定位锚点。
+.diff-pane-editor {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
 .diff-empty {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/src/styles/main-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/main-pane.scss
@@ -19,15 +19,33 @@
   padding: 24px;
 }
 
-// Monaco 懒加载 chunk 拉取期间的占位（DiffView / InlineCodeContext 的 Suspense fallback）
+// 重型组件 async init 期间的延迟 loading 占位（PaneLoading；Monaco Suspense fallback、
+// ChatPane 会话加载、diff 编辑器 ready 前的 overlay 共用）
 .pane-loading {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: $space-2;
   min-height: 120px;
   height: 100%;
   padding: 24px;
   font-size: 13px;
+
+  // .spinner 默认带右 margin（inline-文字场景用），居中布局里由 gap 接管，清掉避免偏移
+  .spinner {
+    margin: 0;
+  }
+}
+
+// overlay 变体：绝对定位铺满父容器（父需 position:relative），盖在 Monaco 编辑器之上，
+// 遮住「空编辑器 → diff 计算 / 折叠跳一下」那段重排，diff 就绪后由调用方卸载。
+.pane-loading-overlay {
+  position: absolute;
+  inset: 0;
+  // 盖在 Monaco 之上：编辑器内部有自带 stacking context，z-index 取高值确保 overlay 在最上层
+  z-index: 20;
+  height: auto;
+  background: $bg-app;
 }
 
 .pr-header {


### PR DESCRIPTION
## 背景

切换 PR / 文件时，diff（Monaco）、聊天会话内容等重型区域在异步初始化完成前先渲染空骨架、各段 ready 时间错开，造成可感知的多段重排抖动（空白 → 内容弹出 → 折叠跳一下）。

## 方案

不引入完整骨架屏，统一用「居中 spinner + 延迟显示」的 loading，闸住单次 reveal。

- **新增 `PaneLoading`**（`components/Loading.tsx`）：挂载后 150ms 内不出现、超过才显 spinner。本地缓存命中的快切换下挂了即被卸载、spinner 从不闪（零闪烁）；只有真慢的场景才落到 loading。`delayMs<=0` 时第 0 帧即显，用于「确定要盖」的 Monaco overlay。复用既有 `.spinner` 视觉。
- **Monaco overlay-until-ready**：编辑器外壳 `.diff-pane-editor`（relative）上盖 overlay，从挂载第一帧即遮住「启动编辑器 → 加载内容」；`onDidUpdateDiff`（diff 算完）后再等 80ms 让 `hideUnchangedRegions` 折叠布局 paint 稳定，才一次性揭开，避免露出折叠那一跳。overlay 底色 `$bg-app`(#1e1e1e) = Monaco vs-dark 编辑器底色，揭开无缝。
- **ChatPane**：初次拉取会话（runs / 规则 / 会话 / transcript）期间盖延迟 loading，加载完成才落到真实空态（避免空 PR 误显 loading）。
- **MainPane**：Monaco chunk 懒加载的 Suspense fallback 从纯文字换成 `PaneLoading`。

## 验证

- `npx nx typecheck/lint/build desktop` 全绿
- 本地 dev 实测：切 PR / 切文件时仅一个 spinner，随后直接出现已折叠好的 diff，无多段抖动

🤖 Generated with [Claude Code](https://claude.com/claude-code)