### PR TITLE
fix: 评审总结不硬截断 + 评论页刷新抗抖动

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
 - /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
 - 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
+- 评审总结不再硬截断：`summary_max_chars` 仅作提示词里的参考性软约束引导 LLM 收敛篇幅，AI 已生成的总结完整保留，不再被切在词中间（如「参数…」）。
 
 ### Fixed
 
@@ -28,6 +29,7 @@
 - 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
 - Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
 - 本地仓库镜像 clone/fetch 中途被打断后留下残缺镜像（缺 origin remote），导致后续拉取变更文件一直 fatal（`'origin' does not appear to be a git repository`）、点「重试」也卡在同一坏镜像：现自动识别不健康 / 损坏镜像并删库重建，可自愈。
+- 消除评论页 poll / 刷新触发的渲染抖动：pr 按 localId 冻结后下传、评论内容结构相等就跳过重渲染、内嵌 Monaco 按锚点值 memo——定位信息没变时不再重渲染重排。
 
 ## [0.5.0-alpha.1] - 2026-06-17
 

--- a/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
@@ -18,6 +18,30 @@ import { mermaidComponents } from './markdownMermaid';
 const InlineCodeContext = lazy(() =>
   import('./InlineCodeContext').then((m) => ({ default: m.InlineCodeContext })),
 );
