### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,33 +5,10 @@
 
 ## [Unreleased]
 
-### Added
+## [0.5.0] - 2026-06-17
 
-- 评审步骤分步展示 token 用量：judge / 总结 / 规划等经独立通道的推理步在步骤行右侧显示本步
-  输入 / 输出 token（不累计）；工具调用的开销仍由各自运行卡片承载。
-- PR 列表项「执行中」标记覆盖 Agent **纯思考阶段**（无活跃工具运行时，含后台 AutoPilot），不再只在工具运行时显示。
-
-### Changed
-
-- describe「文件变更」walkthrough 各文件分类（功能增强 / 配置变更 …）默认折叠，点分类标题按需展开，避免输出过长。
-- **评论嵌套展示统一**（评论 tab + 行内评论）：回复满 5 层后拉平为同一缩进层级、纵向排列并加横向分割线，
-  避免无限右移；嵌套回复改走「左竖线缩进」的扁平样式（不再层层卡片「盒中盒」），两处视觉一致。
-- 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
-- /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
-- 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
-- 评审总结不再硬截断：`summary_max_chars` 仅作提示词里的参考性软约束引导 LLM 收敛篇幅，AI 已生成的总结完整保留，不再被切在词中间（如「参数…」）。
-
-### Fixed
-
-- 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
-- 自动评审（手动 / AutoPilot）完成后，PR 列表的评审建议 ★ 现即时更新，不必等下个轮询周期才体现。
-- PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
-- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
-- Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
-- 本地仓库镜像 clone/fetch 中途被打断后留下残缺镜像（缺 origin remote），导致后续拉取变更文件一直 fatal（`'origin' does not appear to be a git repository`）、点「重试」也卡在同一坏镜像：现自动识别不健康 / 损坏镜像并删库重建，可自愈。
-- 消除评论页 poll / 刷新触发的渲染抖动：pr 按 localId 冻结后下传、评论内容结构相等就跳过重渲染、内嵌 Monaco 按锚点值 memo——定位信息没变时不再重渲染重排。
-
-## [0.5.0-alpha.1] - 2026-06-17
+> 首个 0.5 正式版。本版重点：在 PR 评审中引入可委派的**高阶 Agent（会话 Agent 化 + AutoPilot 后台预评审）**，
+> 并打磨无边框窗口、重型组件加载抖动、评论嵌套展示等体验。开发期 0.5.0-alpha.1 的变更已并入本版。
 
 ### Added
 
@@ -68,6 +45,7 @@
   深色主题从顶贯通到底。窗控按钮交由系统绘制以保留原生行为——macOS 保留红绿灯（下移到标题栏内）、
   Windows/Linux 用 `titleBarOverlay` 在右上画最小化/最大化/关闭。标题栏展示品牌名与当前 PR 标题，
   Windows/Linux 开头另显应用图标（macOS 因红绿灯占位不显）。
+- PR 列表项「执行中」标记覆盖 Agent **纯思考阶段**（无活跃工具运行时，含后台 AutoPilot），不再只在工具运行时显示。
 
 ### Changed
 
@@ -82,6 +60,12 @@
   稳定后才揭开，遮罩底色与编辑器一致、揭开无缝。
 - **describe「文件变更」分类默认折叠**：walkthrough 各文件分类（功能增强 / 配置变更 …）默认折叠收起，
   点分类标题按需展开，避免 describe 输出过长（仅作用于 walkthrough，不影响其它折叠区）。
+- **评论嵌套展示统一**（评论 tab + 行内评论）：回复满 5 层后拉平为同一缩进层级、纵向排列并加横向分割线，
+  避免无限右移；嵌套回复改走「左竖线缩进」的扁平样式（不再层层卡片「盒中盒」），两处视觉一致。
+- 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
+- /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
+- 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
+- 评审总结不再硬截断：`summary_max_chars` 仅作提示词里的参考性软约束引导 LLM 收敛篇幅，AI 已生成的总结完整保留，不再被切在词中间（如「参数…」）。
 
 ### Fixed
 
@@ -101,8 +85,17 @@
 - 修复 finding 锚点解析在文件路径含方括号（如 `a/[m-123]/x.ts`）时出错：marker `[file: …, lines: …]`
   的路径捕获原排除了 `]`，遇到路径里的 `]` 即误截，导致 marker 抽不出跳转锚点、且原样泄漏到
   finding 正文。改为带 lines 时以 `, lines:` 后缀界定路径（允许路径含 `[]`）。
