### PR TITLE
feat(agent): PR 列表执行中标记覆盖思考态 + 评审星标改四角

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -169,14 +169,14 @@ export function registerIpcHandlers({
   /** 生效的 Agent 目录：用户配置优先，未配置则回落工作目录默认位置（~/.code-meeseeks/agent）。 */
   const effectiveAgentDir = (): string => bootstrap.config.agent.dir || bootstrap.paths.agentDir;
 
-  // /ask 输出去重：pr-agent answer markdown 里会回显完整问题，跟 UI chat-user-msg
-  // 气泡重复。逐行精确匹配 question (含 trim 后) 的行整行删掉，保留其余正文
-  const stripAskQuestionEcho = (md: string, question: string): string => {
-    const q = question.trim();
-    if (!q || !md) return md;
+  // /ask 输出去重：pr-agent answer markdown 里会回显完整问题（以及我们追加到问题末尾的语言要求），
+  // 跟 UI chat-user-msg 气泡重复。逐行精确匹配（trim 后整行 == 任一给定串）删掉，保留其余正文。
+  const stripAskQuestionEcho = (md: string, ...echoed: string[]): string => {
+    const qs = new Set(echoed.map((q) => q.trim()).filter(Boolean));
+    if (!qs.size || !md) return md;
     return md
       .split('\n')
-      .filter((line) => line.trim() !== q)
+      .filter((line) => !qs.has(line.trim()))
       .join('\n');
   };
 
@@ -1075,8 +1075,18 @@ export function registerIpcHandlers({
         );
       }
 
-      // ask 工具的问题作为位置参数 (spawn args 单元素，含空格也是一个 arg 不切分)
-      const extraArgs = req.tool === 'ask' && req.question ? [req.question] : undefined;
+      // ask 工具：问题作为位置参数（user turn，spawn args 单元素，含空格也是一个 arg 不切分），
+      // 并在问题**末尾**硬性追加语言要求。系统侧 CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS 对
+      // 自由问答常被大量英文 diff（full diff 数万 token）盖过 → 模型用英文作答；在 user turn 末尾
+      // （近因位置、用目标语言书写）再要求一次，显著提升按 UI 语言作答的遵循度。en-US 返回空、不追加。
+      const askLangSuffix = req.tool === 'ask' ? askLanguageSuffixFor(getMainLanguage()) : '';
+      const askQuestion =
+        req.tool === 'ask' && req.question
+          ? askLangSuffix
+            ? `${req.question}\n\n${askLangSuffix}`
+            : req.question
+          : undefined;
+      const extraArgs = askQuestion ? [askQuestion] : undefined;
 
       // embedded 策略：执行期在嵌入式安装目录补空 .secrets.toml 压掉启动告警
       // （直接写安装目录；memo 化只首次做）。local-cli 不需要 (pipx 装的 pr-agent
@@ -1123,7 +1133,7 @@ export function registerIpcHandlers({
       // 重复)。在解析前把跟用户问题逐字匹配的整行删掉，避免渲染时出现两次问题
       const cleanedContent =
         req.tool === 'ask' && req.question?.trim()
-          ? stripAskQuestionEcho(fileContent, req.question)
+          ? stripAskQuestionEcho(fileContent, req.question, askLangSuffix)
           : fileContent;
       const parsed = parseReviewOutput(cleanedContent || result.stdout, req.tool);
       // M4 草稿再摄入：/review 成功完成时丢掉 pending+finding 旧草稿，
@@ -2318,6 +2328,28 @@ function languageDirectiveFor(lang: string): string {
   }
   if (norm.startsWith('de')) {
     return 'Respond in German (Deutsch). All section labels, table headers, column names, headings, and content MUST be in German — do not leave any English template strings untranslated.';
+  }
+  return '';
+}
+
+/**
+ * /ask 专用：把语言要求作为「问题末尾」的硬性指令，**用目标语言书写本身**（最能促使模型切换到该
+ * 语言作答）。系统侧 CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS 对自由问答常被大量英文 diff
+ * 盖过，故在 user turn 末尾（近因位置）再要求一次。en-US / 未知 locale 返回空串（默认即英文）。
+ */
+function askLanguageSuffixFor(lang: string): string {
+  const norm = lang.toLowerCase();
+  if (norm.startsWith('zh-cn') || norm === 'zh') {
+    return '请用简体中文回答整个回复（包括所有解释、说明与结论）。代码、标识符、文件路径保留原样，但所有叙述文字必须是简体中文，不要用英文作答。';
+  }
+  if (norm.startsWith('zh-tw') || norm.startsWith('zh-hk')) {
+    return '請用繁體中文回答整個回覆（包括所有解釋、說明與結論）。程式碼、識別符、檔案路徑保留原樣，但所有敘述文字必須是繁體中文，不要用英文作答。';
+  }
+  if (norm.startsWith('ja')) {
+    return '回答全体を日本語で記述してください（説明・結論を含む）。コード・識別子・ファイルパスはそのまま残し、説明文はすべて日本語にしてください。英語で回答しないでください。';
+  }
+  if (norm.startsWith('de')) {
+    return 'Bitte antworte vollständig auf Deutsch (einschließlich aller Erklärungen und Schlussfolgerungen). Code, Bezeichner und Dateipfade bleiben unverändert, aber der gesamte erläuternde Text muss auf Deutsch sein. Antworte nicht auf Englisch.';
   }
   return '';
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1389,6 +1389,24 @@ export function registerIpcHandlers({
   // agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
   const agentControllers = new Map<string, AbortController>();
 
+  // 运行中（思考或派发工具）的编排 Agent 所属 PR 集合，向 renderer 广播「执行中」。区别于
+  // agentControllers（仅手动可停会话）：这里**手动 run/ask 与 AutoPilot 后台评审一并计入**，
+  // 让 PR 列表项在纯思考阶段（无活跃工具 run）也显示执行中标记。
+  const runningAgentPrs = new Set<string>();
+  const broadcastAgentRunning = (): void => {
+    const prLocalIds = [...runningAgentPrs];
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('agent:runningChanged', { prLocalIds });
+    }
+  };
+  const markAgentRunning = (localId: string): void => {
+    runningAgentPrs.add(localId);
+    broadcastAgentRunning();
+  };
+  const unmarkAgentRunning = (localId: string): void => {
+    if (runningAgentPrs.delete(localId)) broadcastAgentRunning();
+  };
+
   /** 取消某 PR 的全部 pr-agent run：active 的 SIGKILL，waiting 的出队 + reject。 */
   const cancelRunsForPr = (localId: string): void => {
     for (const item of active.values()) if (item.req.localId === localId) item.ac?.abort();
@@ -1505,6 +1523,7 @@ export function registerIpcHandlers({
       // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
+      markAgentRunning(pr.localId);
       logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
       try {
         const session = await withAgentChat(
@@ -1520,6 +1539,7 @@ export function registerIpcHandlers({
         return session;
       } finally {
         agentControllers.delete(pr.localId);
+        unmarkAgentRunning(pr.localId);
       }
     },
   );
@@ -1577,6 +1597,7 @@ export function registerIpcHandlers({
       });
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
+      markAgentRunning(pr.localId);
       // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
       logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
       try {
@@ -1596,6 +1617,7 @@ export function registerIpcHandlers({
         return session;
       } finally {
         agentControllers.delete(pr.localId);
+        unmarkAgentRunning(pr.localId);
       }
     },
   );
@@ -1728,10 +1750,16 @@ export function registerIpcHandlers({
           // （run-queue maxConcurrency）尽量被填满，而非逐 PR 串行空等。各 PR 写各自的文件，无竞争。
           await Promise.all(
             toReview.map(async (pr) => {
-              const session = await runReviewForPr(pr, agentContext, chat, undefined, true);
-              // done：落「评审总结」消息 + 台账（含 verdict）+ 广播会话变更（与手动评审一致）。
-              // 失败 / 暂停不落台账 → 无产出，下轮可重试（准入闸 2 用 hasReviewOutput 判，不再靠台账拦）。
-              await recordReviewSummaryMessage(pr, session);
+              // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
+              markAgentRunning(pr.localId);
+              try {
+                const session = await runReviewForPr(pr, agentContext, chat, undefined, true);
+                // done：落「评审总结」消息 + 台账（含 verdict）+ 广播会话变更（与手动评审一致）。
+                // 失败 / 暂停不落台账 → 无产出，下轮可重试（准入闸 2 用 hasReviewOutput 判，不再靠台账拦）。
+                await recordReviewSummaryMessage(pr, session);
+              } finally {
+                unmarkAgentRunning(pr.localId);
+              }
             }),
           );
         });

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -97,11 +97,12 @@ export function Sidebar({
     Record<string, AgentRecommendationVerdict>
   >({});
 
-  // 「执行中」指示数据源：运行队列里有在跑 / 排队 run 的 PR 集合（active + waiting），随队列实时变化。
-  const { active, waiting } = useChatRunStore();
+  // 「执行中」指示数据源：运行队列里有在跑 / 排队 run 的 PR（active + waiting），**并上**有编排 Agent
+  // 运行中的 PR（agentPrs，含纯思考阶段、无活跃工具 run 时）——补齐 agent 思考态下列表项缺执行中标记的空档。
+  const { active, waiting, agentPrs } = useChatRunStore();
   const executingPrIds = useMemo(
-    () => new Set([...active, ...waiting].map((r) => r.prLocalId)),
-    [active, waiting],
+    () => new Set([...active.map((r) => r.prLocalId), ...waiting.map((r) => r.prLocalId), ...agentPrs]),
+    [active, waiting, agentPrs],
   );
 
   // 有发现分类标签时（GitHub / Bitbucket 均含「我创建的」），reviewer 决断类（通过/需修改）

--- a/apps/desktop/src/renderer/src/components/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/icons.tsx
@@ -433,7 +433,8 @@ export function RobotIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 实心五角星：评审建议徽标（手动 / AutoPilot 一视同仁）。SVG 保证字形居中、跨平台一致。 */
+/** 实心四角星（AI 常见 sparkle）：评审建议徽标（手动 / AutoPilot 一视同仁）。四条边向中心内凹，
+ *  四个尖角居中对称，SVG 保证字形居中、跨平台一致。 */
 export function StarIcon({ size = 11 }: IconProps) {
   return (
     <svg
@@ -443,7 +444,7 @@ export function StarIcon({ size = 11 }: IconProps) {
       fill="currentColor"
       aria-hidden="true"
     >
-      <path d="M8 1l1.65 4.74 5.01.1-4 3.03 1.45 4.79L8 10.8l-4.11 2.86 1.45-4.79-4-3.03 5.01-.1L8 1z" />
+      <path d="M8 1 Q9 7 15 8 Q9 9 8 15 Q7 9 1 8 Q7 7 8 1 Z" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/stores/chat-run-store.ts
+++ b/apps/desktop/src/renderer/src/stores/chat-run-store.ts
@@ -18,9 +18,17 @@ export interface ChatRunStoreState {
   waiting: ReadonlyArray<PragentRunInfo>;
   /** 各 run 的实时 stdout 行缓存。键 = runId；run 完成后保留直到 clearLines 调用 */
   linesByRunId: ReadonlyMap<string, ReadonlyArray<string>>;
+  /** 有编排 Agent 运行中（思考或派发工具）的 PR localId 集合——含纯思考阶段（无活跃工具 run），
+   *  来自主进程 `agent:runningChanged`。PR 列表项「执行中」指示在工具队列之外再并入此集合。 */
+  agentPrs: ReadonlyArray<string>;
 }
 
-let state: ChatRunStoreState = { active: [], waiting: [], linesByRunId: new Map() };
+let state: ChatRunStoreState = {
+  active: [],
+  waiting: [],
+  linesByRunId: new Map(),
+  agentPrs: [],
+};
 const subscribers = new Set<() => void>();
 
 function notify(): void {
@@ -62,6 +70,19 @@ function setQueue(
   notify();
 }
 
+/** 集合相等（顺序无关）：长度相同且每个 id 都在旧集合里。避免广播顺序差异引发无谓 re-render。 */
+function sameIdSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every((id) => sa.has(id));
+}
+
+function setAgentPrs(ids: ReadonlyArray<string>): void {
+  if (sameIdSet(state.agentPrs, ids)) return;
+  state = { ...state, agentPrs: ids };
+  notify();
+}
+
 function appendLine(runId: string, line: string): void {
   const cur = state.linesByRunId.get(runId) ?? [];
   const nextMap = new Map(state.linesByRunId);
@@ -87,6 +108,7 @@ export const chatRunStore = {
     };
   },
   setQueue,
+  setAgentPrs,
   appendLine,
   clearLines,
 };
@@ -119,9 +141,14 @@ export function wireChatRunStore(): () => void {
   const unsubProgress = subscribe('pragent:runProgress', (ev) => {
     chatRunStore.appendLine(ev.runId, ev.line);
   });
+  // 编排 Agent 运行中（含纯思考阶段）的 PR 集合：手动 run/ask 与 AutoPilot 后台评审一并计入。
+  const unsubAgentRunning = subscribe('agent:runningChanged', (ev) => {
+    chatRunStore.setAgentPrs(ev.prLocalIds);
+  });
   return () => {
     cancelled = true;
     unsubQueue();
     unsubProgress();
+    unsubAgentRunning();
   };
 }

--- a/apps/desktop/src/renderer/src/styles/sidebar.scss
+++ b/apps/desktop/src/renderer/src/styles/sidebar.scss
@@ -257,16 +257,23 @@
   margin-left: auto;
 }
 
-// reviewer 统计胶囊：靠右贴边，把 author/branch meta 挤左
+// reviewer 统计胶囊：靠右贴边，把 author/branch meta 挤左。固定带高 + 居中：让不同行无论含哪种
+// chip（文字计数 / 图标星标 / 执行中 spinner）都占同一高度，避免跨行 chip 垂直位置漂移。
 .pr-item-review-chips {
   display: inline-flex;
+  align-items: center;
+  min-height: 18px;
   gap: $space-2;
   margin-left: auto;
 }
 
+// 所有 chip 统一带高（含图标类 verdict / mergeable 与文字类 approved / needs-work）：图标 chip 原本
+// 只有 ~13px、比文字 chip(~17px)矮，导致「星标 only」行与「星标+计数」行高度不一。固定 18px + 居中对齐。
 .review-chip {
   display: inline-flex;
   align-items: center;
+  box-sizing: border-box;
+  height: 18px;
   gap: 3px;
   padding: 1px $space-3;
   border-radius: $radius-pill;

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
@@ -78,6 +78,7 @@
   "Tests": "Tests",
   "Other": "Sonstiges",
   "Miscellaneous": "Verschiedenes",
+  "Formatting": "Formatierung",
   "High": "Hoch",
   "Medium": "Mittel",
   "Low": "Niedrig"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
@@ -78,6 +78,7 @@
   "Tests": "テスト",
   "Other": "その他",
   "Miscellaneous": "雑多",
+  "Formatting": "フォーマット",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
@@ -78,6 +78,7 @@
   "Tests": "测试",
   "Other": "其他",
   "Miscellaneous": "杂项",
+  "Formatting": "格式化",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -139,6 +139,12 @@ export interface IpcEvents {
    * 该 PR 则据此重载会话，让后台产生的总结卡片即时出现（手动评审走 invoke 返回后自行重载，不依赖此事件）。
    */
   'agent:conversationChanged': { prLocalId: string };
+  /**
+   * 运行中（思考或派发工具）的编排 Agent 所属 PR 集合变化时推送：手动 `agent:run` / `agent:ask`
+   * 与 AutoPilot 后台评审一并计入。renderer 据此在 PR 列表项显示「执行中」指示——覆盖**纯思考阶段**
+   * （无活跃工具 run 时），补齐仅看运行队列时思考态缺失执行中标记的空档。
+   */
+  'agent:runningChanged': { prLocalIds: string[] };
 }
 
 export type IpcEventName = keyof IpcEvents;


### PR DESCRIPTION
## 背景

两个交互问题：
1. 主 agent 处于**思考态**（LLM 推理、尚未派发工具）时，PR 列表项缺少「执行中」标记——此前执行中只来自 pr-agent 工具 run 队列。
2. 评审建议星标用的是五角星，期望换成 AI 常见的四角 sparkle ✦。

## 改动

**① 执行中标记覆盖思考态**
- 根因：执行中指示只看工具 run 队列（`chatRunStore.active/waiting`）；ChatPane 思考态是面板局部、Sidebar 读不到；AutoPilot 后台评审不在可停注册表。
- 主进程新增统一「运行中 agent PR 集合」`runningAgentPrs`，在**手动 `agent:run`/`agent:ask` 与 AutoPilot 后台评审**三处 mark/unmark，经新增推送事件 `agent:runningChanged` 广播。
- renderer `chat-run-store` 新增 `agentPrs` 订阅之；`Sidebar` 并入 `executingPrIds`。
- 效果：agent 一进入思考即显示执行中 spinner（含后台 AutoPilot），工具阶段照旧。

**② 星标五角 → 四角**
- `StarIcon` 的 SVG path 改为四角内凹、尖角居中对称的 sparkle。仅评审建议徽标（PrItem）使用，无其它影响。

## 验证

本地 `lint` / `typecheck` / `test` / `build` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
