### PR TITLE
feat(agent): 主动记忆按专题章节落盘，无法归类即不记录

### DIFF
--- a/docs/arch/06-agent.md
+++ b/docs/arch/06-agent.md
@@ -140,7 +140,10 @@ ReAct 循环——**每一轮就是一次编排级 LLM 调用**（一个 `AgentS
 - `recommendation`：评审类收尾的非约束性判定（`approve` / `needs_work` / `manual_review` + 理由），
   与 `final` 在**同一次调用**产出，供 UI 展示判定徽标。
 - `remember`：主动记下的**非隐私**条目，按目标可写文件分组（`user` → USER.md / `memory` → MEMORY.md
-  / `agents` → AGENTS.md），随本轮动作一并返回、收尾后落盘（**`SOUL.md` 永不写**）。
+  / `agents` → AGENTS.md），随本轮动作一并返回、收尾后落盘（**`SOUL.md` 永不写**）。每条**必带**
+  `section`：把条目**抽象归纳**后归入目标文件里最贴切的既有 `## 专题章节`（命中则追加到该节末尾、不存在则
+  文件末尾新建），而非统一堆到单一记录区，便于跨会话上下文管理。**无法归入某个专题的条目不是耐久记忆**
+  （多半是本 PR 的发现）——直接丢弃、不记录（无兜底区）。
 
 **路由策略**（写进规划提示词，也在这同一次调用里裁决）：自然对话（问候 / 自我介绍 / 澄清）直接
 `final` 回答、不调工具；评审领域外的任务礼貌拒绝、不调工具；与本 PR 相关但无明确工具指向时默认
@@ -168,7 +171,7 @@ flowchart TD
     SEL --> EXEC["工具执行（跨进程 / 并行）<br/>各为独立 ReviewRun · pr-agent run"]
     EXEC -. "结果回喂 → 下一轮规划调用" .-> CALL
     FIN --> DONE["收尾：落多轮对话消息 + 判定徽标"]