-- 补 describe 文件走查分类标题「Miscellaneous」的中 / 日 / 德译文：此前未在 pr-agent 标签字典中，
-  非英文界面下仍以英文显示。
+- 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
+- 自动评审（手动 / AutoPilot）完成后，PR 列表的评审建议 ★ 现即时更新，不必等下个轮询周期才体现。
+- PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
+- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+- Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
+- 本地仓库镜像 clone/fetch 中途被打断后留下残缺镜像（缺 origin remote），导致后续拉取变更文件一直 fatal（`'origin' does not appear to be a git repository`）、点「重试」也卡在同一坏镜像：现自动识别不健康 / 损坏镜像并删库重建，可自愈。
+- 消除评论页 poll / 刷新触发的渲染抖动：pr 按 localId 冻结后下传、评论内容结构相等就跳过重渲染、内嵌 Monaco 按锚点值 memo——定位信息没变时不再重渲染重排。
+
+## [0.5.0-alpha.1] - 2026-06-17
+
+> 开发期预览版。其全部变更内容已并入正式版 **[0.5.0](#050---2026-06-17)**，此处不再展开。
 
 ## [0.4.0] - 2026-06-14
 
@@ -369,6 +362,7 @@
 许可证：[Apache-2.0](LICENSE)。打包内含第三方组件（pr-agent、Electron 等），各按其许可证分发，见 [NOTICE](NOTICE)。
 
 [Unreleased]: https://github.com/huhamhire/code-meeseeks/compare/v0.5.0-alpha.1...HEAD
+[0.5.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.4.0...v0.5.0
 [0.5.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.4.0...v0.5.0-alpha.1
 [0.4.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.1...v0.4.0
 [0.4.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.3.1...v0.4.0-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
 ### Fixed
 
 - 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
+- 自动评审（手动 / AutoPilot）完成后，PR 列表的评审建议 ★ 现即时更新，不必等下个轮询周期才体现。
 - PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
-- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
 - Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
 
 ## [0.5.0-alpha.1] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
 - /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
 - 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
+- 评审总结不再硬截断：`summary_max_chars` 仅作提示词里的参考性软约束引导 LLM 收敛篇幅，AI 已生成的总结完整保留，不再被切在词中间（如「参数…」）。
 
 ### Fixed
 
@@ -28,6 +29,7 @@
 - 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」「Dependencies」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
 - Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
 - 本地仓库镜像 clone/fetch 中途被打断后留下残缺镜像（缺 origin remote），导致后续拉取变更文件一直 fatal（`'origin' does not appear to be a git repository`）、点「重试」也卡在同一坏镜像：现自动识别不健康 / 损坏镜像并删库重建，可自愈。
+- 消除评论页 poll / 刷新触发的渲染抖动：pr 按 localId 冻结后下传、评论内容结构相等就跳过重渲染、内嵌 Monaco 按锚点值 memo——定位信息没变时不再重渲染重排。
 
 ## [0.5.0-alpha.1] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
 - 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
 - Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
+- 本地仓库镜像 clone/fetch 中途被打断后留下残缺镜像（缺 origin remote），导致后续拉取变更文件一直 fatal（`'origin' does not appear to be a git repository`）、点「重试」也卡在同一坏镜像：现自动识别不健康 / 损坏镜像并删库重建，可自愈。
 
 ## [0.5.0-alpha.1] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,31 @@
 
 ## [Unreleased]
 
+### Added
+
+- 评审步骤分步展示 token 用量：judge / 总结 / 规划等经独立通道的推理步在步骤行右侧显示本步
+  输入 / 输出 token（不累计）；工具调用的开销仍由各自运行卡片承载。
+- PR 列表项「执行中」标记覆盖 Agent **纯思考阶段**（无活跃工具运行时，含后台 AutoPilot），不再只在工具运行时显示。
+
+### Changed
+
+- describe「文件变更」walkthrough 各文件分类（功能增强 / 配置变更 …）默认折叠，点分类标题按需展开，避免输出过长。
+- **评论嵌套展示统一**（评论 tab + 行内评论）：回复满 5 层后拉平为同一缩进层级、纵向排列并加横向分割线，
+  避免无限右移；嵌套回复改走「左竖线缩进」的扁平样式（不再层层卡片「盒中盒」），两处视觉一致。
+- 评审建议星标由五角星改为 AI 常见的四角 sparkle ✦。
+- /ask 在问题末尾追加语言要求，改善按界面语言（中 / 日 / 德）作答的遵循度——此前自由问答常被大量英文 diff 盖过而用英文作答。
+- 统一 PR 列表状态 chip 带高，消除「星标」与「星标 + 计数」等不同行的高度漂移。
+
+### Fixed
+
+- 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
+- PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
+- 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+
 ## [0.5.0-alpha.1] - 2026-06-17
 
 ### Added
+
 - **高阶 Agent（会话 Agent 化 + AutoPilot 预评审）**：在 PR 评审中引入可委派的智能体能力，随 LLM
   配置自动可用、无需单独的启用开关。
   - **一键自动评审**：聊天框命令区右侧新增自动评审按钮（✦ 图标），对当前 PR 跑「描述 → 评审 →
@@ -43,6 +65,7 @@
   Windows/Linux 开头另显应用图标（macOS 因红绿灯占位不显）。
 
 ### Changed
+
 - **移除独立 `ollama` provider**，统一经 `openai-compatible` 接入本地 Ollama（Base URL 填
   `http://localhost:11434/v1`）：Ollama 自带 OpenAI 兼容端点，走此路径更标准稳健。旧 `ollama` 配置
   加载时**自动迁移**为 `openai-compatible` 并补足 `/v1`，存量无感升级。
@@ -56,6 +79,7 @@
   点分类标题按需展开，避免 describe 输出过长（仅作用于 walkthrough，不影响其它折叠区）。
 
 ### Fixed
+
 - **修复 PR diff 基准随目标分支漂移导致的「修改被撤回」误判**：此前文件内容（Monaco 左栏）按目标
   分支当前 tip（`targetRef.sha`）读取，目标分支被别的 PR 合入而前移后，编辑器实际成了两点对比，
   别的 PR 的改动会以倒挂 / 撤回形式串进当前 PR 的 diff（变更文件列表用三点 diff 本不受影响，但内容
@@ -86,6 +110,7 @@
 > UAC 提权运行；安装后的应用以普通权限启动。从旧版升级会自动清理旧安装，无需手动卸载。
 
 ### Added
+
 - **GitLab 接入**（gitlab.com + Self-Managed，CE / EE，REST API v4）：新增 `@meebox/platform-gitlab`
   适配器——MR 发现（`reviewer_username` 待我评审，跨项目）、diff 评论读 / 发 / 改 / 删 / 回复
   （discussions + notes 归一）、合并、clone（PAT / SSH）、头像 / 内嵌附件代理。设置页与首启向导可
@@ -96,6 +121,7 @@
   - 嵌套 group 路径、N+1 取详情（diff_refs / 审批）、行内评论按 `position` 三 sha 锚定。
 
 ### Changed
+
 - 拒绝代码反馈 / 改进建议后，卡片自动折叠收起并置灰：左色条转中性灰、类别 chip 置灰，正文与
   代码对比收起，仅保留头部与锚点行（含撤销入口）；头部 chevron 图标可临时展开回看。降低已决断
   项的视觉占用。
@@ -112,6 +138,7 @@
   依赖上游 CLI（claude / codex 等）、行为可能随上游版本变更，稳定性与持续可用性不作保证。
 
 ### Fixed
+
 - Bitbucket 评论内嵌附件图片不渲染：`rehype-sanitize` 的协议白名单（`src` / `href` 仅
   http/https）在 `urlTransform` 之前即剥掉 `attachment:` 内部协议，使 img/a 收不到 src/href、
   图片代理永不触发（属随 sanitize 链引入的回归）。schema 放行 `attachment` 协议；并让附件拉取
@@ -138,6 +165,7 @@
 ## [0.3.1] - 2026-06-11
 
 ### Fixed
+
 - **macOS 分发版「本地 CLI」provider（claude / codex）失效**（Finder/Dock 启动）：macOS GUI 应用
   只继承 launchd 的最小 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），读不到 shell 配置，故找不到装在
   `~/.local/bin` / homebrew 等目录的 CLI，评审报错（`litellm ... LLM Provider NOT provided` 或

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - 清空某 PR 执行历史时一并清掉其 PR 列表 AI 评审建议 ★ 徽标，不再残留陈旧评审状态。
 - PR「提交」数角标排除「源分支把目标分支合入自己」带进来的提交与 merge 提交，与「提交」列表口径一致（此前会多计）。
 - 补 walkthrough 文件分类标题「Miscellaneous」「Formatting」的中 / 日 / 德译文（此前非英文界面下仍显示英文）。
+- Anthropic provider 配置的 base_url（自建 / 中转端点）此前未透传给底层 litellm → 请求仍打到官方 `api.anthropic.com`；现经 `ANTHROPIC_API_BASE` 正确透传（填根域名即可，litellm 自动补 `/v1/messages`）。(#65，感谢 @dnvyrn)
 
 ## [0.5.0-alpha.1] - 2026-06-17
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meebox/desktop",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0",
   "private": true,
   "description": "meebox Electron desktop app",
   "author": {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -772,12 +772,14 @@ export function registerIpcHandlers({
     ): Promise<IpcChannels['diff:commitCount']['response']> => {
       const pr = await findPrOrThrow(req.localId);
       const id = repoIdentityFor(pr);
-      // 本地 git 算 base..head；不打远端、不主动触发 sync。镜像还没拉齐就返回 null，
+      // 本地 git 算提交数；不打远端、不主动触发 sync。镜像还没拉齐就返回 null，
       // UI 角标暂不显示，等下次 poll 触发 syncMirror 完成后自然命中。
-      // base 用固定 merge-base：base..head（base 为 merge-base 时）即 PR 自身提交数，
-      // 与三点 diff 同源、对目标分支前移稳定（旧版用 targetRef.sha 会随漂移跳变）
-      const base = await resolveDiffBaseSha(pr);
-      const n = await repoMirror.countCommits(id, base, pr.sourceRef.sha);
+      // 口径 = PR 自身提交（源分支「不在目标分支上」的非 merge 提交），对齐平台 /commits 列表。
+      // **基准用目标分支 sha（head ^target）而非固定 merge-base**：源分支把目标分支（如 dev）合入自己后，
+      // merge-base 之后被带进来的目标提交也可达 head、不可达 merge-base → 用 merge-base 会把它们误计
+      // （标 31 实则 2）。以 targetRef.sha 排除这些合入提交；merge 提交本身由 countCommits 的 --no-merges 略去。
+      // （diff 仍用固定 merge-base 保稳定，与本计数口径各司其职。）
+      const n = await repoMirror.countCommits(id, pr.targetRef.sha, pr.sourceRef.sha);
       return n === null ? null : { count: n };
     },
   );

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -203,7 +203,7 @@ export function registerIpcHandlers({
         } catch {
           await fs.writeFile(
             f,
-            '# meebox 占位空文件：抑制 pr-agent 缺失 .secrets.toml 的启动告警\n',
+            '# meebox placeholder: silence pr-agent warning about a missing .secrets.toml\n',
           );
         }
       }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -40,6 +40,7 @@ import {
   writeCommentsCache,
   writeAutopilotLedger,
   getAutopilotLedger,
+  clearAutopilotLedger,
   getAgentSession,
   clearAgentSession,
   getAgentConversation,
@@ -1842,6 +1843,12 @@ export function registerIpcHandlers({
       // 清执行历史时一并清掉 Agent 会话（含收尾 summary / 步骤 transcript），否则清空后
       // 重开 PR 仍会从落盘会话恢复出「评审总结」卡片。
       await clearAgentSession(stateStore, req.localId);
+      // 一并清掉 AutoPilot 台账（评审建议 verdict），并广播 → PR 列表该 PR 的 ★ 徽标即时消失，
+      // 不残留陈旧评审状态、也不必等下个 poll 重取台账。
+      await clearAutopilotLedger(stateStore, req.localId);
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('agent:reviewStatusCleared', { prLocalId: req.localId });
+      }
       return { cleared: await clearReviewRunsForPr(stateStore, req.localId) };
     },
   );

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -169,14 +169,14 @@ export function registerIpcHandlers({
   /** 生效的 Agent 目录：用户配置优先，未配置则回落工作目录默认位置（~/.code-meeseeks/agent）。 */
   const effectiveAgentDir = (): string => bootstrap.config.agent.dir || bootstrap.paths.agentDir;
 
-  // /ask 输出去重：pr-agent answer markdown 里会回显完整问题，跟 UI chat-user-msg
-  // 气泡重复。逐行精确匹配 question (含 trim 后) 的行整行删掉，保留其余正文
-  const stripAskQuestionEcho = (md: string, question: string): string => {
-    const q = question.trim();
-    if (!q || !md) return md;
+  // /ask 输出去重：pr-agent answer markdown 里会回显完整问题（以及我们追加到问题末尾的语言要求），
+  // 跟 UI chat-user-msg 气泡重复。逐行精确匹配（trim 后整行 == 任一给定串）删掉，保留其余正文。
+  const stripAskQuestionEcho = (md: string, ...echoed: string[]): string => {
+    const qs = new Set(echoed.map((q) => q.trim()).filter(Boolean));
+    if (!qs.size || !md) return md;
     return md
       .split('\n')
-      .filter((line) => line.trim() !== q)
+      .filter((line) => !qs.has(line.trim()))
       .join('\n');
   };
 
@@ -1075,8 +1075,18 @@ export function registerIpcHandlers({
         );
       }
 
-      // ask 工具的问题作为位置参数 (spawn args 单元素，含空格也是一个 arg 不切分)
-      const extraArgs = req.tool === 'ask' && req.question ? [req.question] : undefined;
+      // ask 工具：问题作为位置参数（user turn，spawn args 单元素，含空格也是一个 arg 不切分），
+      // 并在问题**末尾**硬性追加语言要求。系统侧 CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS 对
+      // 自由问答常被大量英文 diff（full diff 数万 token）盖过 → 模型用英文作答；在 user turn 末尾
+      // （近因位置、用目标语言书写）再要求一次，显著提升按 UI 语言作答的遵循度。en-US 返回空、不追加。
+      const askLangSuffix = req.tool === 'ask' ? askLanguageSuffixFor(getMainLanguage()) : '';
+      const askQuestion =
+        req.tool === 'ask' && req.question
+          ? askLangSuffix
+            ? `${req.question}\n\n${askLangSuffix}`
+            : req.question
+          : undefined;
+      const extraArgs = askQuestion ? [askQuestion] : undefined;
 
       // embedded 策略：执行期在嵌入式安装目录补空 .secrets.toml 压掉启动告警
       // （直接写安装目录；memo 化只首次做）。local-cli 不需要 (pipx 装的 pr-agent
@@ -1123,7 +1133,7 @@ export function registerIpcHandlers({
       // 重复)。在解析前把跟用户问题逐字匹配的整行删掉，避免渲染时出现两次问题
       const cleanedContent =
         req.tool === 'ask' && req.question?.trim()
-          ? stripAskQuestionEcho(fileContent, req.question)
+          ? stripAskQuestionEcho(fileContent, req.question, askLangSuffix)
           : fileContent;
       const parsed = parseReviewOutput(cleanedContent || result.stdout, req.tool);
       // M4 草稿再摄入：/review 成功完成时丢掉 pending+finding 旧草稿，
@@ -2318,6 +2328,28 @@ function languageDirectiveFor(lang: string): string {
   }
   if (norm.startsWith('de')) {
     return 'Respond in German (Deutsch). All section labels, table headers, column names, headings, and content MUST be in German — do not leave any English template strings untranslated.';
+  }
+  return '';
+}
+
+/**
+ * /ask 专用：把语言要求作为「问题末尾」的硬性指令，**用目标语言书写本身**（最能促使模型切换到该
+ * 语言作答）。系统侧 CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS 对自由问答常被大量英文 diff
+ * 盖过，故在 user turn 末尾（近因位置）再要求一次。en-US / 未知 locale 返回空串（默认即英文）。
+ */
+function askLanguageSuffixFor(lang: string): string {
+  const norm = lang.toLowerCase();
+  if (norm.startsWith('zh-cn') || norm === 'zh') {
+    return '请用简体中文回答整个回复（包括所有解释、说明与结论）。代码、标识符、文件路径保留原样，但所有叙述文字必须是简体中文，不要用英文作答。';
+  }
+  if (norm.startsWith('zh-tw') || norm.startsWith('zh-hk')) {
+    return '請用繁體中文回答整個回覆（包括所有解釋、說明與結論）。程式碼、識別符、檔案路徑保留原樣，但所有敘述文字必須是繁體中文，不要用英文作答。';
+  }
+  if (norm.startsWith('ja')) {
+    return '回答全体を日本語で記述してください（説明・結論を含む）。コード・識別子・ファイルパスはそのまま残し、説明文はすべて日本語にしてください。英語で回答しないでください。';
+  }
+  if (norm.startsWith('de')) {
+    return 'Bitte antworte vollständig auf Deutsch (einschließlich aller Erklärungen und Schlussfolgerungen). Code, Bezeichner und Dateipfade bleiben unverändert, aber der gesamte erläuternde Text muss auf Deutsch sein. Antworte nicht auf Englisch.';
   }
   return '';
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1389,6 +1389,24 @@ export function registerIpcHandlers({
   // agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
   const agentControllers = new Map<string, AbortController>();
 
+  // 运行中（思考或派发工具）的编排 Agent 所属 PR 集合，向 renderer 广播「执行中」。区别于
+  // agentControllers（仅手动可停会话）：这里**手动 run/ask 与 AutoPilot 后台评审一并计入**，
+  // 让 PR 列表项在纯思考阶段（无活跃工具 run）也显示执行中标记。
+  const runningAgentPrs = new Set<string>();
+  const broadcastAgentRunning = (): void => {
+    const prLocalIds = [...runningAgentPrs];
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('agent:runningChanged', { prLocalIds });
+    }
+  };
+  const markAgentRunning = (localId: string): void => {
+    runningAgentPrs.add(localId);
+    broadcastAgentRunning();
+  };
+  const unmarkAgentRunning = (localId: string): void => {
+    if (runningAgentPrs.delete(localId)) broadcastAgentRunning();
+  };
+
   /** 取消某 PR 的全部 pr-agent run：active 的 SIGKILL，waiting 的出队 + reject。 */
   const cancelRunsForPr = (localId: string): void => {
     for (const item of active.values()) if (item.req.localId === localId) item.ac?.abort();
@@ -1505,6 +1523,7 @@ export function registerIpcHandlers({
       // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
+      markAgentRunning(pr.localId);
       logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
       try {
         const session = await withAgentChat(
@@ -1520,6 +1539,7 @@ export function registerIpcHandlers({
         return session;
       } finally {
         agentControllers.delete(pr.localId);
+        unmarkAgentRunning(pr.localId);
       }
     },
   );
@@ -1577,6 +1597,7 @@ export function registerIpcHandlers({
       });
       const ac = new AbortController();
       agentControllers.set(pr.localId, ac);
+      markAgentRunning(pr.localId);
       // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
       logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
       try {
@@ -1596,6 +1617,7 @@ export function registerIpcHandlers({
         return session;
       } finally {
         agentControllers.delete(pr.localId);
+        unmarkAgentRunning(pr.localId);
       }
     },
   );
@@ -1728,10 +1750,16 @@ export function registerIpcHandlers({
           // （run-queue maxConcurrency）尽量被填满，而非逐 PR 串行空等。各 PR 写各自的文件，无竞争。
           await Promise.all(
             toReview.map(async (pr) => {
-              const session = await runReviewForPr(pr, agentContext, chat, undefined, true);
-              // done：落「评审总结」消息 + 台账（含 verdict）+ 广播会话变更（与手动评审一致）。
-              // 失败 / 暂停不落台账 → 无产出，下轮可重试（准入闸 2 用 hasReviewOutput 判，不再靠台账拦）。
-              await recordReviewSummaryMessage(pr, session);
+              // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
+              markAgentRunning(pr.localId);
+              try {
+                const session = await runReviewForPr(pr, agentContext, chat, undefined, true);
+                // done：落「评审总结」消息 + 台账（含 verdict）+ 广播会话变更（与手动评审一致）。
+                // 失败 / 暂停不落台账 → 无产出，下轮可重试（准入闸 2 用 hasReviewOutput 判，不再靠台账拦）。
+                await recordReviewSummaryMessage(pr, session);
+              } finally {
+                unmarkAgentRunning(pr.localId);
+              }
             }),
           );
         });

--- a/apps/desktop/src/main/utils/agent.ts
+++ b/apps/desktop/src/main/utils/agent.ts
@@ -135,6 +135,14 @@ export function buildPragentEnv(profile: LlmProfile): Record<string, string> {
       break;
     case 'anthropic':
       if (profile.api_key) env['ANTHROPIC__KEY'] = profile.api_key;
+      // base_url 必须走 litellm 原生 env `ANTHROPIC_API_BASE`（单下划线），**不能**用
+      // pr-agent 风格的双下划线 `ANTHROPIC__API_BASE`：pr-agent 0.36 的 litellm_ai_handler
+      // 只读 settings.anthropic.key、不读 anthropic.api_base，对 anthropic 把 api_base=None
+      // 透传给 litellm.acompletion；litellm 的 get_api_base 仅在 api_base 为空时才回落到
+      // ANTHROPIC_API_BASE / ANTHROPIC_BASE_URL（都没有才用官方 https://api.anthropic.com）。
+      // litellm 默认会给 base 自动补 `/v1/messages`，故填到根域名即可、勿自带该后缀（中转端点
+      // 本身已是完整路径时，另设 LITELLM_ANTHROPIC_DISABLE_URL_SUFFIX=true 关掉自动补全）。
+      if (profile.base_url) env['ANTHROPIC_API_BASE'] = profile.base_url;
       break;
     case 'cli': {
       // 本地 CLI 模式：不直连任何 API，也不下发任何密钥。仅打两个哨兵 env 让

--- a/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
@@ -18,6 +18,30 @@ import { mermaidComponents } from './markdownMermaid';
 const InlineCodeContext = lazy(() =>
   import('./InlineCodeContext').then((m) => ({ default: m.InlineCodeContext })),
 );
+
+/**
+ * 评论树结构相等比较（按 remoteId + 正文 + version + 编辑/删除权限 + 递归 replies）。poll 多数返回
+ * 内容不变的评论：相等就跳过 setComments、保留旧引用，让 React bail-out，避免整棵评论树（含内联
+ * Monaco）无谓重渲染（刷新抖动）。
+ */
+function sameCommentList(a: readonly PrComment[], b: readonly PrComment[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!;
+    const y = b[i]!;
+    if (
+      x.remoteId !== y.remoteId ||
+      x.body !== y.body ||
+      x.version !== y.version ||
+      x.canEdit !== y.canEdit ||
+      x.canDelete !== y.canDelete ||
+      !sameCommentList(x.replies, y.replies)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 interface CommentsPanelProps {
   pr: StoredPullRequest;
@@ -42,6 +66,11 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
   const { t } = useTranslation();
   const [comments, setComments] = useState<PrComment[] | null>(null);
   const [error, setError] = useState<FormattedError | null>(null);
+  // poll 会把选中的 pr 换成新对象（localId 不变）；内联 Monaco 编辑器若收到新 pr ref 会重渲染/重排 →
+  // 刷新抖动。把 pr 按 localId 冻结：同一 PR 内传给评论树的 pr ref 跨 poll 稳定，切 PR 才更新。
+  const stablePrRef = useRef(pr);
+  if (stablePrRef.current.localId !== pr.localId) stablePrRef.current = pr;
+  const stablePr = stablePrRef.current;
 
   useEffect(() => {
     let cancelled = false;
@@ -51,7 +80,8 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
       try {
         const list = await invoke('diff:listComments', { localId: pr.localId, force });
         if (cancelled) return;
-        setComments(list);
+        // 内容相等就保留旧引用让 React bail-out：poll 多数返回不变的评论，避免整棵评论树重渲染抖动。
+        setComments((prev) => (prev && sameCommentList(prev, list) ? prev : list));
         onCommentsLoaded?.(list.length);
       } catch (e) {
         if (!cancelled) setError(formatBackendError(e));
@@ -93,6 +123,24 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
     return out;
   }, [ordered]);
 
+  // 缓存顶层评论元素列表：deps 全是稳定引用（ordered 经 sameCommentList 跳过后不变、stablePr 按 localId
+  // 冻结、autoExpandSet 随 ordered）。poll 无评论变化时元素引用不变 → React 跳过整棵评论子树（含内联
+  // Monaco），消除刷新抖动。
+  const commentEls = useMemo(
+    () =>
+      ordered.map((c) => (
+        <CommentItem
+          key={c.remoteId}
+          comment={c}
+          pr={stablePr}
+          depth={0}
+          autoExpandCode={autoExpandSet.has(c.remoteId)}
+          hardBreaks={hardBreaks}
+        />
+      )),
+    [ordered, stablePr, autoExpandSet, hardBreaks],
+  );
+
   if (error) {
     return (
       <div className="pr-comments-panel">
@@ -120,18 +168,7 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
 
   return (
     <div className="pr-comments-panel">
-      <ul className="pr-comments-list">
-        {ordered.map((c) => (
-          <CommentItem
-            key={c.remoteId}
-            comment={c}
-            pr={pr}
-            depth={0}
-            autoExpandCode={autoExpandSet.has(c.remoteId)}
-            hardBreaks={hardBreaks}
-          />
-        ))}
-      </ul>
+      <ul className="pr-comments-list">{commentEls}</ul>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/CommentsPanel.tsx
@@ -137,9 +137,16 @@ export function CommentsPanel({ pr, onCommentsLoaded, capabilities }: CommentsPa
 }
 
 /**
+ * 嵌套回复的最大缩进层级：满此层级后继续递归但**不再加缩进**（拉平展示），避免深嵌套把内容挤到
+ * 右侧极窄。depth 0 为顶层评论；depth 1..MAX 逐级缩进，超过 MAX 的更深回复一律平铺在 MAX 层缩进上，
+ * 仍按作者归属可读。Bitbucket 实际只一层 reply，GitHub / GitLab 可深嵌套，故设上限。
+ */
+const MAX_REPLY_DEPTH = 5;
+
+/**
  * 单条评论 + 嵌套 replies。inline 评论顶部显示 `path:line side` chip 区分锚点位置；
- * summary 评论不挂 chip。replies 走递归，depth 控制左侧缩进 (Bitbucket 实际只一层 reply
- * 但 schema 允许深嵌套，递归更稳)。
+ * summary 评论不挂 chip。replies 走递归，depth 控制左侧缩进；满 MAX_REPLY_DEPTH 层后拉平
+ * （不再加缩进，见该常量）。
  */
 function CommentItem({
   comment,
@@ -192,7 +199,7 @@ function CommentItem({
   };
 
   return (
-    <li className={`pr-comment pr-comment-depth-${String(depth)}`}>
+    <li className={`pr-comment pr-comment-depth-${String(Math.min(depth, MAX_REPLY_DEPTH))}`}>
       <div className="pr-comment-head">
         <Avatar
           connectionId={pr.connectionId}
@@ -311,7 +318,11 @@ function CommentItem({
         />
       )}
       {comment.replies.length > 0 && (
-        <ul className="pr-comments-list pr-comments-replies">
+        // 满 MAX_REPLY_DEPTH 层后用 pr-comments-flat 取代 pr-comments-replies（不再缩进 / 左边框）→
+        // 更深回复拉平在该层缩进上；pr-comments-flat 据此给同层级相邻评论加横向分割线区分。
+        <ul
+          className={`pr-comments-list ${depth < MAX_REPLY_DEPTH ? 'pr-comments-replies' : 'pr-comments-flat'}`}
+        >
           {comment.replies.map((r) => (
             <CommentItem
               key={r.remoteId}

--- a/apps/desktop/src/renderer/src/components/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/DiffView.tsx
@@ -1655,11 +1655,11 @@ function makeCommentMarkdownComponents(
 }
 
 /**
- * 递归渲染单条评论 + 它的回复子树。Bitbucket 的 comment.comments[] 是任意层级的，
- * 之前只画了第一层 → 第三层及以上不显示；这里递归到底。每往下一层左移 18px
- * 并多一道左竖线（跟 Bitbucket 原生 UI 视觉对齐）。
+ * 递归渲染单条评论 + 它的回复子树。comment.replies 是任意层级的；这里递归到底。每往下一层
+ * 步进缩进 + 一道左竖线（缩进量 / 边框色与评论 tab 的 .pr-comments-replies 对齐，见 comment-zone.scss）。
  */
-/** 嵌套缩进最大 5 层；第 6 层起 ml=0，跟第 5 层左对齐（避免过深一直右滑） */
+/** 嵌套缩进最大 5 层；超过此层级的更深回复**拉平**（comment-zone-reply-flat：去步进 / 边框 / 左 padding），
+ *  平铺在第 5 层缩进上、上下排列，避免无限嵌套一直右滑。 */
 const MAX_REPLY_INDENT_DEPTH = 5;
 
 function CommentNode({
@@ -1831,12 +1831,12 @@ function CommentNode({
     </>
   );
   if (depth === 0) return inner;
-  // 第 1~5 层每层缩进 18px (相对父)；第 6+ 层 ml=0 跟上一级平齐
-  const ml = depth <= MAX_REPLY_INDENT_DEPTH ? 18 : 0;
+  // 满 MAX_REPLY_INDENT_DEPTH 层后**拉平**：去掉步进缩进与左竖线，更深回复平铺在上限层级上
+  // （与评论 tab 设计一致）。关键：必须同时去掉 padding-left 与 border —— 仅去步进、保留每层的
+  // padding/border 会逐级累加仍右移（之前"还是有缩进"的根因）。
+  const flat = depth > MAX_REPLY_INDENT_DEPTH;
   return (
-    <div className="comment-zone-reply" style={{ marginLeft: ml }}>
-      {inner}
-    </div>
+    <div className={`comment-zone-reply${flat ? ' comment-zone-reply-flat' : ''}`}>{inner}</div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/InlineCodeContext.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCodeContext.tsx
@@ -3,7 +3,7 @@
 import '../monaco-setup';
 import { Editor, type Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { PrCommentAnchor, StoredPullRequest } from '@meebox/shared';
 import { invoke } from '../api';
@@ -33,7 +33,7 @@ interface InlineCodeContextProps {
  * 性能：每个 inline 评论都会挂一个 Monaco 实例 (读 + tokenize)。CommentsPanel 控
  * 默认只 auto-expand 前 N 条 (按时间线)，超额走 click-to-expand 懒加载。
  */
-export function InlineCodeContext({
+function InlineCodeContextImpl({
   pr,
   anchor,
   contextLines = 5,
@@ -158,3 +158,19 @@ export function InlineCodeContext({
     </div>
   );
 }
+
+/**
+ * 按**锚点值**（path / line / side）+ pr.localId + 展示选项比较的 memo：父级（CommentsPanel）在 poll
+ * 重渲染时会传新的 anchor / pr **对象引用**（值未变），默认浅比较会误判变化 → 内嵌 Monaco 重渲染重排
+ * （刷新抖动）。这里按值比较，定位信息没变就跳过整个组件，Monaco 不动。
+ */
+export const InlineCodeContext = memo(
+  InlineCodeContextImpl,
+  (prev, next) =>
+    prev.pr.localId === next.pr.localId &&
+    prev.anchor.path === next.anchor.path &&
+    prev.anchor.line === next.anchor.line &&
+    prev.anchor.side === next.anchor.side &&
+    (prev.contextLines ?? 5) === (next.contextLines ?? 5) &&
+    (prev.autoExpand ?? true) === (next.autoExpand ?? true),
+);

--- a/apps/desktop/src/renderer/src/components/LlmProfileForm.tsx
+++ b/apps/desktop/src/renderer/src/components/LlmProfileForm.tsx
@@ -10,7 +10,7 @@ export interface ProviderMeta {
   hint: string;
   /** Model 字段示例值 / placeholder */
   modelExample: string;
-  /** Base URL 字段默认值（有就回显；填空字段时 pr-agent 会用它） */
+  /** Base URL 字段的默认 endpoint：作占位提示；用户填了即透传给 pr-agent，留空则由下游回落到等同此处的默认 endpoint */
   defaultBaseUrl: string;
   /** API Key 字段是否必填 */
   needsKey: boolean;

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import type {
   PrDiscoveryFilter,
   StoredPullRequest,
 } from '@meebox/shared';
-import { invoke } from '../api';
+import { invoke, subscribe } from '../api';
 import { useChatRunStore } from '../stores/chat-run-store';
 import { PrItem } from './PrItem';
 
@@ -132,6 +132,19 @@ export function Sidebar({
       cancelled = true;
     };
   }, [prs]);
+
+  // 清空某 PR 执行历史会一并清掉其 AutoPilot 台账 → 即时清掉该 PR 的评审建议 ★（不必等下个 poll 重取）。
+  useEffect(() => {
+    const unsub = subscribe('agent:reviewStatusCleared', (ev) => {
+      setReviewVerdicts((prev) => {
+        if (!(ev.prLocalId in prev)) return prev;
+        const next = { ...prev };
+        delete next[ev.prLocalId];
+        return next;
+      });
+    });
+    return unsub;
+  }, []);
 
   // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
   // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -97,11 +97,12 @@ export function Sidebar({
     Record<string, AgentRecommendationVerdict>
   >({});
 
-  // 「执行中」指示数据源：运行队列里有在跑 / 排队 run 的 PR 集合（active + waiting），随队列实时变化。
-  const { active, waiting } = useChatRunStore();
+  // 「执行中」指示数据源：运行队列里有在跑 / 排队 run 的 PR（active + waiting），**并上**有编排 Agent
+  // 运行中的 PR（agentPrs，含纯思考阶段、无活跃工具 run 时）——补齐 agent 思考态下列表项缺执行中标记的空档。
+  const { active, waiting, agentPrs } = useChatRunStore();
   const executingPrIds = useMemo(
-    () => new Set([...active, ...waiting].map((r) => r.prLocalId)),
-    [active, waiting],
+    () => new Set([...active.map((r) => r.prLocalId), ...waiting.map((r) => r.prLocalId), ...agentPrs]),
+    [active, waiting, agentPrs],
   );
 
   // 有发现分类标签时（GitHub / Bitbucket 均含「我创建的」），reviewer 决断类（通过/需修改）

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -146,6 +146,21 @@ export function Sidebar({
     return unsub;
   }, []);
 
+  // 评审完成（手动 / AutoPilot 都经 recordReviewSummaryMessage 写台账 + 广播 agent:conversationChanged）→
+  // 即时重取该 PR 的评审建议，让 ★ 立刻出现在 PR 列表，不必等下个 poll 刷新 prs 才体现。
+  useEffect(() => {
+    const unsub = subscribe('agent:conversationChanged', (ev) => {
+      void invoke('agent:autopilotLedgers', { localIds: [ev.prLocalId] }).then((v) => {
+        const verdict = v[ev.prLocalId];
+        if (verdict === undefined) return;
+        setReviewVerdicts((prev) =>
+          prev[ev.prLocalId] === verdict ? prev : { ...prev, [ev.prLocalId]: verdict },
+        );
+      });
+    });
+    return unsub;
+  }, []);
+
   // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
   // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。
   const scopedPrs = useMemo(

--- a/apps/desktop/src/renderer/src/components/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/icons.tsx
@@ -433,7 +433,8 @@ export function RobotIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 实心五角星：评审建议徽标（手动 / AutoPilot 一视同仁）。SVG 保证字形居中、跨平台一致。 */
+/** 实心四角星（AI 常见 sparkle）：评审建议徽标（手动 / AutoPilot 一视同仁）。四条边向中心内凹，
+ *  四个尖角居中对称，SVG 保证字形居中、跨平台一致。 */
 export function StarIcon({ size = 11 }: IconProps) {
   return (
     <svg
@@ -443,7 +444,7 @@ export function StarIcon({ size = 11 }: IconProps) {
       fill="currentColor"
       aria-hidden="true"
     >
-      <path d="M8 1l1.65 4.74 5.01.1-4 3.03 1.45 4.79L8 10.8l-4.11 2.86 1.45-4.79-4-3.03 5.01-.1L8 1z" />
+      <path d="M8 1 Q9 7 15 8 Q9 9 8 15 Q7 9 1 8 Q7 7 8 1 Z" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/stores/chat-run-store.ts
+++ b/apps/desktop/src/renderer/src/stores/chat-run-store.ts
@@ -18,9 +18,17 @@ export interface ChatRunStoreState {
   waiting: ReadonlyArray<PragentRunInfo>;
   /** 各 run 的实时 stdout 行缓存。键 = runId；run 完成后保留直到 clearLines 调用 */
   linesByRunId: ReadonlyMap<string, ReadonlyArray<string>>;
+  /** 有编排 Agent 运行中（思考或派发工具）的 PR localId 集合——含纯思考阶段（无活跃工具 run），
+   *  来自主进程 `agent:runningChanged`。PR 列表项「执行中」指示在工具队列之外再并入此集合。 */
+  agentPrs: ReadonlyArray<string>;
 }
 
-let state: ChatRunStoreState = { active: [], waiting: [], linesByRunId: new Map() };
+let state: ChatRunStoreState = {
+  active: [],
+  waiting: [],
+  linesByRunId: new Map(),
+  agentPrs: [],
+};
 const subscribers = new Set<() => void>();
 
 function notify(): void {
@@ -62,6 +70,19 @@ function setQueue(
   notify();
 }
 
+/** 集合相等（顺序无关）：长度相同且每个 id 都在旧集合里。避免广播顺序差异引发无谓 re-render。 */
+function sameIdSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every((id) => sa.has(id));
+}
+
+function setAgentPrs(ids: ReadonlyArray<string>): void {
+  if (sameIdSet(state.agentPrs, ids)) return;
+  state = { ...state, agentPrs: ids };
+  notify();
+}
+
 function appendLine(runId: string, line: string): void {
   const cur = state.linesByRunId.get(runId) ?? [];
   const nextMap = new Map(state.linesByRunId);
@@ -87,6 +108,7 @@ export const chatRunStore = {
     };
   },
   setQueue,
+  setAgentPrs,
   appendLine,
   clearLines,
 };
@@ -119,9 +141,14 @@ export function wireChatRunStore(): () => void {
   const unsubProgress = subscribe('pragent:runProgress', (ev) => {
     chatRunStore.appendLine(ev.runId, ev.line);
   });
+  // 编排 Agent 运行中（含纯思考阶段）的 PR 集合：手动 run/ask 与 AutoPilot 后台评审一并计入。
+  const unsubAgentRunning = subscribe('agent:runningChanged', (ev) => {
+    chatRunStore.setAgentPrs(ev.prLocalIds);
+  });
   return () => {
     cancelled = true;
     unsubQueue();
     unsubProgress();
+    unsubAgentRunning();
   };
 }

--- a/apps/desktop/src/renderer/src/styles/comment-zone.scss
+++ b/apps/desktop/src/renderer/src/styles/comment-zone.scss
@@ -183,13 +183,23 @@
 // (前 5 层每层 18px，第 6+ 层 0 跟第 5 层平齐)
 .comment-zone-reply {
   margin-top: $space-4;
+  // 每层步进 12px + 左竖线 —— 缩进量与边框色对齐评论 tab 的 .pr-comments-replies（$space-6 / $border-muted）。
+  margin-left: $space-6;
   padding: $space-2 0 $space-2 $space-5;
-  border-left: 2px solid $border-default;
+  border-left: 2px solid $border-muted;
   // 字号继承父级 (.monaco-comment-zone-inner 14px)，不再缩减 — 嵌套 reply 跟
   // 父评论同等可读性，视觉层级靠左侧 border + indent 区分就够
 
   & + & {
     margin-top: $space-3;
+  }
+
+  // 满 MAX_REPLY_INDENT_DEPTH 层后拉平：去步进 / 去左竖线 / 去左 padding，更深回复平铺在上限层级上。
+  // 必须三者全去 —— 仅去 margin 步进、保留 padding-left + border 会逐级累加仍右移（"还是有缩进"的根因）。
+  &.comment-zone-reply-flat {
+    margin-left: 0;
+    padding-left: 0;
+    border-left: none;
   }
 
   .comment-zone-body {

--- a/apps/desktop/src/renderer/src/styles/main-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/main-pane.scss
@@ -425,10 +425,26 @@
   border-left: 2px solid $border-muted;
 }
 .pr-comment {
-  background: $bg-elev;
-  border: 1px solid $border-default;
-  border-radius: $radius-md;
   padding: $space-4 $space-5;
+  // 卡片视觉（底色 / 边框 / 圆角）只给**顶层评论**；嵌套回复改走「左竖线缩进」的扁平样式（与行内
+  // 评论 DiffView 一致）——回复的 <ul> 渲染在父 <li.pr-comment> 内部，若每层都是卡片就会层层「盒中盒」。
+  &.pr-comment-depth-0 {
+    background: $bg-elev;
+    border: 1px solid $border-default;
+    border-radius: $radius-md;
+  }
+  // 嵌套回复：无卡片盒子，仅纵向留白；横向缩进与左竖线由 .pr-comments-replies 提供，满 5 层后拉平。
+  &:not(.pr-comment-depth-0) {
+    padding: $space-3 0;
+  }
+}
+// 拉平层（满 MAX_REPLY_DEPTH 层后）的回复同层级、无卡片盒子区隔 → 每条加一道顶部横向分割线 + 上下
+// 留白（margin 在线上方、padding 在线下方），清晰区分上下相邻评论（首条同时与上一缩进层级隔开）。
+// 置于 .pr-comment 之后以盖过其 padding-top。
+.pr-comments-flat > .pr-comment {
+  margin-top: $space-4;
+  padding-top: $space-4;
+  border-top: 1px solid $border-muted;
 }
 .pr-comment-head {
   display: flex;

--- a/apps/desktop/src/renderer/src/styles/sidebar.scss
+++ b/apps/desktop/src/renderer/src/styles/sidebar.scss
@@ -257,16 +257,23 @@
   margin-left: auto;
 }
 
-// reviewer 统计胶囊：靠右贴边，把 author/branch meta 挤左
+// reviewer 统计胶囊：靠右贴边，把 author/branch meta 挤左。固定带高 + 居中：让不同行无论含哪种
+// chip（文字计数 / 图标星标 / 执行中 spinner）都占同一高度，避免跨行 chip 垂直位置漂移。
 .pr-item-review-chips {
   display: inline-flex;
+  align-items: center;
+  min-height: 18px;
   gap: $space-2;
   margin-left: auto;
 }
 
+// 所有 chip 统一带高（含图标类 verdict / mergeable 与文字类 approved / needs-work）：图标 chip 原本
+// 只有 ~13px、比文字 chip(~17px)矮，导致「星标 only」行与「星标+计数」行高度不一。固定 18px + 居中对齐。
 .review-chip {
   display: inline-flex;
   align-items: center;
+  box-sizing: border-box;
+  height: 18px;
   gap: 3px;
   padding: 1px $space-3;
   border-radius: $radius-pill;

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
@@ -79,6 +79,7 @@
   "Other": "Sonstiges",
   "Miscellaneous": "Verschiedenes",
   "Formatting": "Formatierung",
+  "Dependencies": "Abhängigkeiten",
   "High": "Hoch",
   "Medium": "Mittel",
   "Low": "Niedrig"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/de-DE.json
@@ -78,6 +78,7 @@
   "Tests": "Tests",
   "Other": "Sonstiges",
   "Miscellaneous": "Verschiedenes",
+  "Formatting": "Formatierung",
   "High": "Hoch",
   "Medium": "Mittel",
   "Low": "Niedrig"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
@@ -78,6 +78,7 @@
   "Tests": "テスト",
   "Other": "その他",
   "Miscellaneous": "雑多",
+  "Formatting": "フォーマット",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/ja-JP.json
@@ -79,6 +79,7 @@
   "Other": "その他",
   "Miscellaneous": "雑多",
   "Formatting": "フォーマット",
+  "Dependencies": "依存関係",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
@@ -79,6 +79,7 @@
   "Other": "其他",
   "Miscellaneous": "杂项",
   "Formatting": "格式化",
+  "Dependencies": "依赖",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
+++ b/apps/desktop/src/renderer/src/utils/pr-agent-labels/zh-CN.json
@@ -78,6 +78,7 @@
   "Tests": "测试",
   "Other": "其他",
   "Miscellaneous": "杂项",
+  "Formatting": "格式化",
   "High": "高",
   "Medium": "中",
   "Low": "低"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/desktop": {
       "name": "@meebox/desktop",
-      "version": "0.5.0-alpha.1",
+      "version": "0.5.0",
       "dependencies": {
         "@iconify-json/material-icon-theme": "^1.2.66",
         "@iconify/react": "^5.2.1",

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -26,10 +26,7 @@ export interface ToolText {
 
 export interface ReviewOrchestratorDeps {
   /** 分发一个只读 pr-agent 工具，返回文本结果（描述 / findings / 回答）。 */
-  runTool(call: {
-    tool: 'describe' | 'review' | 'ask';
-    question?: string;
-  }): Promise<ToolText>;
+  runTool(call: { tool: 'describe' | 'review' | 'ask'; question?: string }): Promise<ToolText>;
   /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
   chat(input: { system: string; user: string }): Promise<ToolText>;
   /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
@@ -47,7 +44,7 @@ export interface ReviewOrchestratorInput {
   toolCatalog?: ToolCatalogEntry[];
   /** 条件性追问 /ask 的硬上限（默认 2）。 */
   maxFollowupAsks?: number;
-  /** 总结严格篇幅上限（默认 800 字符）。 */
+  /** 总结篇幅的**参考**上限（默认 800 字符）：仅作提示词里的软约束引导 LLM 收敛，**不**对产出做硬截断。 */
   summaryMaxChars?: number;
 }
 
@@ -72,11 +69,6 @@ function addUsage(acc: TokenUsage, u?: TokenUsage): TokenUsage {
     totalTokens: (acc.totalTokens ?? 0) + (u.totalTokens ?? 0),
     calls: (acc.calls ?? 0) + (u.calls ?? 1),
   };
-}
-
-function clamp(s: string, max: number): string {
-  const t = s.trim();
-  return t.length <= max ? t : `${t.slice(0, max - 1).trimEnd()}…`;
 }
 
 /** 把 JSON 串字面量内部未转义的裸控制符（换行/回车/制表）补转义。LLM 常把多行 markdown 原样塞进
@@ -208,7 +200,7 @@ function summaryPrompt(
   const [overview, findings, suggestions] = sections;
   return [
     'Write a closing review summary for the human reviewer, in the SAME LANGUAGE as the review findings',
-    `(at most ${String(maxChars)} characters; compress, never truncate key points).`,
+    `(aim for roughly ${String(maxChars)} characters — compress and prioritize; this is a soft guideline, not a hard limit, so do NOT truncate key points to fit).`,
     'Use EXACTLY this markdown skeleton — these three "## " sections, in this order, and nothing else.',
     'Keep each line short; put every finding / suggestion on its own "- " bullet:',
     '',
@@ -329,7 +321,9 @@ export async function runReviewMicroflow(
     recommendation?: { verdict?: unknown; reason?: unknown };
   }>(sum.text);
   // 解析失败兜底：从原始文本捞 summary 散文；再剥掉模型误并入末尾的判定 JSON，绝不把原始 JSON 展示给用户。
-  const summary = clamp(stripTrailingJson(parsed?.summary ?? salvageProse(sum.text)), summaryMax);
+  // **不做硬截断**：篇幅只在提示词里作参考性约束（summaryMax，见 summaryPrompt），AI 已生成的总结完整保留，
+  // 避免「参数…」这种半句被切断。
+  const summary = stripTrailingJson(parsed?.summary ?? salvageProse(sum.text)).trim();
   const recommendation: AgentRecommendation =
     parsed?.recommendation && isVerdict(parsed.recommendation.verdict)
       ? {

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -24,7 +24,10 @@ function makeDeps(opts: {
   const deps: ReviewOrchestratorDeps = {
     runTool: vi.fn(async (call: { tool: 'describe' | 'review' | 'ask'; question?: string }) => {
       toolCalls.push(call);
-      return { text: opts.toolText?.[call.tool] ?? `${call.tool}-result`, usage: { totalTokens: 10 } };
+      return {
+        text: opts.toolText?.[call.tool] ?? `${call.tool}-result`,
+        usage: { totalTokens: 10 },
+      };
     }),
     chat: vi.fn(async () => {
       const text = opts.chatReplies[chatIdx++] ?? '{}';
@@ -43,7 +46,8 @@ describe('extractJson', () => {
 
   it('recovers JSON with unescaped raw newlines inside string values', () => {
     // 模型常把多行 markdown 原样塞进字符串值、不转义换行——补转义后应能解析。
-    const raw = '{"final": "## 摘要\n\n第一行\n第二行", "recommendation": {"verdict": "needs_work"}}';
+    const raw =
+      '{"final": "## 摘要\n\n第一行\n第二行", "recommendation": {"verdict": "needs_work"}}';
     const parsed = extractJson<{ final: string; recommendation: { verdict: string } }>(raw);
     expect(parsed?.final).toBe('## 摘要\n\n第一行\n第二行');
     expect(parsed?.recommendation.verdict).toBe('needs_work');
@@ -65,9 +69,11 @@ describe('salvageProse', () => {
 
 describe('stripTrailingJson', () => {
   it('strips a trailing recommendation JSON block the model wrongly appended', () => {
-    const fenced = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n```json\n{"recommendation": {"verdict": "needs_work"}}\n```';
+    const fenced =
+      '## 摘要\n\n本 PR 修复了空值崩溃。\n\n```json\n{"recommendation": {"verdict": "needs_work"}}\n```';
     expect(stripTrailingJson(fenced)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
-    const bare = '## 摘要\n\n本 PR 修复了空值崩溃。\n\n{\n  "recommendation": {"verdict": "approve"}\n}';
+    const bare =
+      '## 摘要\n\n本 PR 修复了空值崩溃。\n\n{\n  "recommendation": {"verdict": "approve"}\n}';
     expect(stripTrailingJson(bare)).toBe('## 摘要\n\n本 PR 修复了空值崩溃。');
   });
 
@@ -112,7 +118,7 @@ describe('runReviewMicroflow', () => {
     expect(r.recommendation.verdict).toBe('needs_work');
   });
 
-  it('clamps the summary to summaryMaxChars', async () => {
+  it('does not truncate the summary (summaryMaxChars is a soft prompt hint only)', async () => {
     const long = 'x'.repeat(500);
     const { deps } = makeDeps({
       chatReplies: [
@@ -120,8 +126,9 @@ describe('runReviewMicroflow', () => {
         `{"summary": "${long}", "recommendation": {"verdict": "approve", "reason": "ok"}}`,
       ],
     });
+    // summaryMaxChars=100 远小于 500 字符的产出：现仅作提示词软约束，不再硬截断 → 完整保留。
     const r = await runReviewMicroflow(deps, { context, pr, summaryMaxChars: 100 });
-    expect(r.summary.length).toBe(100);
+    expect(r.summary).toBe(long);
   });
 
   it('falls back to manual_review when the summary JSON is unparseable', async () => {
@@ -135,7 +142,10 @@ describe('runReviewMicroflow', () => {
   it('streams every step via onStep', async () => {
     const seen: string[] = [];
     const { deps } = makeDeps({
-      chatReplies: ['{"severe": false}', '{"summary": "s", "recommendation": {"verdict": "approve", "reason": "r"}}'],
+      chatReplies: [
+        '{"severe": false}',
+        '{"summary": "s", "recommendation": {"verdict": "approve", "reason": "r"}}',
+      ],
     });
     deps.onStep = (step) => {
       seen.push(step.kind);

--- a/packages/poller/src/autopilot-ledger.ts
+++ b/packages/poller/src/autopilot-ledger.ts
@@ -28,6 +28,17 @@ export async function writeAutopilotLedger(
 }
 
 /**
+ * 清掉该 PR 的 AutoPilot 台账（清空执行历史时一并删）。台账存的是评审建议 verdict，PR 列表 ★ 徽标
+ * 据此显示；删掉后 ★ 随之消失，避免清空结果后仍残留陈旧评审状态。
+ */
+export async function clearAutopilotLedger(
+  stateStore: StateStore,
+  prLocalId: string,
+): Promise<void> {
+  await stateStore.delete(ledgerKey(prLocalId));
+}
+
+/**
  * 该 PR 是否需要自动评审：无台账（从未跑过）或台账记录的 updatedAt 与当前不一致
  * （PR 已变更）即为 true。内容未变则 false（去重，不重复跑）。
  */

--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -142,9 +142,11 @@ export class RepoMirrorManager {
 
   /**
    * 计算 base..head 之间的 commit 数 (PR 引入的提交数)。完全走本地 bare 镜像
-   * `git rev-list --count <base>..<head>` —— 不打远端，毫秒级返回。
+   * `git rev-list --count --no-merges <base>..<head>` —— 不打远端，毫秒级返回。
    *
-   * 用途：UI 在 PR 标签页上展示 commits 数角标，不必为了一个数字去拉远端。
+   * 用途：UI 在 PR 标签页上展示 commits 数角标，不必为了一个数字去拉远端。base 传**目标分支 sha**
+   * 时 base..head = head ^target，即「源分支不在目标分支上的提交」；`--no-merges` 略去合并提交，
+   * 与平台 PR /commits 列表口径一致（不把源分支合入目标分支带进来的提交、以及 merge 提交计入）。
    *
    * 任一 sha 不在本地镜像 (尚未 sync 到本 PR 范围) → 返回 null，调用方把它
    * 当 "暂时未知" 处理 (不显示角标 / 显示加载占位)。
@@ -162,7 +164,12 @@ export class RepoMirrorManager {
     if (!hasBase || !hasHead) return null;
     const mp = this.mirrorPath(repo);
     try {
-      const out = await simpleGit(mp).raw(['rev-list', '--count', `${baseSha}..${headSha}`]);
+      const out = await simpleGit(mp).raw([
+        'rev-list',
+        '--count',
+        '--no-merges',
+        `${baseSha}..${headSha}`,
+      ]);
       const n = Number.parseInt(out.trim(), 10);
       return Number.isNaN(n) ? null : n;
     } catch {

--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -141,6 +141,22 @@ export class RepoMirrorManager {
   }
 
   /**
+   * 镜像是否「健康」：是有效 git 目录且 origin remote 已配置。clone/fetch 中途被打断会留下「HEAD 在、
+   * 但 git 元数据残缺（常缺 origin remote）」的目录，仅判 HEAD 存在会误以为可 fetch → `git fetch origin`
+   * 直接 fatal（`'origin' does not appear to be a git repository`）。用 `git config --get
+   * remote.origin.url` 同时验证两点：命令在非 git 目录会失败，origin 未配置则无输出 → 任一不满足即不健康，
+   * 调用方据此删库重建（见 doSyncMirror 的主动自愈）。
+   */
+  private async isHealthyMirror(mirrorPath: string): Promise<boolean> {
+    try {
+      const url = await simpleGit(mirrorPath).raw(['config', '--get', 'remote.origin.url']);
+      return url.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * 计算 base..head 之间的 commit 数 (PR 引入的提交数)。完全走本地 bare 镜像
    * `git rev-list --count --no-merges <base>..<head>` —— 不打远端，毫秒级返回。
    *
@@ -499,8 +515,19 @@ export class RepoMirrorManager {
 
   private async doSyncMirror(repo: RepoIdentity): Promise<MirrorResult> {
     const mirrorPath = this.mirrorPath(repo);
-    const hasMirror = await this.exists(path.join(mirrorPath, 'HEAD'));
     const key = this.repoKey(repo);
+    let hasMirror = await this.exists(path.join(mirrorPath, 'HEAD'));
+    // 自愈（主动）：目录存在但不是**健康**镜像 —— clone/fetch 中途被打断会留下「HEAD 在、但缺 origin
+    // remote / 非有效 git 目录」的残缺镜像，后续 `git fetch origin` 直接 fatal
+    // （`'origin' does not appear to be a git repository`）。检出即删掉，按首次 clone 走完整重建。
+    if (hasMirror && !(await this.isHealthyMirror(mirrorPath))) {
+      this.opts.logger?.warn(
+        { repo: key, mirrorPath },
+        'unhealthy mirror detected (interrupted clone?); removing for full re-clone',
+      );
+      await fs.rm(mirrorPath, { recursive: true, force: true }).catch(() => undefined);
+      hasMirror = false;
+    }
 
     const emit = (e: Omit<SyncProgressEvent, 'repo'>): void => {
       this.opts.onProgress?.({ repo: key, ...e });
@@ -524,22 +551,34 @@ export class RepoMirrorManager {
 
     try {
       if (hasMirror) {
-        this.opts.logger?.debug({ repo: key }, 'mirror exists, fetching');
-        // 显式 refspec，覆盖式拉：
-        //   - refs/heads/*：所有分支（含 PR target 与 source 分支）
-        //   - refs/pull-requests/*/from：Bitbucket 把 PR 源头 sha 单独保存在这里。
-        //     当源分支已被删除 / 强推后，refs/heads 看不到，但 from ref 仍指向
-        //     PR 开启时的 sha；没有它 `git diff base...head` 会 "Invalid
-        //     symmetric difference" 因为 head 不可达。
-        await this.withProxyEnv(simpleGit({ baseDir: mirrorPath, ...gitProgressOpt })).raw([
-          'fetch',
-          '--progress',
-          'origin',
-          '+refs/heads/*:refs/heads/*',
-          '+refs/pull-requests/*/from:refs/pull-requests/*/from',
-        ]);
-        emit({ phase: 'done' });
-        return { mirrorPath, freshClone: false };
+        try {
+          this.opts.logger?.debug({ repo: key }, 'mirror exists, fetching');
+          // 显式 refspec，覆盖式拉：
+          //   - refs/heads/*：所有分支（含 PR target 与 source 分支）
+          //   - refs/pull-requests/*/from：Bitbucket 把 PR 源头 sha 单独保存在这里。
+          //     当源分支已被删除 / 强推后，refs/heads 看不到，但 from ref 仍指向
+          //     PR 开启时的 sha；没有它 `git diff base...head` 会 "Invalid
+          //     symmetric difference" 因为 head 不可达。
+          await this.withProxyEnv(simpleGit({ baseDir: mirrorPath, ...gitProgressOpt })).raw([
+            'fetch',
+            '--progress',
+            'origin',
+            '+refs/heads/*:refs/heads/*',
+            '+refs/pull-requests/*/from:refs/pull-requests/*/from',
+          ]);
+          emit({ phase: 'done' });
+          return { mirrorPath, freshClone: false };
+        } catch (fetchErr) {
+          // 自愈（被动）：fetch 撞上**本地损坏 / 残缺**镜像（缺 origin、坏对象等）→ 删掉，落到下方完整
+          // clone 重建。其它错误（网络 / 认证 / 远端拒绝）原样抛出，不误删健康镜像、不把临时网络问题当损坏。
+          if (!isLocalMirrorCorruption(fetchErr)) throw fetchErr;
+          this.opts.logger?.warn(
+            { repo: key, err: fetchErr instanceof Error ? fetchErr.message : String(fetchErr) },
+            'fetch failed on corrupt mirror; removing for full re-clone',
+          );
+          await fs.rm(mirrorPath, { recursive: true, force: true }).catch(() => undefined);
+          // 不 return，落到下方完整 clone 自愈重建。
+        }
       }
 
       this.opts.logger?.info({ repo: key }, 'cloning bare mirror (full + all refs)');
@@ -603,6 +642,24 @@ export class RepoMirrorManager {
     return total;
   }
 
+}
+
+/**
+ * 错误消息是否指向**本地镜像损坏 / 残缺**（而非网络 / 认证 / 远端拒绝等可重试的远端问题）。fetch 失败
+ * 后据此判断是否「删库重 clone」自愈——只对本地损坏自愈，避免把临时网络问题误判为损坏而无谓全量重建。
+ * 不匹配 "could not read from remote repository"：它对网络 / 认证失败也会出现，不能据它判定本地损坏。
+ */
+function isLocalMirrorCorruption(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    msg.includes('does not appear to be a git repository') || // 缺 origin remote（中断的 clone）
+    msg.includes('not a git repository') ||
+    msg.includes('bad object') ||
+    msg.includes('object file is empty') ||
+    msg.includes('loose object') || // "loose object <sha> is corrupt"
+    msg.includes('did not send all necessary objects') ||
+    msg.includes('unable to read')
+  );
 }
 
 /**

--- a/packages/shared/src/agent-contract.ts
+++ b/packages/shared/src/agent-contract.ts
@@ -99,7 +99,7 @@ export interface AgentSession {
    * 无文本输入 → 不填。UI 据此把用户输入回显为右对齐气泡、归属其发起 PR、持久化恢复。
    */
   userRequest?: string;
-  /** 本 PR 收尾总结正文（受 summary_max_chars 限长）。 */
+  /** 本 PR 收尾总结正文（summary_max_chars 仅作提示词软约束引导篇幅，不对正文硬截断）。 */
   summary?: string;
   /** 收尾建议（非约束性）。 */
   recommendation?: AgentRecommendation;

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -145,6 +145,11 @@ export interface IpcEvents {
    * （无活跃工具 run 时），补齐仅看运行队列时思考态缺失执行中标记的空档。
    */
   'agent:runningChanged': { prLocalIds: string[] };
+  /**
+   * 某 PR 的评审状态被清除（清空执行历史时一并清掉 AutoPilot 台账）。renderer 据此即时清掉 PR 列表
+   * 该 PR 的评审建议 ★ 徽标，避免清空后仍残留陈旧评审状态（不必等下个 poll 重取台账）。
+   */
+  'agent:reviewStatusCleared': { prLocalId: string };
 }
 
 export type IpcEventName = keyof IpcEvents;

--- a/packages/shared/src/ipc.ts
+++ b/packages/shared/src/ipc.ts
@@ -139,6 +139,12 @@ export interface IpcEvents {
    * 该 PR 则据此重载会话，让后台产生的总结卡片即时出现（手动评审走 invoke 返回后自行重载，不依赖此事件）。
    */
   'agent:conversationChanged': { prLocalId: string };
+  /**
+   * 运行中（思考或派发工具）的编排 Agent 所属 PR 集合变化时推送：手动 `agent:run` / `agent:ask`
+   * 与 AutoPilot 后台评审一并计入。renderer 据此在 PR 列表项显示「执行中」指示——覆盖**纯思考阶段**
+   * （无活跃工具 run 时），补齐仅看运行队列时思考态缺失执行中标记的空档。
+   */
+  'agent:runningChanged': { prLocalIds: string[] };
 }
 
 export type IpcEventName = keyof IpcEvents;


### PR DESCRIPTION
发布 **0.5.0** 首个正式版（dev → master）。合并后在 master 打 `v0.5.0` tag 触发 release。

## 本版重点

- **高阶 Agent（会话 Agent 化 + AutoPilot 后台预评审）**：PR 评审中引入可委派智能体，随 LLM 配置自动可用——一键自动评审微流程、对话即委派、AutoPilot 后台预评审（逐项授权 + 红线硬校验）、评审状态可视化、并行多问、分步 token 用量、Agent 上下文目录。
- **无边框窗口 + 自绘标题栏**（VS Code 风）；设置页「关于 & 反馈」入口。
- 体验打磨：重型组件加载抖动收敛、评论嵌套展示统一（评论 tab + 行内、满 5 层拉平）、describe 分类默认折叠、PR 列表状态 chip 对齐、评审总结不再硬截断。
- 修复：diff 基准随目标分支漂移误判、Windows 控制台中文乱码、含方括号路径锚点、Anthropic base_url 透传（#65）、镜像损坏自愈、评论页刷新抖动等。

完整条目见 [CHANGELOG.md](CHANGELOG.md) `[0.5.0]` 段（开发期 0.5.0-alpha.1 已并入本版、收为存根）。

## 发布前置

- `apps/desktop` 版本已置 `0.5.0`、`package-lock.json` 对齐（artifact 命名 `code-meeseeks-0.5.0-*`）。
- CHANGELOG 过 `prettier --check`；release notes 从 `[0.5.0]` 段提取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
