### PR TITLE
fix: 评论嵌套展示统一拉平 + 评审状态/提交数等交互修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,31 @@
 
 ## [Unreleased]
 
+### Added
+
+- 评审步骤分步展示 token 用量：judge / 总结 / 规划等经独立通道的推理步在步骤行右侧显示本步
+  输入 / 输出 token（不累计）；工具调用的开销仍由各自运行卡片承载。
+- PR 列表项「执行中」标记覆盖 Agent **纯思考阶段**（无活跃工具运行时，含后台 AutoPilot），不再只在工具运行时显示。
+
+### Changed
+
+- describe「文件变更」walkthrough 各文件分类（功能增强 / 配置变更 …）默认折叠，点分类标题按需展开，避免输出过长。
+- **评论嵌套展示统一**（评论 tab + 行内评论）：回复满 5 层后拉平为同一缩进层级、纵向排列并加横向分割线，
+  避免无限右移；嵌套回复改走「左竖线缩进」的扁平样式（不再层层卡片「盒中盒」），两处视觉一致。
+- 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
+- /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
+- 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
+
+### Fixed
+
+- 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
+- PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
+- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+
 ## [0.5.0-alpha.1] - 2026-06-17
 
 ### Added
+
 - **高阶 Agent（会话 Agent 化 + AutoPilot 预评审）**：在 PR 评审中引入可委派的智能体能力，随 LLM
   配置自动可用、无需单独的启用开关。
   - **一键自动评审**：聊天框命令区右侧新增自动评审按钮（✦ 图标），对当前 PR 跑「描述 → 评审 →
@@ -43,6 +65,7 @@
   Windows/Linux 开头另显应用图标（macOS 因红绿灯占位不显）。
 
 ### Changed
+
 - **移除独立 `ollama` provider**，统一经 `openai-compatible` 接入本地 Ollama（Base URL 填
   `http://localhost:11434/v1`）：Ollama 自带 OpenAI 兼容端点，走此路径更标准稳健。旧 `ollama` 配置
   加载时**自动迁移**为 `openai-compatible` 并补足 `/v1`，存量无感升级。
@@ -56,6 +79,7 @@
   点分类标题按需展开，避免 describe 输出过长（仅作用于 walkthrough，不影响其它折叠区）。
 
 ### Fixed
+
 - **修复 PR diff 基准随目标分支漂移导致的「修改被撤回」误判**：此前文件内容（Monaco 左栏）按目标
   分支当前 tip（`targetRef.sha`）读取，目标分支被别的 PR 合入而前移后，编辑器实际成了两点对比，
   别的 PR 的改动会以倒挂 / 撤回形式串进当前 PR 的 diff（变更文件列表用三点 diff 本不受影响，但内容
@@ -86,6 +110,7 @@
 > UAC 提权运行；安装后的应用以普通权限启动。从旧版升级会自动清理旧安装，无需手动卸载。
 
 ### Added
+
 - **GitLab 接入**（gitlab.com + Self-Managed，CE / EE，REST API v4）：新增 `@meebox/platform-gitlab`
   适配器——MR 发现（`reviewer_username` 待我评审，跨项目）、diff 评论读 / 发 / 改 / 删 / 回复
   （discussions + notes 归一）、合并、clone（PAT / SSH）、头像 / 内嵌附件代理。设置页与首启向导可
@@ -96,6 +121,7 @@
   - 嵌套 group 路径、N+1 取详情（diff_refs / 审批）、行内评论按 `position` 三 sha 锚定。
 
 ### Changed
+
 - 拒绝代码反馈 / 改进建议后，卡片自动折叠收起并置灰：左色条转中性灰、类别 chip 置灰，正文与
   代码对比收起，仅保留头部与锚点行（含撤销入口）；头部 chevron 图标可临时展开回看。降低已决断
   项的视觉占用。
@@ -112,6 +138,7 @@
   依赖上游 CLI（claude / codex 等）、行为可能随上游版本变更，稳定性与持续可用性不作保证。
 
 ### Fixed
+
 - Bitbucket 评论内嵌附件图片不渲染：`rehype-sanitize` 的协议白名单（`src` / `href` 仅
   http/https）在 `urlTransform` 之前即剥掉 `attachment:` 内部协议，使 img/a 收不到 src/href、
   图片代理永不触发（属随 sanitize 链引入的回归）。schema 放行 `attachment` 协议；并让附件拉取
