### PR TITLE
fix(agent): 透传 Anthropic provider 的 base_url 到 litellm

### DIFF
--- a/apps/desktop/src/main/utils/agent.ts
+++ b/apps/desktop/src/main/utils/agent.ts
@@ -135,6 +135,14 @@ export function buildPragentEnv(profile: LlmProfile): Record<string, string> {
       break;
     case 'anthropic':
       if (profile.api_key) env['ANTHROPIC__KEY'] = profile.api_key;
+      // base_url 必须走 litellm 原生 env `ANTHROPIC_API_BASE`（单下划线），**不能**用
+      // pr-agent 风格的双下划线 `ANTHROPIC__API_BASE`：pr-agent 0.36 的 litellm_ai_handler
+      // 只读 settings.anthropic.key、不读 anthropic.api_base，对 anthropic 把 api_base=None
+      // 透传给 litellm.acompletion；litellm 的 get_api_base 仅在 api_base 为空时才回落到
+      // ANTHROPIC_API_BASE / ANTHROPIC_BASE_URL（都没有才用官方 https://api.anthropic.com）。
+      // litellm 默认会给 base 自动补 `/v1/messages`，故填到根域名即可、勿自带该后缀（中转端点
+      // 本身已是完整路径时，另设 LITELLM_ANTHROPIC_DISABLE_URL_SUFFIX=true 关掉自动补全）。
+      if (profile.base_url) env['ANTHROPIC_API_BASE'] = profile.base_url;
       break;
     case 'cli': {
       // 本地 CLI 模式：不直连任何 API，也不下发任何密钥。仅打两个哨兵 env 让

--- a/apps/desktop/src/renderer/src/components/LlmProfileForm.tsx
+++ b/apps/desktop/src/renderer/src/components/LlmProfileForm.tsx
@@ -10,7 +10,7 @@ export interface ProviderMeta {
   hint: string;
   /** Model 字段示例值 / placeholder */
   modelExample: string;
-  /** Base URL 字段默认值（有就回显；填空字段时 pr-agent 会用它） */
+  /** Base URL 字段的默认 endpoint：作占位提示；用户填了即透传给 pr-agent，留空则由下游回落到等同此处的默认 endpoint */
   defaultBaseUrl: string;
   /** API Key 字段是否必填 */
   needsKey: boolean;


### PR DESCRIPTION
此前 buildPragentEnv 的 anthropic 分支只下发 ANTHROPIC__KEY、未透传 base_url， 用户在 LLM Profile 填的 Base URL 被丢弃，litellm 始终打官方 api.anthropic.com。

改用 litellm 原生 env ANTHROPIC_API_BASE（单下划线），而非 pr-agent 双下划线 ANTHROPIC__API_BASE：pr-agent 0.36 只读 anthropic.key、不读 anthropic.api_base， 对 anthropic 把 api_base=None 透传给 litellm；litellm 的 get_api_base 在 api_base 为空时回落 ANTHROPIC_API_BASE/ANTHROPIC_BASE_URL，且自动补 /v1/messages（base_url 填根域名即可）。

附带对齐 LlmProfileForm 中 defaultBaseUrl 的注释。