+
+/**
+ * 评论树结构相等比较（按 remoteId + 正文 + version + 编辑/删除权限 + 递归 replies）。poll 多数返回
+ * 内容不变的评论：相等就跳过 setComments、保留旧引用，让 React bail-out，避免整棵评论树（含内联
+ * Monaco）无谓重渲染（刷新抖动）。
+ */
+function sameCommentList(a: readonly PrComment[], b: readonly PrComment[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!;
+    const y = b[i]!;
+    if (
+      x.remoteId !== y.remoteId ||
+      x.body !== y.body ||
+      x.version !== y.version ||
+      x.canEdit !== y.canEdit ||
+      x.canDelete !== y.canDelete ||
+      !sameCommentList(x.replies, y.replies)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 interface CommentsPanelProps {
   pr: StoredPullRequest;
@@ -42,6 +66,11 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
   const { t } = useTranslation();
   const [comments, setComments] = useState<PrComment[] | null>(null);
   const [error, setError] = useState<FormattedError | null>(null);
+  // poll 会把选中的 pr 换成新对象（localId 不变）；内联 Monaco 编辑器若收到新 pr ref 会重渲染/重排 →
+  // 刷新抖动。把 pr 按 localId 冻结：同一 PR 内传给评论树的 pr ref 跨 poll 稳定，切 PR 才更新。
+  const stablePrRef = useRef(pr);
+  if (stablePrRef.current.localId !== pr.localId) stablePrRef.current = pr;
+  const stablePr = stablePrRef.current;
 
   useEffect(() => {
     let cancelled = false;
@@ -51,7 +80,8 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
       try {
         const list = await invoke('diff:listComments', { localId: pr.localId, force });
         if (cancelled) return;
-        setComments(list);
+        // 内容相等就保留旧引用让 React bail-out：poll 多数返回不变的评论，避免整棵评论树重渲染抖动。
+        setComments((prev) => (prev && sameCommentList(prev, list) ? prev : list));
         onCommentsLoaded?.(list.length);
       } catch (e) {
         if (!cancelled) setError(formatBackendError(e));
@@ -93,6 +123,24 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
     return out;
   }, [ordered]);
 
+  // 缓存顶层评论元素列表：deps 全是稳定引用（ordered 经 sameCommentList 跳过后不变、stablePr 按 localId
+  // 冻结、autoExpandSet 随 ordered）。poll 无评论变化时元素引用不变 → React 跳过整棵评论子树（含内联
+  // Monaco），消除刷新抖动。
+  const commentEls = useMemo(
+    () =>
+      ordered.map((c) => (
+        <CommentItem
+          key={c.remoteId}
+          comment={c}
+          pr={stablePr}
+          depth={0}
+          autoExpandCode={autoExpandSet.has(c.remoteId)}
+          hardBreaks={hardBreaks}
+        />
+      )),
+    [ordered, stablePr, autoExpandSet, hardBreaks],
+  );
+
   if (error) {
     return (
       <div className="pr-comments-panel">
@@ -120,18 +168,7 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
 
   return (
     <div className="pr-comments-panel">
-      <ul className="pr-comments-list">
-        {ordered.map((c) => (
-          <CommentItem
-            key={c.remoteId}
-            comment={c}
-            pr={pr}
-            depth={0}
-            autoExpandCode={autoExpandSet.has(c.remoteId)}
-            hardBreaks={hardBreaks}
-          />
-        ))}
-      </ul>
+      <ul className="pr-comments-list">{commentEls}</ul>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/InlineCodeContext.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCodeContext.tsx
@@ -3,7 +3,7 @@
 import '../monaco-setup';
 import { Editor, type Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PrCommentAnchor, StoredPullRequest } from '@meebox/shared';
 import { invoke } from '../api';
@@ -33,7 +33,7 @@ interface InlineCodeContextProps {
  * 性能：每个 inline 评论都会挂一个 Monaco 实例 (读 + tokenize)。CommentsPanel 控
  * 默认只 auto-expand 前 N 条 (按时间线)，超额走 click-to-expand 懒加载。
  */
-export function InlineCodeContext({
+function InlineCodeContextImpl({
   pr,
   anchor,
   contextLines = 5,
@@ -158,3 +158,19 @@ export function InlineCodeContext({
     </div>
   );
 }
+
+/**
+ * 按**锚点值**（path / line / side）+ pr.localId + 展示选项比较的 memo：父级（CommentsPanel）在 poll
+ * 重渲染时会传新的 anchor / pr **对象引用**（值未变），默认浅比较会误判变化 → 内嵌 Monaco 重渲染重排
+ * （刷新抖动）。这里按值比较，定位信息没变就跳过整个组件，Monaco 不动。
+ */
+export const InlineCodeContext = memo(
+  InlineCodeContextImpl,
+  (prev, next) =>
+    prev.pr.localId === next.pr.localId &&
+    prev.anchor.path === next.anchor.path &&
+    prev.anchor.line === next.anchor.line &&
+    prev.anchor.side === next.anchor.side &&
+    (prev.contextLines ?? 5) === (next.contextLines ?? 5) &&
+    (prev.autoExpand ?? true) === (next.autoExpand ?? true),
+);

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -26,10 +26,7 @@ export interface ToolText {
 
 export interface ReviewOrchestratorDeps {
   /** 分发一个只读 pr-agent 工具，返回文本结果（描述 / findings / 回答）。 */
-  runTool(call: {
-    tool: 'describe' | 'review' | 'ask';
-    question?: string;
-  }): Promise<ToolText>;
+  runTool(call: { tool: 'describe' | 'review' | 'ask'; question?: string }): Promise<ToolText>;
   /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
   chat(input: { system: string; user: string }): Promise<ToolText>;
   /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
@@ -47,7 +44,7 @@ export interface ReviewOrchestratorInput {
   toolCatalog?: ToolCatalogEntry[];
   /** 条件性追问 /ask 的硬上限（默认 2）。 */
   maxFollowupAsks?: number;
-  /** 总结严格篇幅上限（默认 800 字符）。 */
+  /** 总结篇幅的**参考**上限（默认 800 字符）：仅作提示词里的软约束引导 LLM 收敛，**不**对产出做硬截断。 */
   summaryMaxChars?: number;
 }
 
@@ -72,11 +69,6 @@ function addUsage(acc: TokenUsage, u?: TokenUsage): TokenUsage {
     totalTokens: (acc.totalTokens ?? 0) + (u.totalTokens ?? 0),
     calls: (acc.calls ?? 0) + (u.calls ?? 1),
   };
-}
-
-function clamp(s: string, max: number): string {
-  const t = s.trim();
-  return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
 }
 
 /** 把 JSON 串字面量内部未转义的裸控制符（换行/回车/制表）补转义。LLM 常把多行 markdown 原样塞进
@@ -208,7 +200,7 @@ function summaryPrompt(
   const [overview, findings, suggestions] = sections;
   return [
     'Write a closing review summary for the human reviewer, in the SAME LANGUAGE as the review findings',
-    `(at most ${String(maxChars)} characters; compress, never truncate key points).`,
+    `(aim for roughly ${String(maxChars)} characters — compress and prioritize; this is a soft guideline, not a hard limit, so do NOT truncate key points to fit).`,
     'Use EXACTLY this markdown skeleton — these three "## " sections, in this order, and nothing else.',
     'Keep each line short; put every finding / suggestion on its own "- " bullet:',
     '',
@@ -329,7 +321,9 @@ export async function runReviewMicroflow(
     recommendation?: { verdict?: unknown; reason?: unknown };
   }>(sum.text);
   // 解析失败兜底：从原始文本捞 summary 散文；再剥掉模型误并入末尾的判定 JSON，绝不把原始 JSON 展示给用户。
-  const summary = clamp(stripTrailingJson(parsed?.summary ?? salvageProse(sum.text)), summaryMax);
+  // **不做硬截断**：篇幅只在提示词里作参考性约束（summaryMax，见 summaryPrompt），AI 已生成的总结完整保留，
+  // 避免「参数…」这种半句被切断。
+  const summary = stripTrailingJson(parsed?.summary ?? salvageProse(sum.text)).trim();
   const recommendation: AgentRecommendation =
     parsed?.recommendation && isVerdict(parsed.recommendation.verdict)
       ? {

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -24,7 +24,10 @@ function makeDeps(opts: {
   const deps: ReviewOrchestratorDeps = {
     runTool: vi.fn(async (call: { tool: 'describe' | 'review' | 'ask'; question?: string }) => {
       toolCalls.push(call);
-      return { text: opts.toolText?.[call.tool] ?? `${call.tool}-result`, usage: { totalTokens: 10 } };
+      return {
+        text: opts.toolText?.[call.tool] ?? `${call.tool}-result`,
+        usage: { totalTokens: 10 },
+      };
     }),
     chat: vi.fn(async () => {
       const text = opts.chatReplies[chatIdx++] ?? '{}';
@@ -43,7 +46,8 @@ describe('extractJson', () => {
 
   it('recovers JSON with unescaped raw newlines inside string values', () => {
     // 模型常把多行 markdown 原样塞进字符串值、不转义换行——补转义后应能解析。
-    const raw = '{"final": "## 摘要\n\n第一行\n第二行", "recommendation": {"verdict": "needs_work"}}';
+    const raw =
+      '{"final": "## 摘要\n\n第一行\n第二行", "recommendation": {"verdict": "needs_work"}}';
     const parsed = extractJson<{ final: string; recommendation: { verdict: string } }>(raw);
     expect(parsed?.final).toBe('## 摘要\n\n第一行\n第二行');
     expect(parsed?.recommendation.verdict).toBe('needs_work');
@@ -65,9 +69,11 @@ describe('salvageProse', () => {
 
 describe('stripTrailingJson', () => {
   it('strips a trailing recommendation JSON block the model wrongly appended', () => {
-    const fenced = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n```json\n{"recommendation": {"verdict": "needs_work"}}\n```';
+    const fenced =
+      '## 摘要\n\n本 PR 修复了空值崩溃。\n\n```json\n{"recommendation": {"verdict": "needs_work"}}\n```';
     expect(stripTrailingJson(fenced)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
-    const bare = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n{\n  "recommendation": {"verdict": "approve"}\n}';
+    const bare =
+      '## 摘要\n\n本 PR 修复了空值崩溃。\n\n{\n  "recommendation": {"verdict": "approve"}\n}';
     expect(stripTrailingJson(bare)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
   });
 
@@ -112,7 +118,7 @@ describe('runReviewMicroflow', () => {
     expect(r.recommendation.verdict).toBe('needs_work');
   });
 
-  it('clamps the summary to summaryMaxChars', async () => {
+  it('does not truncate the summary (summaryMaxChars is a soft prompt hint only)', async () => {
     const long = 'x'.repeat(500);
     const { deps } = makeDeps({
       chatReplies: [
@@ -120,8 +126,9 @@ describe('runReviewMicroflow', () => {
         `{"summary": "${long}", "recommendation": {"verdict": "approve", "reason": "ok"}}`,
       ],
     });
+    // summaryMaxChars=100 远小于 500 字符的产出：现仅作提示词软约束，不再硬截断 → 完整保留。
     const r = await runReviewMicroflow(deps, { context, pr, summaryMaxChars: 100 });
-    expect(r.summary.length).toBe(100);
+    expect(r.summary).toBe(long);
   });
 
   it('falls back to manual_review when the summary JSON is unparseable', async () => {
@@ -135,7 +142,10 @@ describe('runReviewMicroflow', () => {
   it('streams every step via onStep', async () => {
     const seen: string[] = [];
     const { deps } = makeDeps({
-      chatReplies: ['{"severe": false}', '{"summary": "s", "recommendation": {"verdict": "approve", "reason": "r"}}'],
+      chatReplies: [
+        '{"severe": false}',
+        '{"summary": "s", "recommendation": {"verdict": "approve", "reason": "r"}}',
+      ],
     });
     deps.onStep = (step) => {
       seen.push(step.kind);

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -99,7 +99,7 @@ export interface AgentSession {
    * 无文本输入 → 不填。UI 据此把用户输入回显为右对齐气泡、归属其发起 PR、持久化恢复。
    */
   userRequest?: string;
-  /** 本 PR 收尾总结正文（受 summary_max_chars 限长）。 */
+  /** 本 PR 收尾总结正文（summary_max_chars 仅作提示词软约束引导篇幅，不对正文硬截断）。 */
   summary?: string;
   /** 收尾建议（非约束性）。 */
   recommendation?: AgentRecommendation;


### PR DESCRIPTION
## 改动

**① 评审总结不再硬截断**
此前总结经 `clamp(summary_max_chars)` 硬切，超长被切在词中间（如「参数…」）。改为去掉硬截断：`summary_max_chars` 只在 `summaryPrompt` 里作参考性软约束引导 LLM 收敛篇幅，AI 已生成的总结完整保留。删 `clamp`、软化措辞、调整对应单测。

**② 评论页 poll / 刷新渲染抖动**
poll 换选中 pr 的对象引用（localId 不变）+ `comments:changed` 重拉 → 整棵评论树（含内嵌 Monaco）重渲染。分层规避：
- `pr` 按 localId 冻结后下传评论树；
- 评论内容结构相等就跳过 `setComments`（poll 多数返回不变 → React bail-out）；
- `useMemo` 缓存顶层评论元素列表；
- **内嵌 `InlineCodeContext` 按锚点值（path/line/side）+ pr.localId memo** —— 定位信息没变就跳过 Monaco 重渲染（兜住父级因评论微变重建时 Monaco 仍被波及的情况）。

## 验证

本地 `lint` / `typecheck` / `test`（含 orchestrator）/ `build` 全部通过；CHANGELOG 过 `prettier --check`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