@@ -138,6 +165,7 @@
 ## [0.3.1] - 2026-06-11
 
 ### Fixed
+
 - **macOS 分发版「本地 CLI」provider（claude / codex）失效**（Finder/Dock 启动）：macOS GUI 应用
   只继承 launchd 的最小 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），读不到 shell 配置，故找不到装在
   `~/.local/bin` / homebrew 等目录的 CLI，评审报错（`litellm ... LLM Provider NOT provided` 或

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -772,12 +772,14 @@ export function registerIpcHandlers({
     ): Promise<IpcChannels['diff:commitCount']['response']> => {
       const pr = await findPrOrThrow(req.localId);
       const id = repoIdentityFor(pr);
-      // 本地 git 算 base..head；不打远端、不主动触发 sync。镜像还没拉齐就返回 null，
+      // 本地 git 算提交数；不打远端、不主动触发 sync。镜像还没拉齐就返回 null，
       // UI 角标暂不显示，等下次 poll 触发 syncMirror 完成后自然命中。
-      // base 用固定 merge-base：base..head（base 为 merge-base 时）即 PR 自身提交数，
-      // 与三点 diff 同源、对目标分支前移稳定（旧版用 targetRef.sha 会随漂移跳变）
-      const base = await resolveDiffBaseSha(pr);
-      const n = await repoMirror.countCommits(id, base, pr.sourceRef.sha);
+      // 口径 = PR 自身提交（源分支「不在目标分支上」的非 merge 提交），对齐平台 /commits 列表。
+      // **基准用目标分支 sha（head ^target）而非固定 merge-base**：源分支把目标分支（如 dev）合入自己后，
+      // merge-base 之后被带进来的目标提交也可达 head、不可达 merge-base → 用 merge-base 会把它们误计
+      // （标 31 实则 2）。以 targetRef.sha 排除这些合入提交；merge 提交本身由 countCommits 的 --no-merges 略去。
+      // （diff 仍用固定 merge-base 保稳定，与本计数口径各司其职。）
+      const n = await repoMirror.countCommits(id, pr.targetRef.sha, pr.sourceRef.sha);
       return n === null ? null : { count: n };
     },
   );

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -203,7 +203,7 @@ export function registerIpcHandlers({
         } catch {
           await fs.writeFile(
             f,
-            '# meebox 占位空文件：抑制 pr-agent 缺失 .secrets.toml 的启动告警\n',
+            '# meebox placeholder: silence pr-agent warning about a missing .secrets.toml\n',
           );
         }
       }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -40,6 +40,7 @@ import {
   writeCommentsCache,
   writeAutopilotLedger,
   getAutopilotLedger,
+  clearAutopilotLedger,
   getAgentSession,
   clearAgentSession,
   getAgentConversation,
@@ -1842,6 +1843,12 @@ export function registerIpcHandlers({
       // 清执行历史时一并清掉 Agent 会话（含收尾 summary / 步骤 transcript），否则清空后
       // 重开 PR 仍会从落盘会话恢复出「评审总结」卡片。
       await clearAgentSession(stateStore, req.localId);
+      // 一并清掉 AutoPilot 台账（评审建议 verdict），并广播 → PR 列表该 PR 的 ★ 徽标即时消失，
+      // 不残留陈旧评审状态、也不必等下个 poll 重取台账。
+      await clearAutopilotLedger(stateStore, req.localId);
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('agent:reviewStatusCleared', { prLocalId: req.localId });
+      }
       return { cleared: await clearReviewRunsForPr(stateStore, req.localId) };
     },
   );