-    REM --> MEM["落盘 USER / MEMORY / AGENTS.md（SOUL 永不写）"]
+    REM --> MEM["按专题章节落盘 USER / MEMORY / AGENTS.md（SOUL 永不写）"]
 ```
 
 固定微流程（§6 的自动评审 / AutoPilot）是另一种形态：工具序列**预定**（describe + review → 条件

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,7 +3,7 @@ export type { AgentContextKind } from './layout.js';
 export { loadAgentContext, loadAgentRules } from './load.js';
 export { scaffoldAgentDir } from './scaffold.js';
 export { appendAgentNotes } from './memory.js';
-export type { WritableAgentFile } from './memory.js';
+export type { MemoryNote, WritableAgentFile } from './memory.js';
 export { AGENT_TEMPLATES } from './templates.js';
 export type { AgentTemplate } from './templates.js';
 export type { AgentContext, AgentContextFiles, LoadAgentContextOptions } from './types.js';

--- a/packages/agent/src/memory.ts
+++ b/packages/agent/src/memory.ts
@@ -5,24 +5,68 @@ import { resolveAgentPaths } from './layout.js';
 /** Agent 可写的上下文文件（SOUL.md 永远只读、绝不写）。 */
 export type WritableAgentFile = 'user' | 'memory' | 'agents';
 
-/** 各可写文件中由 Agent 自动维护的记录区标题（复用同一区，不重复建标题）。 */
-const NOTE_HEADING = '## Agent 记录';
+/** 单条主动记忆：必带目标专题章节，写入对应 `## section` 末尾。 */
+export interface MemoryNote {
+  /**
+   * 目标章节标题（**不含** `## ` 前缀）。命中文件里已有的同名 `## 章节` → 追加到该节末尾；
+   * 不存在 → 在文件末尾新建该节。**必填**——无法归入某个专题的条目不是耐久记忆、不应记录。
+   */
+  section: string;
+  /** 条目正文（已是抽象归纳后的耐久陈述）。 */
+  note: string;
+}
 
 /**
- * 把 Agent 主动记下的条目**追加**到指定可写上下文文件：
+ * 把 bullets 插到 `## heading` 区段末尾（下一个 markdown 标题之前）；该标题不存在则在
+ * 文件末尾新建一节。返回新内容（纯字符串变换，不落盘）。
+ */
+function insertUnderHeading(content: string, heading: string, notes: readonly string[]): string {
+  const bullets = notes.map((n) => `- ${n}`);
+  const lines = content.split('\n');
+  const target = `## ${heading}`.toLowerCase();
+  const headingIdx = lines.findIndex((l) => l.trim().toLowerCase() === target);
+
+  if (headingIdx === -1) {
+    const base = content.trimEnd();
+    const prefix = base ? `${base}\n\n` : '';
+    return `${prefix}## ${heading}\n${bullets.join('\n')}\n`;
+  }
+
+  // 区段末尾 = 下一个行首 markdown 标题（# ~ ######）所在行，或文件末。
+  let end = lines.length;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (/^#{1,6}\s/.test(lines[i]!)) {
+      end = i;
+      break;
+    }
+  }
+  // 跳过区段尾部空行，插在最后一条内容之后（保持与后续章节的空行间隔）。
+  let insertAt = end;
+  while (insertAt > headingIdx + 1 && lines[insertAt - 1]!.trim() === '') insertAt--;
+  lines.splice(insertAt, 0, ...bullets);
+  return lines.join('\n');
+}
+
+/**
+ * 把 Agent 主动记下的条目按**专题章节**写入指定可写上下文文件：
  * - user   → USER.md：非隐私的用户信息（称呼 / 语言 / 评审习惯偏好）
  * - memory → MEMORY.md：长期知识 / 仓库事实
  * - agents → AGENTS.md：工作规范 / 评审约定（**仅追加**，不改写、不删除既有红线）
  *
- * 绝不写 SOUL.md。幂等去重：与现有正文重复（子串命中）的不再追加；返回实际新增条目。
- * 隐私边界由提示词在生成 notes 时把关（见 planner Protocol）；此处只负责落盘与去重。
+ * 每条必带 `section`：命中已有 `## 章节`→ 追加到该节末尾；不存在 → 文件末尾新建该节。把条目归到
+ * 专题章节而非单一堆叠区，便于跨会话上下文管理（抽象归纳在提示词把关；无法归类的条目不是耐久记忆、不记录）。
+ *
+ * 绝不写 SOUL.md。幂等去重：正文与现有内容重复（子串命中）或批内重复的不再追加；返回实际新增的条目正文。
+ * 隐私边界由提示词在生成 notes 时把关（见 planner Protocol）；此处只负责分节落盘与去重。
  */
 export async function appendAgentNotes(
   agentDir: string,
   kind: WritableAgentFile,
-  notes: readonly string[],
+  notes: readonly MemoryNote[],
 ): Promise<string[]> {
-  const cleaned = notes.map((n) => n.trim()).filter(Boolean);
+  const cleaned = (notes ?? [])
+    .map((n) => ({ section: n.section.trim(), note: n.note.trim() }))
+    .filter((n) => n.section && n.note);
   if (!agentDir || cleaned.length === 0) return [];
 
   const file = resolveAgentPaths(agentDir)[kind];
@@ -33,24 +77,32 @@ export async function appendAgentNotes(
     content = '';
   }
 
+  // 幂等去重：正文与现有内容重复（子串命中）或批内重复的跳过。
   const haystack = content.toLowerCase();
-  const fresh: string[] = [];
   const seen = new Set<string>();
-  for (const note of cleaned) {
-    const key = note.toLowerCase();
+  const fresh: typeof cleaned = [];
+  for (const n of cleaned) {
+    const key = n.note.toLowerCase();
     if (seen.has(key) || haystack.includes(key)) continue;
     seen.add(key);
-    fresh.push(note);
+    fresh.push(n);
   }
   if (fresh.length === 0) return [];
 
-  let next = content;
-  if (!next.includes(NOTE_HEADING)) {
-    next = `${next.trimEnd()}${next.trim() ? '\n\n' : ''}${NOTE_HEADING}\n`;
+  // 按目标章节分组，保持各组内的原始顺序。
+  const groups = new Map<string, string[]>();
+  for (const n of fresh) {
+    const bucket = groups.get(n.section);
+    if (bucket) bucket.push(n.note);
+    else groups.set(n.section, [n.note]);
   }
-  next = `${next.trimEnd()}\n${fresh.map((n) => `- ${n}`).join('\n')}\n`;
+
+  let next = content;
+  for (const [heading, bullets] of groups) {
+    next = insertUnderHeading(next, heading, bullets);
+  }
 
   await mkdir(path.dirname(file), { recursive: true });
   await writeFile(file, next, 'utf8');
-  return fresh;
+  return fresh.map((n) => n.note);
 }

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -8,6 +8,7 @@ import type {
   ToolCatalogEntry,
 } from '@meebox/shared';
 import { assembleSystemContext, type AssemblePrMeta } from './assemble.js';
+import type { MemoryNote } from './memory.js';
 import { extractJson, salvageProse, stripTrailingJson, summarySections } from './orchestrator.js';
 import { runStaggered } from './stagger.js';
 import { assertToolAllowed } from './tool-catalog.js';
@@ -83,23 +84,34 @@ interface PlannerAction {
   remember?: { user?: unknown; memory?: unknown; agents?: unknown };
 }
 
-/** Agent 主动记忆，按目标可写文件分组（键与 WritableAgentFile 对齐）。 */
+/** Agent 主动记忆，按目标可写文件分组（键与 WritableAgentFile 对齐），各条带目标专题章节。 */
 export interface AgentMemoryNotes {
-  user: string[];
-  memory: string[];
-  agents: string[];
+  user: MemoryNote[];
+  memory: MemoryNote[];
+  agents: MemoryNote[];
 }
 
 function emptyMemoryNotes(): AgentMemoryNotes {
   return { user: [], memory: [], agents: [] };
 }
 
-function toNoteList(raw: unknown): string[] {
-  if (typeof raw === 'string') return raw.trim() ? [raw.trim()] : [];
-  if (Array.isArray(raw)) {
-    return raw.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((x) => x.trim());
-  }
-  return [];
+/**
+ * 解析单条记忆：必须是带 `section` + `note` 的对象。无法归入专题章节的条目（纯字符串 / 缺 section）
+ * 不是耐久记忆 → 丢弃（返回 null）。
+ */
+function toNote(raw: unknown): MemoryNote | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as { section?: unknown; note?: unknown };
+  const note = typeof obj.note === 'string' ? obj.note.trim() : '';
+  const section = typeof obj.section === 'string' ? obj.section.trim() : '';
+  if (!note || !section) return null;
+  return { section, note };
+}
+
+/** 把目标文件的 remember 数组解析为 MemoryNote[]（容错；丢弃无法归类的条目）。 */
+function toNoteList(raw: unknown): MemoryNote[] {
+  const items = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+  return items.map(toNote).filter((n): n is MemoryNote => n !== null);
 }
 
 /** 把一个动作里的 remember 累加进 acc（容错；非对象忽略）。 */
@@ -188,17 +200,26 @@ function buildProtocol(sections: readonly [string, string, string]): string {
     'ONLY in the separate "recommendation" field.',
     'Memory: persisting is RARE and OPT-IN. Most turns have NOTHING to remember — then OMIT "remember"',
     'entirely. Use a "remember" object only for a fact that will matter ACROSS MANY FUTURE, UNRELATED',
-    'reviews, grouped by target file (short notes in the user\'s language):',
-    '  {"remember": {"user": ["称呼: Kyle"], "memory": ["repo uses g-<id> for gray apps"], "agents": ["..."]}}',
-    '- user   → the person you talk to: preferred 称呼, language, lasting review/working preferences.',
+    'reviews, grouped by target file. Each note is {"section": "<a fitting ## heading>", "note": "<short, in',
+    "the user's language>\"}:",
+    '  {"remember": {"user": [{"section": "Review preferences", "note": "preferred name: Kyle"}],',
+    '                "memory": [{"section": "Project conventions", "note": "repo uses g-<id> for gray apps"}]}}',
+    '- "section" is REQUIRED: ABSTRACT the note into a durable, general topic. You are NOT limited to existing',
+    '  headings — a target file may have NONE yet (e.g. USER.md starts empty). PREFER reusing a fitting "## ..."',
+    '  already in that file (its current content is shown above, match it verbatim); otherwise FREELY introduce a',
+    '  new concise topical heading (the section set is meant to grow). Only OMIT a note when it is not a durable,',
+    '  generalizable topic at all (a PR-specific finding) — never force such a note in. If a note merely restates',
+    '  guidance already present in that section, do NOT record it.',
+    '- user   → the person you talk to: preferred name, language, lasting review/working preferences.',
     '- memory → durable PROJECT facts (stable architecture / conventions / IDs that outlive any one PR).',
     '- agents → general working norms you should always follow (e.g. reply language, review order).',
     'HARD BAR — do NOT record findings or heuristics tied to THIS PR or a specific feature / module /',
-    'symbol: e.g. "评审涉及 X 时重点核对 Y", "注意 fn() 对数字 ID 误判". Those are this review\'s OUTPUT,',
-    'not durable rules — putting them in agents/memory pollutes future behavior. If a note names a specific',
-    'function / field / feature / scenario, it is a finding, NOT a memory — keep it in the review, omit here.',
+    'symbol: e.g. "when reviewing X, double-check Y", "note: fn() misjudges numeric IDs". Those are this',
+    "review's OUTPUT, not durable rules — putting them in agents/memory pollutes future behavior. If a note",
+    'names a specific function / field / feature / scenario, it is a finding, NOT a memory — keep it in the',
+    'review, omit here.',
     'When in doubt, do NOT record. Over a whole session you should rarely write more than a note or two.',
-    'NEVER record private or sensitive data: real identity beyond a chosen 称呼, email / phone / address,',
+    'NEVER record private or sensitive data: real identity beyond a chosen display name, email / phone / address,',
     'employer-confidential specifics, secrets / tokens. When unsure whether something is private, do NOT record.',
     'Conversation & scope:',
     '- Natural conversation is fine: greet, say who you are, ask a clarifying question — answer directly',

--- a/packages/agent/tests/memory.test.ts
+++ b/packages/agent/tests/memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -9,36 +9,72 @@ async function tempDir(): Promise<string> {
 }
 
 describe('appendAgentNotes', () => {
-  it('appends notes to USER.md under a managed heading and returns the added items', async () => {
+  it('creates the target section when missing and returns the added items', async () => {
     const dir = await tempDir();
-    const added = await appendAgentNotes(dir, 'user', ['称呼: Kyle', '偏好简体中文']);
+    const added = await appendAgentNotes(dir, 'user', [
+      { section: 'Review preferences', note: '称呼: Kyle' },
+      { section: 'Review preferences', note: '偏好简体中文' },
+    ]);
     expect(added).toEqual(['称呼: Kyle', '偏好简体中文']);
     const content = await readFile(path.join(dir, 'USER.md'), 'utf8');
-    expect(content).toContain('## Agent 记录');
-    expect(content).toContain('- 称呼: Kyle');
-    expect(content).toContain('- 偏好简体中文');
+    expect(content).toBe('## Review preferences\n- 称呼: Kyle\n- 偏好简体中文\n');
+  });
+
+  it('appends a note to the end of an EXISTING matching section, before the next heading', async () => {
+    const dir = await tempDir();
+    const file = path.join(dir, 'AGENTS.md');
+    await writeFile(file, '# Title\n\n## AutoPilot\n- skip branch merges\n\n## Grants\n- none\n', 'utf8');
+    const added = await appendAgentNotes(dir, 'agents', [
+      { section: 'AutoPilot', note: 'skip pure dependency bumps' },
+    ]);
+    expect(added).toEqual(['skip pure dependency bumps']);
+    const content = await readFile(file, 'utf8');
+    // 插到 AutoPilot 节末尾、Grants 之前，不破坏后续章节。
+    expect(content).toBe(
+      '# Title\n\n## AutoPilot\n- skip branch merges\n- skip pure dependency bumps\n\n## Grants\n- none\n',
+    );
+  });
+
+  it('creates a new section at file end when the target heading is missing', async () => {
+    const dir = await tempDir();
+    const file = path.join(dir, 'MEMORY.md');
+    await writeFile(file, '## 项目约定\n- existing\n', 'utf8');
+    await appendAgentNotes(dir, 'memory', [{ section: '平台清单', note: 'GitHub → Bitbucket → GitLab' }]);
+    const content = await readFile(file, 'utf8');
+    expect(content).toBe('## 项目约定\n- existing\n\n## 平台清单\n- GitHub → Bitbucket → GitLab\n');
+  });
+
+  it('drops notes without a section (un-abstractable → not durable memory)', async () => {
+    const dir = await tempDir();
+    const added = await appendAgentNotes(dir, 'memory', [
+      { section: '', note: 'this restates a PR finding' },
+      { section: '   ', note: 'another finding' },
+    ]);
+    expect(added).toEqual([]);
+    // 全被丢弃 → 不建文件。
+    await expect(readFile(path.join(dir, 'MEMORY.md'), 'utf8')).rejects.toThrow();
   });
 
   it('dedups against existing content and within the batch (no duplicate writes)', async () => {
     const dir = await tempDir();
-    await appendAgentNotes(dir, 'memory', ['repo uses g- prefix']);
-    const added = await appendAgentNotes(dir, 'memory', ['repo uses g- prefix', 'new fact', 'new fact']);
-    expect(added).toEqual(['new fact']); // 已存在的 / 批内重复的被跳过
+    await appendAgentNotes(dir, 'memory', [{ section: '项目约定', note: 'repo uses g- prefix' }]);
+    const added = await appendAgentNotes(dir, 'memory', [
+      { section: '项目约定', note: 'repo uses g- prefix' },
+      { section: '项目约定', note: 'new fact' },
+      { section: '其他', note: 'new fact' },
+    ]);
+    expect(added).toEqual(['new fact']); // 已存在的 / 批内重复的被跳过（去重只看正文）
     const content = await readFile(path.join(dir, 'MEMORY.md'), 'utf8');
     expect(content.match(/repo uses g- prefix/g)).toHaveLength(1);
     expect(content.match(/new fact/g)).toHaveLength(1);
   });
 
-  it('writes to the file matching the kind (agents → AGENTS.md, append-only)', async () => {
-    const dir = await tempDir();
-    await appendAgentNotes(dir, 'agents', ['always verify tenant mapping']);
-    const content = await readFile(path.join(dir, 'AGENTS.md'), 'utf8');
-    expect(content).toContain('- always verify tenant mapping');
-  });
-
   it('returns empty for blank input without writing', async () => {
     const dir = await tempDir();
-    const added = await appendAgentNotes(dir, 'user', ['', '   ']);
+    const added = await appendAgentNotes(dir, 'user', [
+      { section: 'x', note: '' },
+      { section: 'x', note: '   ' },
+    ]);
     expect(added).toEqual([]);
   });
 });

--- a/packages/agent/tests/planner.test.ts
+++ b/packages/agent/tests/planner.test.ts
@@ -140,10 +140,10 @@ describe('runPlanningAgent', () => {
     expect(r.steps).toHaveLength(0);
   });
 
-  it('accumulates remember notes by target file across actions', async () => {
+  it('accumulates section-tagged remember notes and drops un-abstractable (sectionless) ones', async () => {
     const { deps } = makeDeps([
-      '{"tool":"/review","remember":{"user":["称呼: Kyle"]}}',
-      '{"final":"done","remember":{"memory":["repo uses g- prefix"],"agents":["check tenant mapping"]}}',
+      '{"tool":"/review","remember":{"user":[{"section":"评审偏好","note":"称呼: Kyle"}]}}',
+      '{"final":"done","remember":{"memory":["repo uses g- prefix"],"agents":[{"section":"AutoPilot","note":"check tenant mapping"}]}}',
     ]);
     const r = await runPlanningAgent(deps, {
       context,
@@ -151,9 +151,9 @@ describe('runPlanningAgent', () => {
       toolCatalog: catalog,
       userRequest: 'x',
     });
-    expect(r.memories.user).toEqual(['称呼: Kyle']);
-    expect(r.memories.memory).toEqual(['repo uses g- prefix']);
-    expect(r.memories.agents).toEqual(['check tenant mapping']);
+    expect(r.memories.user).toEqual([{ section: '评审偏好', note: '称呼: Kyle' }]);
+    expect(r.memories.memory).toEqual([]); // 纯字符串无法归类 → 丢弃
+    expect(r.memories.agents).toEqual([{ section: 'AutoPilot', note: 'check tenant mapping' }]);
   });
 
   it('returns a structured recommendation when the review close includes one', async () => {


### PR DESCRIPTION
## 背景

Agent 主动记忆此前把所有条目堆到单一 `## Agent 记录` 区，对跨会话上下文管理不友好——条目无主题、难检索、易污染。

## 改动

- **按专题章节落盘**：每条 `remember` 条目改为**必带 `section`**，抽象归纳后归入目标文件（USER/MEMORY/AGENTS.md）最贴切的既有 `## 专题章节`——命中则追加到该节末尾，不存在则在文件末尾新建。
- **不限于既有章节**：文件可无任何章节（如 USER.md 默认空），允许模型自由新增专题章节（章节集合本就该随用随长）。
- **无法归类即不记录**：归不进任何专题的条目不是耐久记忆（多半是本 PR 的发现），直接丢弃，**取消兜底区**。
- **系统提示词去中文**：`buildProtocol` 内的示例 / 说明改为英文（代码注释按仓库惯例保留中文）。

## 实现

- [memory.ts](packages/agent/src/memory.ts)：`MemoryNote { section; note }`（`section` 必填）；新增 `insertUnderHeading` 把 bullet 插到对应 `## 章节` 末尾（下一标题之前）；删除 `FALLBACK_HEADING`；正文子串去重不变。
- [planner.ts](packages/agent/src/planner.ts)：`AgentMemoryNotes` 各组改为 `MemoryNote[]`；`toNote` 只接受 `{section, note}` 对象（纯字符串 / 缺 section → 丢弃）；更新记忆相关提示词。
- [index.ts](packages/agent/src/index.ts)：导出 `MemoryNote`。
- 文档 [06-agent.md](docs/arch/06-agent.md) 与两处测试同步。

## 验证

`lint` / `typecheck` / `test` 均通过（agent 包 48 tests）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)