### PR TITLE
fix: 自动评审完成即时更新 PR 列表 ★ + Dependencies 分类国际化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
 ### Fixed
 
 - 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
+- 自动评审（手动 / AutoPilot）完成后，PR 列表的评审建议 ★ 现即时更新，不必等下个轮询周期才体现。
 - PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
-- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
 - Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
 
 ## [0.5.0-alpha.1] - 2026-06-17

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -146,6 +146,21 @@ export function Sidebar({
     return unsub;
   }, []);
 
+  // 评审完成（手动 / AutoPilot 都经 recordReviewSummaryMessage 写台账 + 广播 agent:conversationChanged）→
+  // 即时重取该 PR 的评审建议，让 ★ 立刻出现在 PR 列表，不必等下个 poll 刷新 prs 才体现。
+  useEffect(() => {
+    const unsub = subscribe('agent:conversationChanged', (ev) => {
+      void invoke('agent:autopilotLedgers', { localIds: [ev.prLocalId] }).then((v) => {
+        const verdict = v[ev.prLocalId];
+        if (verdict === undefined) return;
+        setReviewVerdicts((prev) =>
+          prev[ev.prLocalId] === verdict ? prev : { ...prev, [ev.prLocalId]: verdict },
+        );
+      });
+    });
+    return unsub;
+  }, []);
+
   // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
   // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。
   const scopedPrs = useMemo(

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
@@ -79,6 +79,7 @@
   "Other": "Sonstiges",
   "Miscellaneous": "Verschiedenes",
   "Formatting": "Formatierung",
+  "Dependencies": "Abhängigkeiten",
   "High": "Hoch",
   "Medium": "Mittel",
   "Low": "Niedrig"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
@@ -79,6 +79,7 @@
   "Other": "その他",
   "Miscellaneous": "雑多",
   "Formatting": "フォーマット",
+  "Dependencies": "依存関係",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
@@ -79,6 +79,7 @@
   "Other": "其他",
   "Miscellaneous": "杂项",
   "Formatting": "格式化",
+  "Dependencies": "依赖",
   "High": "高",
   "Medium": "中",
   "Low": "低"


### PR DESCRIPTION
## 改动

**① 自动评审完成后 PR 列表评审建议 ★ 即时更新**
此前 Sidebar 的 ★ 只随 `prs` 变化（下个 poll）刷新 → 评审刚完成时列表不更新。评审完成（手动 / AutoPilot 都经 `recordReviewSummaryMessage` 写台账 + 广播 `agent:conversationChanged`）→ Sidebar 订阅该事件、即时重取该 PR 的 verdict 更新 ★。（与已合并的「清空清 ★」是同一刷新通道的反向。）

**② walkthrough 分类标题「Dependencies」国际化**
补中 / 日 / 德译文（依赖 / 依存関係 / Abhängigkeiten）；此前未在 pr-agent 标签字典中，非英文界面下显示英文。

## 验证

本地 `lint` / `typecheck` / `build` 通过；CHANGELOG 过 `prettier --check`。

> 注：CHANGELOG 与并行的 #66 都在 [Unreleased] Fixed 追加条目，合并时若有小冲突按各自条目并存解决即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
