### PR TITLE
feat(agent): 评审步骤分步展示 token 用量

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Code Meeseeks（内部开发代号 `meebox`）是命令行工具 [pr-agent](http
 
 > **本地 CLI 模式说明**：该模式不直连模型 API，而是把评审请求转交给使用者**自行安装并授权**的本地命令行工具，由其代为调用背后的第三方模型。需先在本机完成对应 CLI 工具的安装与登录授权，应用本身不负责其凭据管理与计费。
 
+> 💸 **成本提示**：Agentic 评审与 AutoPilot 预评审会对每个 PR 串联多次模型调用（描述、评审、必要时追问、汇总），token 消耗显著高于单次手动评审。无论使用按量计费的 API、还是有额度上限的订阅 / 本地 CLI 账户，都请留意用量节奏，自行评估成本投入；每步的 token 用量已在评审时间线上分步展示，便于观察消耗。
+
 ---
 
 ## 技术栈
@@ -134,8 +136,7 @@ Code Meeseeks（内部开发代号 `meebox`）是命令行工具 [pr-agent](http
 - **工程**：npm workspaces + Nx 单仓多包
 - **pr-agent 集成**：内嵌 Python 运行时子进程（缺失时回退系统 pr-agent CLI）
 
-- **规划进度、里程碑与未决项** —— 见 **[Roadmap](docs/ROADMAP.md)**。
-- **详细架构与各模块设计** —— 见 **[模块文档](docs/arch/README.md)**。
+> 📚 **延伸阅读**：规划进度、里程碑与未决项见 **[Roadmap](docs/ROADMAP.md)**；详细架构与各模块设计见 **[模块文档](docs/arch/README.md)**。
 
 ---
 

--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -1465,6 +1465,34 @@ function AgentStepRow({ step }: { step: AgentStep }) {
           </span>
         )}
         {headText && <span>{headText}</span>}
+        {/* 本步**单独**的 token 用量（不累计）：judge / 总结 / 规划等经独立 LLM 通道的推理步带值；
+            与 run 卡片同款 ↑输入(绿) / ↓输出(红) 计法，靠行尾对齐。describe/review/ask 的开销在各自 run 卡片上。 */}
+        {step.usage &&
+        (step.usage.promptTokens !== undefined || step.usage.completionTokens !== undefined) ? (
+          <span
+            className="chat-agent-step-tokens"
+            title={t('chatPane.tokensTitle', {
+              prompt: step.usage.promptTokens ?? '—',
+              completion: step.usage.completionTokens ?? '—',
+            })}
+          >
+            {step.usage.promptTokens !== undefined && (
+              <>
+                <span style={{ color: '#22c55e' }}>↑</span>
+                {formatTokens(step.usage.promptTokens)}
+              </>
+            )}
+            {step.usage.promptTokens !== undefined && step.usage.completionTokens !== undefined
+              ? ' '
+              : ''}
+            {step.usage.completionTokens !== undefined && (
+              <>
+                <span style={{ color: '#ef4444' }}>↓</span>
+                {formatTokens(step.usage.completionTokens)}
+              </>
+            )}
+          </span>
+        ) : null}
       </div>
       {hasTime && step.thought && <div className="chat-agent-step-body">{step.thought}</div>}
       {step.kind === 'judge' && step.result && (

--- a/apps/desktop/src/renderer/src/styles/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/chat-pane.scss
@@ -249,6 +249,14 @@
   font-size: $fs-md; // 略大，标记更醒目
   line-height: 1;
 }
+// 步骤行内的本步 token 用量（不累计）：等宽数字、顶到行尾，与「已思考 xx s」同一行右侧轻量呈现。
+.chat-agent-step-tokens {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-family: $font-mono;
+  font-variant-numeric: tabular-nums;
+  font-size: $fs-xs;
+}
 // AutoPilot 触发标记：评审首步行内的机器人图标（强调色），表「这次评审由 AutoPilot 触发」。
 .chat-agent-step-autopilot {
   display: inline-flex;

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -298,6 +298,7 @@ export async function runReviewMicroflow(
     thought: '判断是否存在需追问的严重问题',
     result: questions.length ? `严重，追问 ${String(questions.length)} 个` : '无严重问题，不追问',
     thinkMs: judgeMs,
+    usage: judge.usage,
   });
 
   const askResults: string[] = [];
@@ -342,6 +343,7 @@ export async function runReviewMicroflow(
     thought: '综合描述与审查发现，生成评审总结',
     result: summary,
     thinkMs: sumMs,
+    usage: sum.usage,
   });
 
   return { steps, summary, recommendation, tokenUsage: usage };

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -293,14 +293,14 @@ export async function runPlanningAgent(
     // 无法解析 / 既无 tool(s) 又无 final → 当作收尾。兜底从原始文本打捞散文，绝不把原始 JSON 动作丢给用户。
     if (!action || (!hasCalls && !action.final)) {
       const finalText = action?.final ?? salvageProse(r.text);
-      await record({ kind: 'plan', thought: action?.thought, result: finalText, thinkMs });
+      await record({ kind: 'plan', thought: action?.thought, result: finalText, thinkMs, usage: r.usage });
       return { steps, finalText, tokenUsage: usage, memories };
     }
 
     if (action.final && !hasCalls) {
       // 剥掉模型误并入 final 末尾的判定 JSON（recommendation 走独立字段渲染为判定徽标）。
       const finalText = stripTrailingJson(action.final);
-      await record({ kind: 'plan', thought: action.thought, result: finalText, thinkMs });
+      await record({ kind: 'plan', thought: action.thought, result: finalText, thinkMs, usage: r.usage });
       return {
         steps,
         finalText,
@@ -343,6 +343,7 @@ export async function runPlanningAgent(
       thought: action.thought,
       toolCall: { tool: allowed.map((c) => c.tool).join('、') },
       thinkMs,
+      usage: r.usage,
     });
 
     // 并行分发允许的工具（多选时同时跑，实际并发受运行队列约束）；相互错开 100~200ms 起跑，避免同一瞬间齐发。

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -4,6 +4,8 @@
  * 故置于 shared（与 ReviewRun / Finding 同处）。@meebox/agent 的纯逻辑从此引用。
  */
 
+import type { TokenUsage } from './poller-contract.js';
+
 /** 工具的副作用分类与可用性（红线落地的依据，见「工具修改红线」）。 */
 export interface ToolCatalogEntry {
   /** 工具指令名，如 `/describe`。 */
@@ -42,6 +44,9 @@ export interface AgentStep {
   toolCall?: AgentToolCall;
   /** 工具结果 / 判读结论的摘要。 */
   result?: string;
+  /** 本步**单独**的 LLM token 用量（不累计、不含其它步）：judge / 总结 / 规划等经独立通道的推理步在此带值；
+   *  describe/review/ask 的工具开销由其各自 run 卡片承载、不在步骤上重复计。UI 在步骤行展示，使每步成本可见。 */
+  usage?: TokenUsage;
   /** 步骤产生时间（ISO）。 */
   at?: string;
   /** 本步思考（产生该决策的单次 LLM 推理）耗时（毫秒）；类 Claude Code 的「Thought for Ns」单步计时。


### PR DESCRIPTION
## 背景

AutoPilot / Agentic 评审对每个 PR 串联多次模型调用，token 消耗较快，但过程中缺少**每步**成本可见性：describe/review/ask 的开销已在各自 run 卡片显示，而 judge / 总结 / 规划等经独立 LLM 通道的推理步**完全无展示**。

## 改动

**分步记录、不累计**
- `AgentStep` 新增 `usage?: TokenUsage`（本步单独用量）。
- orchestrator：judge 步挂 `judge.usage`、总结步挂 `sum.usage`。
- planner：每个决策步（final / 兜底 final / 工具派发）挂该轮 `r.usage`；工具拒绝的辅助记录不挂（非独立模型调用）。

**展示**
- `AgentStepRow` 首行右侧加 token chip（↑输入绿 / ↓输出红，等宽数字），tooltip 复用既有 `tokensTitle`，**无新增 i18n**。
- 新增 `.chat-agent-step-tokens` 样式。

> 覆盖完整性：工具调用开销由 run 卡片承载、推理步开销由步骤行承载，互不累计、无重复计。usage 端到端来自 shim（API 模式读 litellm `response.usage`；CLI 模式解析 `claude -p --output-format json` 自带的 usage 块）。

**文档**
- README：Roadmap / 模块文档两行抽出为独立「延伸阅读」引用段；模型支持节补「成本提示」引用段。

## 验证

本地 `lint` / `typecheck` / `test`（含 planner/orchestrator）/ `build` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