--- a/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
@@ -137,9 +137,16 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
 }
 
 /**
+ * 嵌套回复的最大缩进层级：满此层级后继续递归但**不再加缩进**（拉平展示），避免深嵌套把内容挤到
+ * 右侧极窄。depth 0 为顶层评论；depth 1..MAX 逐级缩进，超过 MAX 的更深回复一律平铺在 MAX 层缩进上，
+ * 仍按作者归属可读。Bitbucket 实际只一层 reply，GitHub / GitLab 可深嵌套，故设上限。
+ */
+const MAX_REPLY_DEPTH = 5;
+
+/**
  * 单条评论 + 嵌套 replies。inline 评论顶部显示 `path:line side` chip 区分锚点位置；
- * summary 评论不挂 chip。replies 走递归，depth 控制左侧缩进 (Bitbucket 实际只一层 reply
- * 但 schema 允许深嵌套，递归更稳)。
+ * summary 评论不挂 chip。replies 走递归，depth 控制左侧缩进；满 MAX_REPLY_DEPTH 层后拉平
+ * （不再加缩进，见该常量）。
  */
 function CommentItem({
   comment,
@@ -192,7 +199,7 @@ function CommentItem({
   };
 
   return (
-    <li className={`pr-comment pr-comment-depth-${String(depth)}`}>
+    <li className={`pr-comment pr-comment-depth-${String(Math.min(depth, MAX_REPLY_DEPTH))}`}>
       <div className="pr-comment-head">
         <Avatar
           connectionId={pr.connectionId}
@@ -311,7 +318,11 @@ function CommentItem({
         />
       )}
       {comment.replies.length > 0 && (
-        <ul className="pr-comments-list pr-comments-replies">
+        // 满 MAX_REPLY_DEPTH 层后用 pr-comments-flat 取代 pr-comments-replies（不再缩进 / 左边框）→
+        // 更深回复拉平在该层缩进上；pr-comments-flat 据此给同层级相邻评论加横向分割线区分。
+        <ul
+          className={`pr-comments-list ${depth < MAX_REPLY_DEPTH ? 'pr-comments-replies' : 'pr-comments-flat'}`}
+        >
           {comment.replies.map((r) => (
             <CommentItem
               key={r.remoteId}

--- a/apps/desktop/src/renderer/src/components/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/DiffView.tsx
@@ -1655,11 +1655,11 @@ function makeCommentMarkdownComponents(
 }
 
 /**
- * 递归渲染单条评论 + 它的回复子树。Bitbucket 的 comment.comments[] 是任意层级的，
- * 之前只画了第一层 → 第三层及以上不显示；这里递归到底。每往下一层左移 18px
- * 并多一道左竖线（跟 Bitbucket 原生 UI 视觉对齐）。
+ * 递归渲染单条评论 + 它的回复子树。comment.replies 是任意层级的；这里递归到底。每往下一层
+ * 步进缩进 + 一道左竖线（缩进量 / 边框色与评论 tab 的 .pr-comments-replies 对齐，见 comment-zone.scss）。
  */
-/** 嵌套缩进最大 5 层；第 6 层起 ml=0，跟第 5 层左对齐（避免过深一直右滑） */
+/** 嵌套缩进最大 5 层；超过此层级的更深回复**拉平**（comment-zone-reply-flat：去步进 / 边框 / 左 padding），
+ *  平铺在第 5 层缩进上、上下排列，避免无限嵌套一直右滑。 */
 const MAX_REPLY_INDENT_DEPTH = 5;
 
 function CommentNode({
@@ -1831,12 +1831,12 @@ function CommentNode({
     </>
   );
   if (depth === 0) return inner;
-  // 第 1~5 层每层缩进 18px (相对父)；第 6+ 层 ml=0 跟上一级平齐
-  const ml = depth <= MAX_REPLY_INDENT_DEPTH ? 18 : 0;
+  // 满 MAX_REPLY_INDENT_DEPTH 层后**拉平**：去掉步进缩进与左竖线，更深回复平铺在上限层级上
+  // （与评论 tab 设计一致）。关键：必须同时去掉 padding-left 与 border —— 仅去步进、保留每层的
+  // padding/border 会逐级累加仍右移（之前"还是有缩进"的根因）。
+  const flat = depth > MAX_REPLY_INDENT_DEPTH;
   return (
-    <div className="comment-zone-reply" style={{ marginLeft: ml }}>
-      {inner}
-    </div>
+    <div className={`comment-zone-reply${flat ? ' comment-zone-reply-flat' : ''}`}>{inner}</div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import type {
   PrDiscoveryFilter,
   StoredPullRequest,
 } from '@meebox/shared';
-import { invoke } from '../api';
+import { invoke, subscribe } from '../api';
 import { useChatRunStore } from '../stores/chat-run-store';
 import { PrItem } from './PrItem';
 
@@ -132,6 +132,19 @@ export function Sidebar({
       cancelled = true;
     };
   }, [prs]);
+
+  // 清空某 PR 执行历史会一并清掉其 AutoPilot 台账 → 即时清掉该 PR 的评审建议 ★（不必等下个 poll 重取）。
+  useEffect(() => {
+    const unsub = subscribe('agent:reviewStatusCleared', (ev) => {
+      setReviewVerdicts((prev) => {
+        if (!(ev.prLocalId in prev)) return prev;
+        const next = { ...prev };
+        delete next[ev.prLocalId];
+        return next;
+      });
+    });
+    return unsub;
+  }, []);
 
   // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
   // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。

--- a/apps/desktop/src/renderer/src/styles/comment-zone.scss
+++ b/apps/desktop/src/renderer/src/styles/comment-zone.scss
@@ -183,13 +183,23 @@
 // (前 5 层每层 18px，第 6+ 层 0 跟第 5 层平齐)
 .comment-zone-reply {
   margin-top: $space-4;
+  // 每层步进 12px + 左竖线 —— 缩进量与边框色对齐评论 tab 的 .pr-comments-replies（$space-6 / $border-muted）。
+  margin-left: $space-6;
   padding: $space-2 0 $space-2 $space-5;
-  border-left: 2px solid $border-default;
+  border-left: 2px solid $border-muted;
   // 字号继承父级 (.monaco-comment-zone-inner 14px)，不再缩减 — 嵌套 reply 跟
   // 父评论同等可读性，视觉层级靠左侧 border + indent 区分就够
 
   & + & {
     margin-top: $space-3;
+  }
+
+  // 满 MAX_REPLY_INDENT_DEPTH 层后拉平：去步进 / 去左竖线 / 去左 padding，更深回复平铺在上限层级上。
+  // 必须三者全去 —— 仅去 margin 步进、保留 padding-left + border 会逐级累加仍右移（"还是有缩进"的根因）。
+  &.comment-zone-reply-flat {
+    margin-left: 0;
+    padding-left: 0;
+    border-left: none;
   }
 
   .comment-zone-body {

--- a/apps/desktop/src/renderer/src/styles/main-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/main-pane.scss
@@ -425,10 +425,26 @@
   border-left: 2px solid $border-muted;
 }
 .pr-comment {
-  background: $bg-elev;
-  border: 1px solid $border-default;
-  border-radius: $radius-md;
   padding: $space-4 $space-5;
+  // 卡片视觉（底色 / 边框 / 圆角）只给**顶层评论**；嵌套回复改走「左竖线缩进」的扁平样式（与行内
+  // 评论 DiffView 一致）——回复的 <ul> 渲染在父 <li.pr-comment> 内部，若每层都是卡片就会层层「盒中盒」。
+  &.pr-comment-depth-0 {
+    background: $bg-elev;
+    border: 1px solid $border-default;
+    border-radius: $radius-md;
+  }
+  // 嵌套回复：无卡片盒子，仅纵向留白；横向缩进与左竖线由 .pr-comments-replies 提供，满 5 层后拉平。
+  &:not(.pr-comment-depth-0) {
+    padding: $space-3 0;
+  }
+}
+// 拉平层（满 MAX_REPLY_DEPTH 层后）的回复同层级、无卡片盒子区隔 → 每条加一道顶部横向分割线 + 上下
+// 留白（margin 在线上方、padding 在线下方），清晰区分上下相邻评论（首条同时与上一缩进层级隔开）。
+// 置于 .pr-comment 之后以盖过其 padding-top。
+.pr-comments-flat > .pr-comment {
+  margin-top: $space-4;
+  padding-top: $space-4;
+  border-top: 1px solid $border-muted;
 }
 .pr-comment-head {
   display: flex;

--- a/packages/poller/src/autopilot-ledger.ts
+++ b/packages/poller/src/autopilot-ledger.ts
@@ -28,6 +28,17 @@ export async function writeAutopilotLedger(
 }
 
 /**
+ * 清掉该 PR 的 AutoPilot 台账（清空执行历史时一并删）。台账存的是评审建议 verdict，PR 列表 ★ 徽标
+ * 据此显示；删掉后 ★ 随之消失，避免清空结果后仍残留陈旧评审状态。
+ */
+export async function clearAutopilotLedger(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<void> {
+  await stateStore.delete(ledgerKey(prLocalId));
+}
+
+/**
  * 该 PR 是否需要自动评审：无台账（从未跑过）或台账记录的 updatedAt 与当前不一致
  * （PR 已变更）即为 true。内容未变则 false（去重，不重复跑）。
  */

--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -142,9 +142,11 @@ export class RepoMirrorManager {
 
   /**
    * 计算 base..head 之间的 commit 数 (PR 引入的提交数)。完全走本地 bare 镜像
-   * `git rev-list --count <base>..<head>` —— 不打远端，毫秒级返回。
+   * `git rev-list --count --no-merges <base>..<head>` —— 不打远端，毫秒级返回。
    *
-   * 用途：UI 在 PR 标签页上展示 commits 数角标，不必为了一个数字去拉远端。
+   * 用途：UI 在 PR 标签页上展示 commits 数角标，不必为了一个数字去拉远端。base 传**目标分支 sha**
+   * 时 base..head = head ^target，即「源分支不在目标分支上的提交」；`--no-merges` 略去合并提交，
+   * 与平台 PR /commits 列表口径一致（不把源分支合入目标分支带进来的提交、以及 merge 提交计入）。
    *
    * 任一 sha 不在本地镜像 (尚未 sync 到本 PR 范围) → 返回 null，调用方把它
    * 当 "暂时未知" 处理 (不显示角标 / 显示加载占位)。
@@ -162,7 +164,12 @@ export class RepoMirrorManager {
     if (!hasBase || !hasHead) return null;
     const mp = this.mirrorPath(repo);
     try {
-      const out = await simpleGit(mp).raw(['rev-list', '--count', `${baseSha}..${headSha}`]);
+      const out = await simpleGit(mp).raw([
+        'rev-list',
+        '--count',
+        '--no-merges',
+        `${baseSha}..${headSha}`,
+      ]);
       const n = Number.parseInt(out.trim(), 10);
       return Number.isNaN(n) ? null : n;
     } catch {

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -145,6 +145,11 @@ export interface IpcEvents {
    * （无活跃工具 run 时），补齐仅看运行队列时思考态缺失执行中标记的空档。
    */
   'agent:runningChanged': { prLocalIds: string[] };
+  /**
+   * 某 PR 的评审状态被清除（清空执行历史时一并清掉 AutoPilot 台账）。renderer 据此即时清掉 PR 列表
+   * 该 PR 的评审建议 ★ 徽标，避免清空后仍残留陈旧评审状态（不必等下个 poll 重取台账）。
+   */
+  'agent:reviewStatusCleared': { prLocalId: string };
 }
 
 export type IpcEventName = keyof IpcEvents;


### PR DESCRIPTION
## 概述

一批「评论 / 评审状态展示」相关的交互修复与统一（自 0.5.0-alpha.1 起的本系列调整）。

## 改动（分提交）

**评论嵌套展示统一**
- `fix(comments)`：评论 tab 回复满 5 层后拉平为同一缩进层级、纵向排列 + 横向分割线；卡片只给顶层评论，嵌套回复改扁平「左竖线缩进」，消除层层「盒中盒」。
- `fix(diff)`：行内评论（DiffView）嵌套视觉对齐评论 tab（步进 12px / `$border-muted`），满 5 层**完全拉平**（同时去 margin + padding-left + border，修此前"仍逐级右移"）。

**评审状态 / 计数**
- `fix(agent)`：清空 PR 执行历史时一并清掉 PR 列表 AI 评审建议 ★（新增 `clearAutopilotLedger` + 广播 `agent:reviewStatusCleared`，Sidebar 即时清除）。
- `fix(diff)`：PR「提交」数角标改以**目标分支 sha**为排除基准（`head ^target` + `--no-merges`），排除「源分支合入目标分支」带进来的提交与 merge 提交，与「提交」列表口径一致（修标 31 实则 2）。

**其它**
- `chore(main)`：占位 `.secrets.toml` 注释改英文。
- `docs(changelog)`：补本系列条目（prettier 顺带规范化全文）。

## 验证

本地 `lint` / `typecheck` / `test` / `build` 全部通过；CHANGELOG 过 `prettier --check`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
