### PR TITLE
feat(review): describe 文件变更体验优化（分类默认折叠 + 标题国际化）

### DIFF
--- a/apps/desktop/src/renderer/src/components/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatPane.tsx
@@ -34,7 +34,7 @@ import {
 } from './icons';
 import { ConfirmModal } from './ConfirmModal';
 import { PaneLoading } from './Loading';
-import { mermaidComponents } from './markdownMermaid';
+import { mermaidComponents, walkthroughMdComponents } from './markdownMermaid';
 import { REMOTE_REHYPE_PLUGINS } from '../markdown';
 import { useChatRunStore } from '../stores/chat-run-store';
 import { useDraftsForPr } from '../stores/drafts-store';
@@ -2455,7 +2455,8 @@ function FindingCard({
             <ReactMarkdown
               remarkPlugins={[remarkGfm, remarkBreaks]}
               rehypePlugins={REMOTE_REHYPE_PLUGINS}
-              components={mermaidComponents}
+              // 「文件变更」walkthrough 用去掉 <details open> 的覆盖，使各文件分类默认折叠收起。
+              components={key === 'walkthrough' ? walkthroughMdComponents : mermaidComponents}
             >
               {translatedBody}
             </ReactMarkdown>

--- a/apps/desktop/src/renderer/src/components/markdownMermaid.tsx
+++ b/apps/desktop/src/renderer/src/components/markdownMermaid.tsx
@@ -41,3 +41,13 @@ export const mermaidComponents: Components = {
     return <pre {...rest}>{children}</pre>;
   },
 };
+
+/**
+ * describe「文件变更」walkthrough 专用 components：在 mermaid 覆盖之上再去掉 <details> 的 open
+ * 属性。pr-agent 把各文件分类（功能增强 / 配置变更 …）输出为 <details open> 默认展开，文件多时正文
+ * 很长；去掉 open 让每个分类默认折叠收起，点 <summary> 标题按需展开（原生 <details> 交互、不持久化）。
+ */
+export const walkthroughMdComponents: Components = {
+  ...mermaidComponents,
+  details: ({ node: _node, open: _open, ...rest }) => <details {...rest} />,
+};

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
@@ -77,6 +77,7 @@
   "Configuration changes": "Konfigurationsänderungen",
   "Tests": "Tests",
   "Other": "Sonstiges",
+  "Miscellaneous": "Verschiedenes",
   "High": "Hoch",
   "Medium": "Mittel",
   "Low": "Niedrig"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
@@ -77,6 +77,7 @@
   "Configuration changes": "設定変更",
   "Tests": "テスト",
   "Other": "その他",
+  "Miscellaneous": "雑多",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
@@ -77,6 +77,7 @@
   "Configuration changes": "配置变更",
   "Tests": "测试",
   "Other": "其他",
+  "Miscellaneous": "杂项",
   "High": "高",
   "Medium": "中",
   "Low": "低"


### PR DESCRIPTION
## 背景

describe 输出的「文件变更」walkthrough 存在两个体验问题：
1. pr-agent 把各文件分类（功能增强 / 配置变更 …）输出为 `<details open>`，默认全部展开，文件多时正文很长。
2. 部分分类标题（如 `Miscellaneous`）未在 pr-agent 标签字典中，中/日/德 UI 下仍显示英文。

## 改动

**分类默认折叠**
- 新增 `walkthroughMdComponents`（[markdownMermaid.tsx](apps/desktop/src/renderer/src/components/markdownMermaid.tsx)）：在 mermaid 覆盖之上加 `details` 覆盖，去掉 `open` 属性。
- [ChatPane.tsx](apps/desktop/src/renderer/src/components/ChatPane.tsx) 仅当 `key === 'walkthrough'` 时启用，使各分类默认折叠收起、点标题按需展开（原生 `<details>` 交互）。
- 只作用于 walkthrough finding，不影响评论 / PR 描述等其它远端 markdown。

**分类标题国际化**
- `pr-agent-labels` 三语字典各补 `Miscellaneous`（杂项 / 雑多 / Verschiedenes），与 `Other` 区分。字面量子串替换，计数后缀（`Miscellaneous (2)`）不受影响。

> pr-agent 的 walkthrough 分类标签为 LLM 自由产出，未来若再现其它英文标题，同样在这三份字典补行即可（未臆测预填，避免错译）。

## 验证

本地 `typecheck` / `lint` / `build` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
