### PR TITLE
fix(review): PR diff base 固化为 merge-base，修复目标分支漂移致「修改被撤回」误判

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@
   稳定后才揭开，遮罩底色与编辑器一致、揭开无缝。
 
 ### Fixed
+- **修复 PR diff 基准随目标分支漂移导致的「修改被撤回」误判**：此前文件内容（Monaco 左栏）按目标
+  分支当前 tip（`targetRef.sha`）读取，目标分支被别的 PR 合入而前移后，编辑器实际成了两点对比，
+  别的 PR 的改动会以倒挂 / 撤回形式串进当前 PR 的 diff（变更文件列表用三点 diff 本不受影响，但内容
+  与之不一致）。改为首次为 PR 算出 `merge-base(target, head)` 并固化到 `prs/<localId>/diff-base.json`，
+  之后变更文件列表 / 文件内容 / 提交计数 / blame 改动行 / pr-agent 评审一律以它为 base：编辑器即真
+  三点、对目标分支前移稳定，行锚点（评论 / finding）也有了固定参照。源分支被 rebase（固化 base 不再是
+  head 祖先）时自动重算；正常 push 不失效。固化值为本地派生缓存、独立于平台元数据，poller 重写
+  meta.json 不触碰；历史 PR 无需迁移，首次访问 diff 时按需回填（算不出则退回旧行为且不固化）。
 - 修复 Windows 控制台中文日志仍显示为乱码：① dev 下 electron-vite 把 main 的 stdout 接成管道
   （`isTTY=false`）原会跳过转码，UTF-8 字节被 CJK 控制台按 GBK/SJIS 渲染——改为 `pretty` 模式不卡
   `isTTY`（与上色路径一致）；② 启动期探测真实活动代码页（`chcp`）替代按 locale 猜测：UTF-8 控制台

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -32,6 +32,8 @@ import {
   makeRunId,
   parseReviewOutput,
   readCommentsCache,
+  readDiffBaseCache,
+  writeDiffBaseCache,
   setLocalStatus,
   startReviewRun,
   updateDraft,
@@ -607,6 +609,37 @@ export function registerIpcHandlers({
     return { mirrorPath: r.mirrorPath, freshClone: r.freshClone };
   };
 
+  /**
+   * 解析 PR diff 的固定 base（merge-base）——见 `@meebox/poller` diff-base-cache。
+   *
+   * PR diff 的语义基准是「源分支自目标分支分叉处」= `merge-base(targetRef.sha, sourceRef.sha)`，
+   * 而非目标分支当前 tip（会随别的 PR 合入前移）。首次算出后固化于 `prs/<localId>/diff-base.json`，
+   * 之后 listChangedFiles / 文件内容 / commitCount / blame / pr-agent worktree 一律以它为 base：
+   * - 内容（Monaco 左栏）锚到 merge-base → 编辑器即真三点，目标漂移不再把别的 PR 改动倒挂进来；
+   * - 行锚点（评论 / finding）有了固定参照，目标漂移不致错位。
+   *
+   * 失效重算：固化 base 不再是当前 head 的祖先（源分支被 rebase）→ 重算。head 正常 push（仅前进）
+   * 不失效。算不出（缺对象 / 无共同祖先）→ 兜底退回 targetRef.sha 且**不固化**，下次再试。
+   *
+   * 前置：mirror 已含 head + targetRef.sha（diff 入口已 ensureMirrorReadyForPr / syncMirror）。
+   */
+  const resolveDiffBaseSha = async (pr: StoredPullRequest): Promise<string> => {
+    const id = repoIdentityFor(pr);
+    const head = pr.sourceRef.sha;
+    const cached = await readDiffBaseCache(stateStore, pr.localId);
+    if (cached?.base_sha && (await repoMirror.isAncestor(id, cached.base_sha, head))) {
+      return cached.base_sha;
+    }
+    const mb = await repoMirror.mergeBase(id, pr.targetRef.sha, head);
+    if (!mb) return pr.targetRef.sha;
+    await writeDiffBaseCache(stateStore, pr.localId, {
+      base_sha: mb,
+      head_sha: head,
+      computed_at: new Date().toISOString(),
+    });
+    return mb;
+  };
+
   ipcMain.handle(
     'repo:sync',
     async (
@@ -628,7 +661,9 @@ export function registerIpcHandlers({
       const id = repoIdentityFor(pr);
       // 自动确保 mirror 含 head + base sha (快速路径命中即 noop)；再算 diff
       await ensureMirrorReadyForPr(pr);
-      return repoMirror.listChangedFiles(id, pr.targetRef.sha, pr.sourceRef.sha);
+      // base 锚到固定 merge-base（非漂移的 targetRef.sha），三点 diff 对目标分支前移稳定
+      const base = await resolveDiffBaseSha(pr);
+      return repoMirror.listChangedFiles(id, base, pr.sourceRef.sha);
     },
   );
 
@@ -640,7 +675,8 @@ export function registerIpcHandlers({
     ): Promise<IpcChannels['diff:getFileContent']['response']> => {
       const pr = await findPrOrThrow(req.localId);
       const id = repoIdentityFor(pr);
-      const sha = req.side === 'base' ? pr.targetRef.sha : pr.sourceRef.sha;
+      // base 侧读固定 merge-base 的内容（与三点 diff 一致），head 侧读源 tip
+      const sha = req.side === 'base' ? await resolveDiffBaseSha(pr) : pr.sourceRef.sha;
       return repoMirror.getFileContent(id, sha, req.path);
     },
   );
@@ -736,8 +772,11 @@ export function registerIpcHandlers({
       const pr = await findPrOrThrow(req.localId);
       const id = repoIdentityFor(pr);
       // 本地 git 算 base..head；不打远端、不主动触发 sync。镜像还没拉齐就返回 null，
-      // UI 角标暂不显示，等下次 poll 触发 syncMirror 完成后自然命中
-      const n = await repoMirror.countCommits(id, pr.targetRef.sha, pr.sourceRef.sha);
+      // UI 角标暂不显示，等下次 poll 触发 syncMirror 完成后自然命中。
+      // base 用固定 merge-base：base..head（base 为 merge-base 时）即 PR 自身提交数，
+      // 与三点 diff 同源、对目标分支前移稳定（旧版用 targetRef.sha 会随漂移跳变）
+      const base = await resolveDiffBaseSha(pr);
+      const n = await repoMirror.countCommits(id, base, pr.sourceRef.sha);
       return n === null ? null : { count: n };
     },
   );
@@ -752,9 +791,10 @@ export function registerIpcHandlers({
       const id = repoIdentityFor(pr);
       // 只对 base 已有部分展示 blame；PR 引入的行单独返给 renderer，
       // 由 BlameColumn 画色带占位（对应 Monaco diff 添加/修改区的视觉）。
+      const base = await resolveDiffBaseSha(pr);
       const [allBlame, changedSet] = await Promise.all([
         repoMirror.getBlame(id, pr.sourceRef.sha, req.path),
-        repoMirror.listChangedHeadLines(id, pr.targetRef.sha, pr.sourceRef.sha, req.path),
+        repoMirror.listChangedHeadLines(id, base, pr.sourceRef.sha, req.path),
       ]);
       return {
         lines: allBlame.filter((b) => !changedSet.has(b.line)),
@@ -835,7 +875,10 @@ export function registerIpcHandlers({
 
     const repoId = repoIdentityFor(pr);
     await repoMirror.syncMirror(repoId);
-    const wt = await repoMirror.materializeWorktree(repoId, pr.sourceRef.sha, pr.targetRef.sha);
+    // pr-agent 的 LOCAL__TARGET_BRANCH 用固定 merge-base（与 UI diff 同源）：让 AI 评审基于
+    // 「PR 自分叉后引入的改动」，而非 targetRef.sha 漂移后混入别的 PR 的两点对比
+    const diffBase = await resolveDiffBaseSha(pr);
+    const wt = await repoMirror.materializeWorktree(repoId, pr.sourceRef.sha, diffBase);
     const ac = item.ac!;
     try {
       const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);

--- a/packages/poller/src/diff-base-cache.ts
+++ b/packages/poller/src/diff-base-cache.ts
@@ -1,0 +1,48 @@
+import type { StateStore } from '@meebox/state-store';
+
+/**
+ * PR diff 基准（merge-base）固化文件。落在 `prs/<localId>/diff-base.json`。
+ *
+ * **为什么固化**：PR diff 的语义基准应是「源分支自目标分支分叉处」= `merge-base(target, head)`，
+ * 而非目标分支当前 tip（`targetRef.sha`，会随别的 PR 合入而前移）。
+ * - 变更文件列表 / 改动行用三点 diff（`base...head`），已隐式按 merge-base 算，对目标前移稳定；
+ * - 但**文件内容**（Monaco 左栏）若按 `targetRef.sha` 读，编辑器实际是两点对比，目标漂移后别的 PR
+ *   的改动会以「倒挂/撤回」形式串进来。固化 merge-base 后，内容 / 列表 / 计数 / blame / pr-agent
+ *   一律以它为 base，编辑器即真三点、对目标漂移稳定，评论 / finding 行锚点也有了固定参照。
+ *
+ * **失效**：`head`（`sourceRef.sha`）被 rebase 致固化 base 不再是其祖先时重算（见
+ * `resolveDiffBaseSha`）；源分支正常 push（head 仅前进）不失效，base 仍锚在分叉点。
+ *
+ * 它是**本地派生缓存**、非平台元数据，独立成文件，poller 重写 meta.json 时不触碰。
+ */
+export interface DiffBaseCacheFile {
+  schema_version: 1;
+  /** 固化的 merge-base sha，作为 diff/内容/计数/blame/pr-agent 的统一 base */
+  base_sha: string;
+  /** 算这个 base 时对应的 head（sourceRef.sha），便于排障与人工核对 */
+  head_sha: string;
+  /** 计算完成的 ISO 时间 */
+  computed_at: string;
+}
+
+export function diffBaseCacheKey(localId: string): string {
+  return `prs/${localId}/diff-base`;
+}
+
+export async function readDiffBaseCache(
+  store: StateStore,
+  localId: string,
+): Promise<DiffBaseCacheFile | null> {
+  return store.read<DiffBaseCacheFile>(diffBaseCacheKey(localId));
+}
+
+export async function writeDiffBaseCache(
+  store: StateStore,
+  localId: string,
+  data: { base_sha: string; head_sha: string; computed_at: string },
+): Promise<void> {
+  await store.write<DiffBaseCacheFile>(diffBaseCacheKey(localId), {
+    schema_version: 1,
+    ...data,
+  });
+}

--- a/packages/poller/src/index.ts
+++ b/packages/poller/src/index.ts
@@ -3,6 +3,7 @@ export * from './poller.js';
 export * from './pr-hash-id.js';
 export * from './pr-state.js';
 export * from './comments-cache.js';
+export * from './diff-base-cache.js';
 export * from './runs.js';
 export * from './agent-session.js';
 export * from './autopilot-ledger.js';

--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -171,6 +171,39 @@ export class RepoMirrorManager {
   }
 
   /**
+   * `git merge-base a b` —— 两 sha 的最近共同祖先（PR 源分支自目标分叉处）。
+   * 用于把 PR diff 的 base 锚到分叉点（而非随别的 PR 合入而前移的目标分支 tip）。
+   * 任一 sha 缺失 / 无共同祖先 / 缺对象 → 返回 null，调用方兜底（不固化、下次再试）。
+   */
+  async mergeBase(repo: RepoIdentity, a: string, b: string): Promise<string | null> {
+    if (!a || !b) return null;
+    const mp = this.mirrorPath(repo);
+    try {
+      const out = await simpleGit(mp).raw(['merge-base', a, b]);
+      const sha = out.trim();
+      return sha || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * `git merge-base --is-ancestor anc desc` —— anc 是否为 desc 的祖先。
+   * 用于校验固化的 base 对当前 head 仍有效（head 正常 push 仍成立；被 rebase 则不成立 → 触发重算）。
+   * exit 0 → true；exit 1（非祖先）/ 缺对象 → false。
+   */
+  async isAncestor(repo: RepoIdentity, anc: string, desc: string): Promise<boolean> {
+    if (!anc || !desc) return false;
+    const mp = this.mirrorPath(repo);
+    try {
+      await simpleGit(mp).raw(['merge-base', '--is-ancestor', anc, desc]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * 同步镜像：首次 clone bare partial，后续 fetch。
    *
    * 调度规则：


### PR DESCRIPTION
## 问题

Bitbucket 模式下，某 PR 创建后又有别的 PR 合入其目标分支时，当前 PR 的 diff 会把别的 PR 的改动以「倒挂 / 撤回」形式串进来。

根因：文件内容（Monaco 左栏）按 `pr.targetRef.sha`（= 目标分支**当前 tip**，随别的 PR 合入而前移）读取，使编辑器实际成了 `targetTip` vs `sourceTip` 的**两点对比**。变更文件列表用的是三点 diff（merge-base）本不受影响，但与内容渲染不一致。

## 方案（固化 merge-base）

PR diff 的语义基准应是「源分支自目标分支分叉处」= `merge-base(target, head)`，对目标分支前移稳定。首次为 PR 算出后固化到 `prs/<localId>/diff-base.json`，之后统一以它为 base：

- **变更文件列表 / 文件内容（左栏）/ 提交计数 / blame 改动行 / pr-agent 评审** 五处的 base 全部从 `targetRef.sha` 换成固化 merge-base → 编辑器即真三点、目标漂移不再倒挂，行锚点（评论 / finding）有了固定参照。
- **失效重算**：源分支被 rebase（固化 base 不再是 head 祖先）→ 重算；正常 push（head 仅前进）不失效。

## 改动

- 新增 `@meebox/poller` `diff-base-cache`：`prs/<localId>/diff-base.json`，**本地派生缓存、独立于平台元数据**，poller 重写 meta.json 不触碰。
- `@meebox/repo-mirror` 加 `mergeBase` / `isAncestor`（本地 git）。
- `ipc.ts` 加 `resolveDiffBaseSha(pr)`（读缓存→校验仍是 head 祖先→命中即用，否则算 merge-base 固化；算不出退回 `targetRef.sha` 且不固化）。

## 历史 PR 兼容性

- **无 schema 变更、无需迁移**：固化值在独立缓存文件，`StoredPullRequest` / meta.json 不动。
- **按需懒回填**：历史 PR 首次访问 diff 时现算并固化，对用户透明。
- **兜底即旧行为**：镜像缺对象算不出 merge-base 时退回 `targetRef.sha`、不写坏数据，下次再试。
- **行锚点不破**：锚点是 head 侧行号，head 内容未变，仍有效（diff 反而更准）。
- **自动清理**：PR purge 时 `deleteDir('prs/<localId>')` 连此文件一并删。
- 可见变化：目标已漂移的历史 PR 重开后 diff 会变——之前被误显为「撤回」的别的 PR 改动消失，这正是修复效果。

## 验证

`npx nx typecheck/lint -p poller repo-mirror desktop`、`nx test poller`（87 passed）、`nx build desktop` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)