### PR TITLE
fix(pragent): 修复 codex 编排通道 reasoning.effort=minimal 致 run 失败

### DIFF
--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/specs.py
@@ -16,10 +16,19 @@ _CLI_SPECS = {
     },
     # codex：exec 非交互 + --json（JSONL 事件流）；末位 `-` 让 stdin 作完整 prompt；
     # --skip-git-repo-check 容许临时目录运行，--sandbox read-only 只读不改文件。
-    # 低算力档：-c model_reasoning_effort=minimal（codex 默认推理较重，编排通道无需，调低提速）。
+    # 默认禁用 web_search / image_gen：评审与编排在只读临时目录里跑，这两个工具用不到，
+    # 关掉既收敛工具面、又省 ~3K tokens（工具定义不再随每次请求下发）。键值：
+    #   web_search 是字符串枚举（disabled / cached / live），用 `-c web_search=disabled`；
+    #   image_gen 是 feature flag，用 `-c features.image_generation=false`（等价 --disable image_generation）。
+    # 低算力档：-c model_reasoning_effort=low（codex 默认推理较重，编排通道无需，调低提速）。
+    # 不用 minimal：gpt-5.x-codex 不支持 minimal（仅 none/low/medium/high/xhigh，传 minimal 报 400），
+    # 且 minimal 还与 web_search / image_gen 互斥；low 普遍受支持、与工具兼容，作低算力档更稳。
     "codex": {
-        "flags": ["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only", "-"],
-        "low_effort_flags": ["-c", "model_reasoning_effort=minimal"],
+        "flags": [
+            "exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only",
+            "-c", "web_search=disabled", "-c", "features.image_generation=false", "-",
+        ],
+        "low_effort_flags": ["-c", "model_reasoning_effort=low"],
         "parser": _parse_codex_output,
         "strip_env": ("OPENAI_API_KEY", "CODEX_API_KEY"),
     },

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1367,7 +1367,7 @@ export function registerIpcHandlers({
       ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
       CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
       // Agent 编排通道（规划 / 判读 / 收尾 / 对话）是路由 + 轻量综合，非深度代码分析（那在
-      // pr-agent /review 里）。本机 CLI 模式下调低推理档（codex: model_reasoning_effort=minimal）
+      // pr-agent /review 里）。本机 CLI 模式下调低推理档（codex: model_reasoning_effort=low）
       // 提速；仅作用于本 chat spawn，pr-agent 工具 run 的 env 不含此项 → /review 仍满档推理。
       // 非 CLI 模式（API）由 CLI handler 之外的路径处理，该 env 无副作用。
       MEEBOX_CLI_REASONING: 'low',


### PR DESCRIPTION
## 背景

修复 #77：启用 codex 作为本机 agentic CLI 时，Agent 编排通道（一键评审收尾 / 自由规划等）执行 agent 动作报 `pr-agent exited with code 1`，而普通 `/review` 正常。

## 根因

编排通道开低算力档 `MEEBOX_CLI_REASONING=low` → shim 对 codex 注入 `-c model_reasoning_effort=minimal`，触发两类 codex 400 使 `codex exec` 退 1：

1. `minimal` 与 codex 默认工具 `web_search` / `image_gen` 互斥（API 400 invalid_request_error）。
2. `gpt-5.x-codex` 不支持 `minimal`（仅 none/low/medium/high/xhigh）。

普通 `/review` 不开低算力档，故不受影响。

## 改动

- **低算力档 `minimal` → `low`**：普遍受支持、与工具兼容。
- **默认禁用 codex `web_search` / `image_gen`**：评审/编排在只读临时目录里用不到，关闭收敛工具面并省约 3K tokens/请求。
  - `-c web_search=disabled`（字符串枚举 disabled/cached/live）
  - `-c features.image_generation=false`（feature flag，等价 `--disable image_generation`）
- 同步修正 `ipc.ts` 编排 env 注释中的 `minimal` 表述。

## 验证

实测 codex-cli 0.124.0 / gpt-5.5-codex：

- 改前：`-c model_reasoning_effort=minimal` → exit 1（400）。
- 改后：base flags / base+低算力档两种组合均 exit 0、正常返回 agent_message；input_tokens 30406 → 27420（工具定义不再下发）。

> shim 改动需 `npm --prefix apps/desktop run prepare:pragent` 同步进 vendor（gitignored），本地已同步并冒烟通过。

Closes #77
