### PR TITLE
feat(settings): 连接 / LLM 配置模态左右布局复用 + 危险按钮统一 + 退出拦截等交互优化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - 新建评论：标签栏右侧「评论」按钮可直接发一条不锚到文件的 summary 评论，编辑框作为时间线首个节点（头像在轨上、编辑框缩进）展开，发布后新评论即时出现在顶部（新增 `publishSummaryComment` 平台契约 + `comments:create` 通道）。
   - GitLab 走差异化设计：无统一活动事件源（CE 无审批、审批系统 note 解析脆弱），标签页保持纯「评论」视图（`capabilities.activityTimeline=false`），不混入提交 / 决断。
 
+- 连接 / LLM 配置模态退出拦截：编辑配置时若存在未提交改动，关闭（背景点击 / 取消 / 关闭键）会弹确认框拦截，确认放弃才关闭，避免误丢未保存内容。
+
 ### Changed
 
 - **前端代码结构重构（可维护性）**：纯结构调整，对外接口与界面 / 交互行为均不变。重点：
@@ -33,6 +35,9 @@
   - DiffSearchPanel / DraftZone / ChatInputBar 三个单体组件拆分：搜索算法、read/edit/publish 状态机、命令解析 / 输入状态机各抽为 util / hook，组件退化为瘦渲染
   - `components/common` 收敛 `index` barrel，跨域 import 统一走 barrel
   - 其它整理：目录归并、工具方法去重、main 进程 splash 拆分
+
+- 设置面板「连接 / LLM 配置」模态复用首启向导的左右布局：左侧选集成平台 / LLM provider、右侧填表单（复用的 `PlatformPicker` / `LlmProviderPicker` 统一在 settings 域维护，首启向导同步复用）。LLM 模态与向导 LLM 步改为固定高度、两栏各自滚动——切换 provider 不再抖动、provider 列表后续扩展也不撑高，向导两子步等高对齐；CLI 模式补「实验性」标记、名称 / 命令占位提示 `claude / codex`、文案精简（去品牌名与内部细节）；必填校验改为只标红框（去错误文案、消除控件位置抖动）；「测试连接」按钮收窄为 `btn-sm` 并与结果文案垂直对齐。
+- 危险按钮统一为高饱和度红描边：新增 `$color-danger-strong` token，删除评论（评论 tab + 行内）/ 删除草稿 / 删除连接 / LLM、停止、拒绝 finding 等按钮 hover 由偏浅鲑红改为与模态删除按钮同色系的饱和红，警示力更强、全局一致（保留 ghost 描边风格，不改为实底）。
 
 ### Fixed
 

--- a/apps/desktop/src/renderer/src/App.scss
+++ b/apps/desktop/src/renderer/src/App.scss
@@ -14,6 +14,7 @@
 //   chat-pane    右侧 pr-agent chat 面板
 //   drafts-panel "草稿" tab 列表页 (.drafts-panel / -filter / -item / -anchor)
 //   modal        SettingsModal + LlmEditorModal 子模态 + LLM profile 列表
+//   config-picker 配置选择器左右布局 (平台 / LLM provider 选择列表 + 表单，向导与设置子模态共用)
 @use './styles/base';
 @use './styles/layout/titlebar';
 @use './styles/layout/statusbar';
@@ -29,4 +30,5 @@
 @use './styles/features/chat-pane';
 @use './styles/features/drafts-panel';
 @use './styles/common/modal';
+@use './styles/features/config-picker';
 @use './styles/features/onboarding';

--- a/apps/desktop/src/renderer/src/components/common/ConfirmModal.tsx
+++ b/apps/desktop/src/renderer/src/components/common/ConfirmModal.tsx
@@ -9,6 +9,8 @@ interface ConfirmModalProps {
   cancelLabel?: string;
   /** 危险操作（删除等）时确认按钮显红色 */
   danger?: boolean;
+  /** 从二层嵌套子模态弹出时置 true：用嵌套 backdrop（z-index 抬到 nested 层），叠在子模态之上 */
+  nested?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -25,6 +27,7 @@ export function ConfirmModal({
   confirmLabel,
   cancelLabel,
   danger = false,
+  nested = false,
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
@@ -49,6 +52,7 @@ export function ConfirmModal({
   return (
     <Modal
       portal
+      nested={nested}
       size="confirm"
       onClose={onCancel}
       title={resolvedTitle}

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
@@ -30,7 +30,6 @@ export function LlmStep({
       {!chosen ? (
         // 阶段一：居中的 provider 选择列表（滚动）
         <div className="onboarding-provider-pick">
-          <p className="muted onboarding-provider-pick-hint">{t('onboarding.providerPickHint')}</p>
           {/* 阶段一沿用中性配置选择器视觉，但每项尾随「›」提示可进入、且不预选高亮 */}
           <div
             className="config-pick-list"
@@ -44,8 +43,13 @@ export function LlmStep({
                 className="config-pick-item"
                 onClick={() => pick(p.value)}
               >
-                <LlmProviderIcon provider={p.value} size={28} />
+                <LlmProviderIcon provider={p.value} size={24} />
                 <span className="config-pick-name config-pick-name-fill">{p.label}</span>
+                {p.value === 'cli' && (
+                  <span className="badge-experimental" title={t('settings.cliExperimentalHint')}>
+                    {t('settings.experimental')}
+                  </span>
+                )}
                 <span className="config-pick-arrow" aria-hidden="true">
                   ›
                 </span>

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LlmProfile } from '@meebox/shared';
-import { LLM_PROVIDERS, LlmProfileForm } from '../../settings';
+import { LLM_PROVIDERS, LlmProfileForm, LlmProviderPicker } from '../../settings';
 import { LlmProviderIcon } from '../../../common';
 
 export function LlmStep({
@@ -31,8 +31,9 @@ export function LlmStep({
         // 阶段一：居中的 provider 选择列表（滚动）
         <div className="onboarding-provider-pick">
           <p className="muted onboarding-provider-pick-hint">{t('onboarding.providerPickHint')}</p>
+          {/* 阶段一沿用中性配置选择器视觉，但每项尾随「›」提示可进入、且不预选高亮 */}
           <div
-            className="onboarding-provider-list"
+            className="config-pick-list"
             role="radiogroup"
             aria-label={t('onboarding.providerPickAria')}
           >
@@ -40,12 +41,12 @@ export function LlmStep({
               <button
                 key={p.value}
                 type="button"
-                className="onboarding-provider-item"
+                className="config-pick-item"
                 onClick={() => pick(p.value)}
               >
                 <LlmProviderIcon provider={p.value} size={28} />
-                <span className="onboarding-provider-name">{p.label}</span>
-                <span className="onboarding-provider-arrow" aria-hidden="true">
+                <span className="config-pick-name config-pick-name-fill">{p.label}</span>
+                <span className="config-pick-arrow" aria-hidden="true">
                   ›
                 </span>
               </button>
@@ -55,24 +56,10 @@ export function LlmStep({
       ) : (
         // 阶段二：左侧列表（图标左移）+ 右侧配置
         <div className="onboarding-llm-grid">
-          <div className="onboarding-provider-list" role="radiogroup" aria-label="Provider">
-            {LLM_PROVIDERS.map((p) => {
-              const selected = p.value === draft.provider;
-              return (
-                <button
-                  key={p.value}
-                  type="button"
-                  className={`onboarding-provider-item${selected ? ' selected' : ''}`}
-                  onClick={() => onChange({ ...draft, provider: p.value })}
-                  role="radio"
-                  aria-checked={selected}
-                >
-                  <LlmProviderIcon provider={p.value} size={24} />
-                  <span className="onboarding-provider-name">{p.label}</span>
-                </button>
-              );
-            })}
-          </div>
+          <LlmProviderPicker
+            value={draft.provider}
+            onChange={(provider) => onChange({ ...draft, provider })}
+          />
           <div className="onboarding-llm-form">
             <LlmProfileForm
               draft={draft}

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/PlatformStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/PlatformStep.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { invoke } from '../../../../api';
-import { ConnectionForm, type ConnDraft } from '../../settings';
-import { PLATFORM_META, FolderIcon } from '../../../common';
+import { ConnectionForm, PlatformPicker, type ConnDraft } from '../../settings';
+import { FolderIcon } from '../../../common';
 
 export function PlatformStep({
   connDraft,
@@ -23,46 +23,16 @@ export function PlatformStep({
     <div className="onboarding-platform">
       <h2 className="onboarding-step-title">{t('onboarding.platformTitle')}</h2>
       <p className="muted onboarding-step-sub">{t('onboarding.platformSub')}</p>
-      <div className="onboarding-platform-grid">
+      <div className="config-pick-grid">
         {/* 左：平台方案选择 */}
-        <div
-          className="onboarding-platform-list"
-          role="radiogroup"
-          aria-label={t('onboarding.platformGroupAria')}
-        >
-          {PLATFORM_META.map((p) => {
-            // 可用平台（Bitbucket / GitHub / GitLab）可点选并设 kind；未实现的置灰
-            const selected = p.kind === connDraft.kind;
-            return (
-              <button
-                type="button"
-                key={p.kind}
-                className={`onboarding-platform-item${selected ? ' selected' : ''}${
-                  p.available ? '' : ' disabled'
-                }`}
-                role="radio"
-                aria-checked={selected}
-                aria-disabled={!p.available}
-                disabled={!p.available}
-                onClick={() => {
-                  if (p.available)
-                    onConnChange({ ...connDraft, kind: p.kind as ConnDraft['kind'] });
-                }}
-              >
-                <span className={`onboarding-platform-icon${p.available ? '' : ' muted-icon'}`}>
-                  <p.Icon size={24} />
-                </span>
-                <span className="onboarding-platform-text">
-                  <span className="onboarding-platform-name">{p.label}</span>
-                  <span className="onboarding-platform-meta">{t(p.subKey)}</span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        <PlatformPicker
+          value={connDraft.kind}
+          onChange={(kind) => onConnChange({ ...connDraft, kind })}
+          ariaLabel={t('onboarding.platformGroupAria')}
+        />
 
         {/* 右：连接表单 + 折叠缓存目录 */}
-        <div className="onboarding-platform-form">
+        <div className="config-pick-form">
           <ConnectionForm draft={connDraft} onChange={onConnChange} autoFocus={false} />
 
           <div className="onboarding-advanced">

--- a/apps/desktop/src/renderer/src/components/features/settings/ConnectionForm.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/ConnectionForm.tsx
@@ -216,7 +216,7 @@ export function ConnectionForm({
       <div className="settings-actions" style={{ marginTop: 12, alignItems: 'center' }}>
         <button
           type="button"
-          className="btn"
+          className="btn btn-sm"
           onClick={() => void runTest()}
           disabled={!canTest || testing}
         >

--- a/apps/desktop/src/renderer/src/components/features/settings/LlmProfileForm.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/LlmProfileForm.tsx
@@ -224,11 +224,12 @@ export function LlmProfileForm({
             value={draft.label}
             onChange={(e) => update('label', e.target.value)}
             onBlur={() => markTouched('label')}
-            placeholder={t('llmProfileForm.namePlaceholder')}
+            placeholder={
+              isCli ? t('llmProfileForm.cliNamePlaceholder') : t('llmProfileForm.namePlaceholder')
+            }
             autoFocus
             maxLength={32}
           />
-          {showError('label') && <p className="settings-field-error">{errors.label}</p>}
         </div>
         {!hideProvider && (
           <>
@@ -263,7 +264,6 @@ export function LlmProfileForm({
               isCli ? t('llmProfileForm.cliCommandPlaceholder') : providerMeta.modelExample
             }
           />
-          {showError('model') && <p className="settings-field-error">{errors.model}</p>}
         </div>
         {/* cli 模式不直连 API：没有 Base URL / API Key 概念，整组隐藏 */}
         {!isCli && (
@@ -281,7 +281,6 @@ export function LlmProfileForm({
                 onBlur={() => markTouched('base_url')}
                 placeholder={baseUrlPlaceholder}
               />
-              {showError('base_url') && <p className="settings-field-error">{errors.base_url}</p>}
             </div>
             <div className="modal-kv-key">
               API Key{providerMeta.needsKey && <span className="settings-required"> *</span>}
@@ -309,7 +308,6 @@ export function LlmProfileForm({
                   {keyVisible ? <EyeIcon /> : <EyeOffIcon />}
                 </button>
               </div>
-              {showError('api_key') && <p className="settings-field-error">{errors.api_key}</p>}
             </div>
           </>
         )}

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/ConnectionEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/ConnectionEditorModal.tsx
@@ -1,6 +1,8 @@
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Modal } from '../../../common';
+import { ConfirmModal, Modal } from '../../../common';
 import { ConnectionForm, connDraftCanSave, type ConnDraft } from '../ConnectionForm';
+import { PlatformPicker } from '../pickers/PlatformPicker';
 
 export function ConnectionEditorModal({
   state,
@@ -16,48 +18,70 @@ export function ConnectionEditorModal({
   const { t } = useTranslation();
   const { mode, draft } = state;
   const canSave = connDraftCanSave(draft);
+  // 退出校验：记下打开时的草稿快照，与当前比对判断是否有未提交改动
+  const initialDraft = useRef(JSON.stringify(draft));
+  const dirty = JSON.stringify(draft) !== initialDraft.current;
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  // 关闭（背景点击 / 关闭键 / 取消按钮）统一走这里：有改动则先拦截确认
+  const requestClose = (): void => {
+    if (dirty) setConfirmDiscard(true);
+    else onCancel();
+  };
   return (
-    <Modal
-      nested
-      size="sm"
-      onClose={onCancel}
-      title={mode === 'add' ? t('settings.addConnectionTitle') : t('settings.editConnectionTitle')}
-    >
-      {/* 平台选择仅新增时可改；编辑既有连接不允许切平台（base_url/token 语义不同） */}
-      {mode === 'add' && (
-        <div className="modal-kv" style={{ marginBottom: 8 }}>
-          <div className="modal-kv-key">{t('settings.platform')}</div>
-          <div className="modal-kv-val">
-            <select
-              className="settings-input"
-              value={draft.kind}
-              onChange={(e) => onChange({ ...draft, kind: e.target.value as ConnDraft['kind'] })}
-            >
-              <option value="github">{t('settings.platformGithub')}</option>
-              <option value="bitbucket-server">Bitbucket Server / Data Center</option>
-              <option value="gitlab">{t('settings.platformGitlab')}</option>
-            </select>
+    <>
+      <Modal
+        nested
+        size="sm"
+        onClose={requestClose}
+        title={
+          mode === 'add' ? t('settings.addConnectionTitle') : t('settings.editConnectionTitle')
+        }
+      >
+        {/* 左右两栏：左选集成平台（复用向导布局），右填连接表单。
+          平台选择仅新增时可改；编辑既有连接只读（base_url / token 语义随平台而异）。 */}
+        <div className="config-pick-grid">
+          <PlatformPicker
+            value={draft.kind}
+            onChange={(kind) => onChange({ ...draft, kind })}
+            readOnly={mode === 'edit'}
+            ariaLabel={t('settings.platform')}
+          />
+          <div className="config-pick-form">
+            <ConnectionForm draft={draft} onChange={onChange} />
           </div>
         </div>
-      )}
-      <ConnectionForm draft={draft} onChange={onChange} />
-      <div
-        className="settings-actions"
-        style={{ marginTop: 12, justifyContent: 'flex-end', alignItems: 'center' }}
-      >
-        <button type="button" className="btn" onClick={onCancel}>
-          {t('common.cancel')}
-        </button>
-        <button
-          type="button"
-          className="btn btn-primary"
-          onClick={onSave}
-          disabled={!canSave}
-          title={!canSave ? t('settings.connSaveHint') : undefined}
+        <div
+          className="settings-actions"
+          style={{ marginTop: 12, justifyContent: 'flex-end', alignItems: 'center' }}
         >
-          {t('common.save')}
-        </button>
-      </div>
-    </Modal>
+          <button type="button" className="btn" onClick={requestClose}>
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onSave}
+            disabled={!canSave}
+            title={!canSave ? t('settings.connSaveHint') : undefined}
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </Modal>
+      {confirmDiscard && (
+        <ConfirmModal
+          nested
+          danger
+          title={t('settings.discardChangesTitle')}
+          message={t('settings.discardChangesMessage')}
+          confirmLabel={t('common.discard')}
+          onConfirm={() => {
+            setConfirmDiscard(false);
+            onCancel();
+          }}
+          onCancel={() => setConfirmDiscard(false)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
@@ -47,12 +47,12 @@ export function LlmEditorModal({
         onClose={requestClose}
         title={mode === 'add' ? t('settings.addLlmTitle') : t('settings.editLlmTitle')}
       >
-        {/* 左右两栏：左选 provider（复用向导布局），右填该 provider 的配置（隐藏表单内冗余的 provider 下拉）。 */}
-        <div className="config-pick-grid">
+        {/* 左右两栏：左选 provider（复用向导布局），右填该 provider 的配置（隐藏表单内冗余的 provider 下拉）。
+            固定高度：两栏各自在其内滚动，切换 provider 时模态高度恒定、不抖动。 */}
+        <div className="config-pick-grid config-pick-grid-fixed">
           <LlmProviderPicker
             value={draft.provider}
             onChange={(provider) => onChange({ ...draft, provider })}
-            scroll
           />
           <div className="config-pick-form">
             <LlmProfileForm

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LlmProfile } from '@meebox/shared';
-import { Modal } from '../../../common';
+import { ConfirmModal, Modal } from '../../../common';
 import { LlmProfileForm, validateProfile } from '../LlmProfileForm';
+import { LlmProviderPicker } from '../pickers/LlmProviderPicker';
 
 export function LlmEditorModal({
   state,
@@ -29,33 +30,69 @@ export function LlmEditorModal({
     }
     onSave();
   };
+  // 退出校验：记下打开时的草稿快照，与当前比对判断是否有未提交改动
+  const initialDraft = useRef(JSON.stringify(draft));
+  const dirty = JSON.stringify(draft) !== initialDraft.current;
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  // 关闭（背景点击 / 关闭键 / 取消按钮）统一走这里：有改动则先拦截确认
+  const requestClose = (): void => {
+    if (dirty) setConfirmDiscard(true);
+    else onCancel();
+  };
   return (
-    <Modal
-      nested
-      size="sm"
-      onClose={onCancel}
-      title={mode === 'add' ? t('settings.addLlmTitle') : t('settings.editLlmTitle')}
-    >
-      <LlmProfileForm
-        draft={draft}
-        existing={existing}
-        onChange={onChange}
-        forceShowErrors={forceShowErrors}
-      />
-      <div className="settings-actions" style={{ marginTop: 12, justifyContent: 'flex-end' }}>
-        <button type="button" className="btn" onClick={onCancel}>
-          {t('common.cancel')}
-        </button>
-        <button
-          type="button"
-          className="btn btn-primary"
-          onClick={trySave}
-          disabled={forceShowErrors && !isValid}
-          title={forceShowErrors && !isValid ? t('settings.fillRequiredHint') : undefined}
-        >
-          {t('common.save')}
-        </button>
-      </div>
-    </Modal>
+    <>
+      <Modal
+        nested
+        size="sm"
+        onClose={requestClose}
+        title={mode === 'add' ? t('settings.addLlmTitle') : t('settings.editLlmTitle')}
+      >
+        {/* 左右两栏：左选 provider（复用向导布局），右填该 provider 的配置（隐藏表单内冗余的 provider 下拉）。 */}
+        <div className="config-pick-grid">
+          <LlmProviderPicker
+            value={draft.provider}
+            onChange={(provider) => onChange({ ...draft, provider })}
+            scroll
+          />
+          <div className="config-pick-form">
+            <LlmProfileForm
+              draft={draft}
+              existing={existing}
+              onChange={onChange}
+              forceShowErrors={forceShowErrors}
+              hideProvider
+            />
+          </div>
+        </div>
+        <div className="settings-actions" style={{ marginTop: 12, justifyContent: 'flex-end' }}>
+          <button type="button" className="btn" onClick={requestClose}>
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={trySave}
+            disabled={forceShowErrors && !isValid}
+            title={forceShowErrors && !isValid ? t('settings.fillRequiredHint') : undefined}
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </Modal>
+      {confirmDiscard && (
+        <ConfirmModal
+          nested
+          danger
+          title={t('settings.discardChangesTitle')}
+          message={t('settings.discardChangesMessage')}
+          confirmLabel={t('common.discard')}
+          onConfirm={() => {
+            setConfirmDiscard(false);
+            onCancel();
+          }}
+          onCancel={() => setConfirmDiscard(false)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/desktop/src/renderer/src/components/features/settings/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/settings/index.ts
@@ -9,3 +9,5 @@ export {
   type ConnEntry,
 } from './ConnectionForm';
 export { LlmProfileForm, newProfileId, LLM_PROVIDERS } from './LlmProfileForm';
+export { PlatformPicker } from './pickers/PlatformPicker';
+export { LlmProviderPicker } from './pickers/LlmProviderPicker';

--- a/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { LlmProvider } from '@meebox/shared';
 import { LlmProviderIcon } from '../../../common';
 import { LLM_PROVIDERS } from '../LlmProfileForm';
@@ -9,23 +10,17 @@ import { LLM_PROVIDERS } from '../LlmProfileForm';
 export function LlmProviderPicker({
   value,
   onChange,
-  scroll = false,
   iconSize = 24,
   ariaLabel = 'Provider',
 }: {
   value: LlmProvider;
   onChange: (provider: LlmProvider) => void;
-  /** 列表项较多时限高滚动（如设置子模态内，避免撑高模态） */
-  scroll?: boolean;
   iconSize?: number;
   ariaLabel?: string;
 }) {
+  const { t } = useTranslation();
   return (
-    <div
-      className={`config-pick-list${scroll ? ' config-pick-list-scroll' : ''}`}
-      role="radiogroup"
-      aria-label={ariaLabel}
-    >
+    <div className="config-pick-list" role="radiogroup" aria-label={ariaLabel}>
       {LLM_PROVIDERS.map((p) => {
         const selected = p.value === value;
         return (
@@ -39,6 +34,11 @@ export function LlmProviderPicker({
           >
             <LlmProviderIcon provider={p.value} size={iconSize} />
             <span className="config-pick-name config-pick-name-fill">{p.label}</span>
+            {p.value === 'cli' && (
+              <span className="badge-experimental" title={t('settings.cliExperimentalHint')}>
+                {t('settings.experimental')}
+              </span>
+            )}
           </button>
         );
       })}

--- a/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
@@ -1,0 +1,47 @@
+import type { LlmProvider } from '@meebox/shared';
+import { LlmProviderIcon } from '../../../common';
+import { LLM_PROVIDERS } from '../LlmProfileForm';
+
+/**
+ * LLM provider 选择列表（左侧栏）：品牌图标 + 名称，单选高亮。
+ * 首启向导 LLM 步与设置面板「LLM」子模态共用同一视觉（配置选择器左右布局，见 config-picker.scss）。
+ */
+export function LlmProviderPicker({
+  value,
+  onChange,
+  scroll = false,
+  iconSize = 24,
+  ariaLabel = 'Provider',
+}: {
+  value: LlmProvider;
+  onChange: (provider: LlmProvider) => void;
+  /** 列表项较多时限高滚动（如设置子模态内，避免撑高模态） */
+  scroll?: boolean;
+  iconSize?: number;
+  ariaLabel?: string;
+}) {
+  return (
+    <div
+      className={`config-pick-list${scroll ? ' config-pick-list-scroll' : ''}`}
+      role="radiogroup"
+      aria-label={ariaLabel}
+    >
+      {LLM_PROVIDERS.map((p) => {
+        const selected = p.value === value;
+        return (
+          <button
+            key={p.value}
+            type="button"
+            className={`config-pick-item${selected ? ' selected' : ''}`}
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(p.value)}
+          >
+            <LlmProviderIcon provider={p.value} size={iconSize} />
+            <span className="config-pick-name config-pick-name-fill">{p.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/features/settings/pickers/PlatformPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/pickers/PlatformPicker.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+import { PLATFORM_META } from '../../../common';
+import type { ConnKind } from '../ConnectionForm';
+
+/**
+ * 集成平台选择列表（左侧栏）：图标 + 名称 + 副标题，单选高亮。
+ * 首启向导平台步与设置面板「连接」子模态共用同一视觉（配置选择器左右布局，见 config-picker.scss）。
+ *
+ * readOnly：编辑既有连接时不允许切平台（base_url / token 语义随平台而异）——当前项保持高亮、
+ * 其余置灰，整列禁用交互。
+ */
+export function PlatformPicker({
+  value,
+  onChange,
+  readOnly = false,
+  ariaLabel,
+}: {
+  value: ConnKind;
+  onChange: (kind: ConnKind) => void;
+  readOnly?: boolean;
+  ariaLabel?: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="config-pick-list" role="radiogroup" aria-label={ariaLabel}>
+      {PLATFORM_META.map((p) => {
+        const selected = p.kind === value;
+        // 可点选：平台已实现且非只读。置灰：未实现平台，或只读态下的非当前项。
+        const interactive = p.available && !readOnly;
+        const dim = !p.available || (readOnly && !selected);
+        return (
+          <button
+            type="button"
+            key={p.kind}
+            className={`config-pick-item${selected ? ' selected' : ''}${dim ? ' disabled' : ''}`}
+            role="radio"
+            aria-checked={selected}
+            aria-disabled={!interactive}
+            disabled={!interactive}
+            onClick={() => {
+              if (interactive) onChange(p.kind as ConnKind);
+            }}
+          >
+            <span className={`config-pick-icon${p.available ? '' : ' muted-icon'}`}>
+              <p.Icon size={24} />
+            </span>
+            <span className="config-pick-text">
+              <span className="config-pick-name">{p.label}</span>
+              <span className="config-pick-meta">{t(p.subKey)}</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -407,9 +407,10 @@
     "apiKeyOptionalPlaceholder": "Dieser Provider benötigt keinen Schlüssel (leer lassen)",
     "cliCommandFallback": "Kommandozeilen-Tool",
     "cliCommandLabel": "CLI-Befehl",
-    "cliCommandPlaceholder": "Befehlsname",
+    "cliCommandPlaceholder": "Befehlsname, z. B. claude / codex",
+    "cliNamePlaceholder": "z. B. claude / codex",
     "cliWarningPrefix": "⚠️ Das Ausfüllen und Aktivieren dieses Profils autorisiert Code Meeseeks, das lokale",
-    "cliWarningSuffix": "Tool aufzurufen, um Review-Operationen durchzuführen (läuft in einem Unterprozess unter Ihrer lokalen Anmeldesitzung). Stellen Sie sicher, dass der Befehl installiert und angemeldet ist.",
+    "cliWarningSuffix": "Tool aufzurufen, um Review-Operationen durchzuführen. Stellen Sie sicher, dass der Befehl installiert und angemeldet ist.",
     "errorCliUnsupported": "Nicht unterstütztes CLI-Tool",
     "errorLabelDuplicate": "Name existiert bereits",
     "errorLabelSlug": "Nur Buchstaben / Ziffern / - / _ erlaubt, 1-32 Zeichen",
@@ -422,7 +423,7 @@
         "hint": "Offizielle Anthropic-API; geben Sie den Modellnamen direkt ein (z. B. claude-opus-4-8); das Präfix anthropic/ wird automatisch hinzugefügt"
       },
       "cli": {
-        "hint": "🧪 Experimentell: hängt vom Upstream-CLI ab (z. B. claude / codex); sein Verhalten kann sich mit Upstream-Releases ändern — Stabilität und dauerhafte Verfügbarkeit sind nicht garantiert. Delegiert Review-Anfragen an ein lokal installiertes und autorisiertes Kommandozeilen-Tool, um das Modell aufzurufen, ohne sich direkt mit der API zu verbinden oder einen Schlüssel zu benötigen; das Tool verwaltet sein eigenes Modell und Kontingent. Das Ausfüllen und Aktivieren autorisiert den Aufruf dieses Kommandozeilen-Tools in einem Unterprozess unter Ihrer lokalen Anmeldesitzung.",
+        "hint": "🧪 Experimentell: hängt von einem lokalen Kommandozeilen-Tool ab; sein Verhalten kann sich mit dessen Releases ändern — Stabilität und dauerhafte Verfügbarkeit sind nicht garantiert. Delegiert Review-Anfragen an ein lokal installiertes und autorisiertes Kommandozeilen-Tool, um das Modell aufzurufen.",
         "label": "Lokales CLI"
       },
       "dashscope": {
@@ -523,9 +524,7 @@
     "platformSub": "Wählen Sie eine Plattform und geben Sie Ihre Verbindungsdaten ein.",
     "platformTitle": "Code-Plattform verbinden",
     "progressAria": "Einrichtungsfortschritt",
-    "providerPickAria": "Provider auswählen",
-    "providerPickHint": "Wählen Sie einen Provider zum Verbinden",
-    "skip": "Überspringen",
+    "providerPickAria": "Provider auswählen",    "skip": "Überspringen",
     "startConfig": "Loslegen",
     "stepDone": "Fertig",
     "stepLlm": "KI-Modell",
@@ -608,7 +607,7 @@
     "checkUpdate": "Nach Updates suchen",
     "checkUpdateTitle": "GitHub auf die neueste Version prüfen (nur Erkennung, keine automatische Installation)",
     "checking": "Prüfe…",
-    "cliExperimentalHint": "Lokale CLI-Provider hängen von Upstream-CLIs ab (z. B. claude / codex); ihr Verhalten kann sich mit Upstream-Releases ändern — Stabilität und dauerhafte Verfügbarkeit sind nicht garantiert.",
+    "cliExperimentalHint": "Lokale CLI-Provider hängen von einem lokalen Kommandozeilen-Tool ab; sein Verhalten kann sich mit dessen Releases ändern — Stabilität und dauerhafte Verfügbarkeit sind nicht garantiert.",
     "configKey": "Konfiguration",
     "configure": "Konfigurieren",
     "connSaveHint": "Bitte Name / Base URL / Token ausfüllen",

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -222,6 +222,7 @@
     "close": "Schließen",
     "confirm": "OK",
     "delete": "Löschen",
+    "discard": "Verwerfen",
     "edit": "Bearbeiten",
     "loading": "Wird geladen…",
     "save": "Speichern"
@@ -619,6 +620,8 @@
     "deleteConnectionConfirmTitle": "Verbindung löschen",
     "deleteConnectionTitle": "Diese Verbindung löschen",
     "deleteLlmProfileTitle": "Dieses Profil löschen",
+    "discardChangesMessage": "Dieses Formular enthält nicht gespeicherte Änderungen. Ohne Speichern schließen?",
+    "discardChangesTitle": "Nicht gespeicherte Änderungen verwerfen?",
     "editConfigYaml": "config.yaml bearbeiten",
     "editConnectionTitle": "Verbindung bearbeiten",
     "editLlmTitle": "LLM-Modell bearbeiten",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -222,6 +222,7 @@
     "close": "Close",
     "confirm": "OK",
     "delete": "Delete",
+    "discard": "Discard",
     "edit": "Edit",
     "loading": "Loading…",
     "save": "Save"
@@ -619,6 +620,8 @@
     "deleteConnectionConfirmTitle": "Delete Connection",
     "deleteConnectionTitle": "Delete this connection",
     "deleteLlmProfileTitle": "Delete this profile",
+    "discardChangesMessage": "This form has unsaved changes. Close without saving?",
+    "discardChangesTitle": "Discard unsaved changes?",
     "editConfigYaml": "Edit config.yaml",
     "editConnectionTitle": "Edit Connection",
     "editLlmTitle": "Edit LLM Model",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -407,9 +407,10 @@
     "apiKeyOptionalPlaceholder": "This provider needs no key (leave empty)",
     "cliCommandFallback": "command-line tool",
     "cliCommandLabel": "CLI Command",
-    "cliCommandPlaceholder": "Command name",
+    "cliCommandPlaceholder": "Command name, e.g. claude / codex",
+    "cliNamePlaceholder": "e.g. claude / codex",
     "cliWarningPrefix": "⚠️ Filling in and enabling this profile authorizes Code Meeseeks to invoke the local",
-    "cliWarningSuffix": "tool to perform review operations (running in a subprocess under your local login session). Make sure the command is installed and signed in.",
+    "cliWarningSuffix": "tool to perform review operations. Make sure the command is installed and signed in.",
     "errorCliUnsupported": "Unsupported CLI tool",
     "errorLabelDuplicate": "Name already exists",
     "errorLabelSlug": "Only letters / digits / - / _ allowed, 1-32 characters",
@@ -422,7 +423,7 @@
         "hint": "Official Anthropic API; enter the model name directly (e.g. claude-opus-4-8); the anthropic/ prefix is added automatically"
       },
       "cli": {
-        "hint": "🧪 Experimental: depends on the upstream CLI (e.g. claude / codex); its behavior may change with upstream releases — stability and continued availability are not guaranteed. Delegates review requests to a locally installed and authorized command-line tool to call the model, without connecting to the API directly or requiring a key; the tool manages its own model and quota. Filling in and enabling this authorizes invoking that command-line tool in a subprocess under your local login session.",
+        "hint": "🧪 Experimental: depends on a local command-line tool; its behavior may change with the tool's releases — stability and continued availability are not guaranteed. Delegates review requests to a locally installed and authorized command-line tool to call the model.",
         "label": "Local CLI"
       },
       "dashscope": {
@@ -523,9 +524,7 @@
     "platformSub": "Choose a platform and enter your connection details.",
     "platformTitle": "Connect Code Platform",
     "progressAria": "Setup progress",
-    "providerPickAria": "Choose provider",
-    "providerPickHint": "Choose a provider to connect",
-    "skip": "Skip",
+    "providerPickAria": "Choose provider",    "skip": "Skip",
     "startConfig": "Get Started",
     "stepDone": "Done",
     "stepLlm": "AI Model",
@@ -608,7 +607,7 @@
     "checkUpdate": "Check for Updates",
     "checkUpdateTitle": "Check GitHub for the latest version (detection only, no auto-install)",
     "checking": "Checking…",
-    "cliExperimentalHint": "Local CLI providers depend on upstream CLIs (e.g. claude / codex); their behavior may change with upstream releases — stability and continued availability are not guaranteed.",
+    "cliExperimentalHint": "Local CLI providers depend on a local command-line tool; its behavior may change with the tool's releases — stability and continued availability are not guaranteed.",
     "configKey": "Config",
     "configure": "Configure",
     "connSaveHint": "Please fill in Name / Base URL / Token",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -396,9 +396,10 @@
     "apiKeyOptionalPlaceholder": "このプロバイダーはキー不要です（空のままに）",
     "cliCommandFallback": "コマンドラインツール",
     "cliCommandLabel": "CLI コマンド",
-    "cliCommandPlaceholder": "コマンド名",
+    "cliCommandPlaceholder": "コマンド名（例：claude / codex）",
+    "cliNamePlaceholder": "例：claude / codex",
     "cliWarningPrefix": "⚠️ このプロファイルを入力して有効化すると、Code Meeseeks がローカルの",
-    "cliWarningSuffix": "ツールを呼び出して レビュー操作を実行することを許可します（ローカルのログインセッション下のサブプロセスで実行されます）。対応するコマンドがインストール済みで、サインイン済みであることを確認してください。",
+    "cliWarningSuffix": "ツールを呼び出してレビュー操作を実行することを許可します。対応するコマンドがインストール済みで、サインイン済みであることを確認してください。",
     "errorCliUnsupported": "サポートされていない CLI ツール",
     "errorLabelDuplicate": "名前はすでに存在します",
     "errorLabelSlug": "使用できるのは 英字 / 数字 / - / _ のみ、1〜32 文字",
@@ -411,7 +412,7 @@
         "hint": "公式 Anthropic API；モデル名を直接入力してください（例：claude-opus-4-8）。anthropic/ プレフィックスは自動的に付加されます"
       },
       "cli": {
-        "hint": "🧪 実験的：上流 CLI（claude / codex など）に依存し、その挙動は上流のバージョン変更で変わる可能性があります。安定性・継続的な利用は保証されません。レビューリクエストを、ローカルにインストール済みかつ認可されたコマンドラインツールに委譲してモデルを呼び出します。API に直接接続せず、キーも不要です。使用するモデルと利用枠はそのツールが自己管理します。入力して有効化すると、ローカルのログインセッション下のサブプロセスでそのコマンドラインツールを呼び出すことを許可します。",
+        "hint": "🧪 実験的：ローカルのコマンドラインツールに依存し、その挙動はツールのバージョン変更で変わる可能性があります。安定性・継続的な利用は保証されません。レビューリクエストを、ローカルにインストール済みかつ認可されたコマンドラインツールに委譲してモデルを呼び出します。",
         "label": "ローカル CLI"
       },
       "dashscope": {
@@ -509,9 +510,7 @@
     "platformSub": "プラットフォームを選択し、接続情報を入力してください。",
     "platformTitle": "コードプラットフォームに接続",
     "progressAria": "設定の進捗",
-    "providerPickAria": "プロバイダーを選択",
-    "providerPickHint": "接続するプロバイダーを選択してください",
-    "skip": "スキップ",
+    "providerPickAria": "プロバイダーを選択",    "skip": "スキップ",
     "startConfig": "始める",
     "stepDone": "完了",
     "stepLlm": "AI モデル",
@@ -592,7 +591,7 @@
     "checkUpdate": "アップデートを確認",
     "checkUpdateTitle": "GitHub で最新バージョンを確認（検出のみ、自動インストールなし）",
     "checking": "確認中…",
-    "cliExperimentalHint": "ローカル CLI プロバイダーは上流 CLI（claude / codex など）に依存し、その挙動は上流のバージョン変更で変わる可能性があります。安定性・継続的な利用は保証されません。",
+    "cliExperimentalHint": "ローカル CLI プロバイダーはローカルのコマンドラインツールに依存し、その挙動はツールのバージョン変更で変わる可能性があります。安定性・継続的な利用は保証されません。",
     "configKey": "設定",
     "configure": "設定",
     "connSaveHint": "Name / Base URL / Token を入力してください",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -216,6 +216,7 @@
     "close": "閉じる",
     "confirm": "OK",
     "delete": "削除",
+    "discard": "破棄",
     "edit": "編集",
     "loading": "読み込み中…",
     "save": "保存"
@@ -603,6 +604,8 @@
     "deleteConnectionConfirmTitle": "接続を削除",
     "deleteConnectionTitle": "この接続を削除",
     "deleteLlmProfileTitle": "このプロファイルを削除",
+    "discardChangesMessage": "このフォームには未保存の変更があります。保存せずに閉じますか？",
+    "discardChangesTitle": "未保存の変更を破棄しますか？",
     "editConfigYaml": "config.yaml を編集",
     "editConnectionTitle": "接続を編集",
     "editLlmTitle": "LLM モデルを編集",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -396,9 +396,10 @@
     "apiKeyOptionalPlaceholder": "该 provider 无需密钥（留空）",
     "cliCommandFallback": "命令行",
     "cliCommandLabel": "CLI 命令",
-    "cliCommandPlaceholder": "命令名",
+    "cliCommandPlaceholder": "命令名，如 claude / codex",
+    "cliNamePlaceholder": "如 claude / codex",
     "cliWarningPrefix": "⚠️ 填写并启用此预设，即代表你授权 Code Meeseeks 调用本机的",
-    "cliWarningSuffix": "工具执行评审操作（在子进程中以你的本地登录态运行）。请确认对应命令已安装并完成登录。",
+    "cliWarningSuffix": "工具执行评审操作。请确认对应命令已安装并完成登录。",
     "errorCliUnsupported": "不受支持的 CLI 工具",
     "errorLabelDuplicate": "名称已存在",
     "errorLabelSlug": "只允许 字母 / 数字 / - / _，1-32 字符",
@@ -411,7 +412,7 @@
         "hint": "官方 Anthropic API；模型直接填型号名（claude-opus-4-8 等），会自动补 anthropic/ 前缀"
       },
       "cli": {
-        "hint": "🧪 实验性：依赖上游 CLI（claude / codex 等），行为可能随其版本变更，稳定性与持续可用性不作保证。将评审请求转交本机已安装并授权的命令行工具代为调用模型，不直连 API、无需填写密钥；所用模型与额度由该工具自理。填写并启用即代表你授权在子进程中以本机登录态调用对应命令行。",
+        "hint": "🧪 实验性：依赖本机命令行工具，行为可能随其版本变更，稳定性与持续可用性不作保证。将评审请求转交本机已安装并授权的命令行工具代为调用模型。",
         "label": "本地 CLI"
       },
       "dashscope": {
@@ -509,9 +510,7 @@
     "platformSub": "选择平台方案并填写连接信息。",
     "platformTitle": "连接代码平台",
     "progressAria": "配置进度",
-    "providerPickAria": "选择 Provider",
-    "providerPickHint": "选择要对接的 Provider",
-    "skip": "跳过",
+    "providerPickAria": "选择 Provider",    "skip": "跳过",
     "startConfig": "开始配置",
     "stepDone": "完成",
     "stepLlm": "AI 模型",
@@ -592,7 +591,7 @@
     "checkUpdate": "检查更新",
     "checkUpdateTitle": "查 GitHub 最新版本（仅检测，不自动安装）",
     "checking": "检查中…",
-    "cliExperimentalHint": "本地 CLI provider 依赖上游 CLI（如 claude / codex），其行为可能随上游版本变更，稳定性与持续可用性不作保证。",
+    "cliExperimentalHint": "本地 CLI provider 依赖本机命令行工具，其行为可能随工具版本变更，稳定性与持续可用性不作保证。",
     "configKey": "配置",
     "configure": "配置",
     "connSaveHint": "请填完名称 / Base URL / Token",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -216,6 +216,7 @@
     "close": "关闭",
     "confirm": "确定",
     "delete": "删除",
+    "discard": "放弃",
     "edit": "编辑",
     "loading": "加载中…",
     "save": "保存"
@@ -603,6 +604,8 @@
     "deleteConnectionConfirmTitle": "删除连接",
     "deleteConnectionTitle": "删除该连接",
     "deleteLlmProfileTitle": "删除该配置",
+    "discardChangesMessage": "当前表单有未保存的更改，确定不保存就关闭？",
+    "discardChangesTitle": "放弃未保存的更改？",
     "editConfigYaml": "编辑 config.yaml",
     "editConnectionTitle": "编辑连接",
     "editLlmTitle": "编辑 LLM 模型",

--- a/apps/desktop/src/renderer/src/styles/_tokens.scss
+++ b/apps/desktop/src/renderer/src/styles/_tokens.scss
@@ -39,7 +39,11 @@ $color-approved:       #16a34a; // PR review "approved/通过" 专用绿 (Tailwi
 $color-warning:        #d97706; // PR review "needs work / 需修改" 饱和琥珀 (Tailwind amber-600，对齐 $color-approved 重量)
 $color-warning-bright: #fbbf24; // 亮琥珀，只用于纯文字告警 (conflict-tag / diff-binary)，无背景
 $color-danger:        #f48771; // 错误文案 / 红边框
-$color-danger-bg:     #c72e0f; // 错误 chip 实底
+$color-danger-bg:     #c72e0f; // 错误 chip / 模态删除按钮实底（高饱和）
+// ghost 危险按钮（删除评论 / 草稿 / 连接 / LLM、停止、拒绝等）的描边 + 文字饱和红：
+// 与实底 $color-danger-bg(#c72e0f) 同色相、提亮以保暗底可读，比 $color-danger 更饱和、警示力更强
+$color-danger-strong:      #e8512e;
+$color-danger-strong-fade: rgba(232, 81, 46, 0.12); // ghost 危险按钮 hover 浅红底
 $color-token-in:       #22c55e; // token 用量 ↑输入 (Tailwind green-500)
 $color-token-out:      #ef4444; // token 用量 ↓输出 (Tailwind red-500)
 

--- a/apps/desktop/src/renderer/src/styles/base.scss
+++ b/apps/desktop/src/renderer/src/styles/base.scss
@@ -120,10 +120,11 @@ textarea {
   }
 }
 
-// 危险图标按钮（删除）：hover 变红
+// 危险图标按钮（删除连接 / LLM 配置等）：hover 变饱和红，与其它危险按钮统一
 .btn-icon-danger:hover:not(:disabled) {
-  border-color: $color-danger;
-  color: $color-danger;
+  border-color: $color-danger-strong;
+  color: $color-danger-strong;
+  background: $color-danger-strong-fade;
 }
 
 // 主操作图标按钮（编辑）：hover 变蓝

--- a/apps/desktop/src/renderer/src/styles/common/modal.scss
+++ b/apps/desktop/src/renderer/src/styles/common/modal.scss
@@ -265,6 +265,10 @@
   gap: $space-4;
   flex-wrap: wrap;
 }
+// 行内结果文案（如「测试连接」结果）：去掉块级 margin-top，与同行按钮垂直居中对齐
+.settings-actions .error-text {
+  margin-top: 0;
+}
 
 // 关于 & 反馈：低频社区外链行（Star / Issue / Releases）。带 1px 分隔线 + 留白与上方运行时
 // 控件清晰分区；各链接带专属图标、加大间距，彼此可辨。克制的文字链接，不抢运行时控件。

--- a/apps/desktop/src/renderer/src/styles/features/chat-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/features/chat-pane.scss
@@ -883,9 +883,9 @@
 }
 .chat-finding-draft-btn-reject {
   &:hover {
-    border-color: $color-danger;
-    color: $color-danger;
-    background: rgba(244, 135, 113, 0.08);
+    border-color: $color-danger-strong;
+    color: $color-danger-strong;
+    background: $color-danger-strong-fade;
   }
 }
 
@@ -1259,12 +1259,12 @@
     cursor: not-allowed;
   }
 }
-// Stop 形态：保留同样的边框结构但用 danger 着色，hover 仍变深，明确表达"危险动作"
+// Stop 形态：保留同样的边框结构但用饱和 danger 着色，hover 仍变深，明确表达"危险动作"
 .chat-pane-send-stop {
-  color: $color-danger;
+  color: $color-danger-strong;
   &:hover:not(:disabled) {
-    background: rgba(244, 135, 113, 0.12);
-    border-color: $color-danger;
-    color: $color-danger;
+    background: $color-danger-strong-fade;
+    border-color: $color-danger-strong;
+    color: $color-danger-strong;
   }
 }

--- a/apps/desktop/src/renderer/src/styles/features/comment-zone.scss
+++ b/apps/desktop/src/renderer/src/styles/features/comment-zone.scss
@@ -78,9 +78,9 @@
 }
 // 删除按钮主色用 danger，跟其它按钮拉开语义；disabled 时半透明
 .comment-zone-delete-btn:hover:not(:disabled) {
-  border-color: $color-danger;
-  color: $color-danger;
-  background: rgba(244, 135, 113, 0.08);
+  border-color: $color-danger-strong;
+  color: $color-danger-strong;
+  background: $color-danger-strong-fade;
 }
 .comment-zone-delete-btn:disabled {
   opacity: 0.4;

--- a/apps/desktop/src/renderer/src/styles/features/config-picker.scss
+++ b/apps/desktop/src/renderer/src/styles/features/config-picker.scss
@@ -20,12 +20,23 @@
   flex-direction: column;
   gap: $space-3;
 }
-// provider 列表项较多时可滚动；平台列表项少不需要。
-// 限高 ~4 项（< 右侧表单常见高度）：让表单成为模态高度的下限，列表在其内滚动，
-// 既不把设置子模态撑高，也不在右侧表单下方留大片空白。向导里在大卡片中铺开，不传 scroll、不受此限。
-.config-pick-list-scroll {
-  max-height: 180px;
-  overflow-y: auto;
+
+// 设置子模态内的左右两栏：固定高度，避免切换 provider 时右侧表单高矮变化导致模态抖动。
+// 左侧列表与右侧表单各自在该固定高度内独立滚动（自适应填满，内容不足时下方留白、内容超出则滚动），
+// 整体高度恒定。向导里在大卡片中铺开、不加此类，保持自适应。
+.config-pick-grid-fixed {
+  height: 190px;
+  align-items: stretch;
+
+  > .config-pick-list,
+  > .config-pick-form {
+    min-height: 0; // 允许在 grid 行内收缩，从而触发自身滚动
+    overflow-y: auto;
+  }
+  // 右侧表单顶部留半行余白，第一项不贴顶、与左侧列表卡片视觉更协调
+  > .config-pick-form {
+    padding-top: $space-5;
+  }
 }
 
 .config-pick-item {

--- a/apps/desktop/src/renderer/src/styles/features/config-picker.scss
+++ b/apps/desktop/src/renderer/src/styles/features/config-picker.scss
@@ -1,0 +1,111 @@
+@use '../tokens' as *;
+
+// 配置选择器：左右两栏布局 —— 左侧集成平台 / LLM provider 选择列表，右侧受控表单。
+// 由 settings 域的 PlatformPicker / LlmProviderPicker 复用，首启向导与设置面板子模态共用同一视觉。
+// （从原 .onboarding-platform-* / .onboarding-provider-* 收敛为中性类，统一在 settings 维护。）
+
+.config-pick-grid {
+  display: grid;
+  // 左列固定 220px：容下最长副标题（如「gitlab.com / Self-Managed」）单行不折行
+  grid-template-columns: 220px 1fr;
+  gap: $space-8;
+  align-items: start;
+}
+.config-pick-form {
+  min-width: 0; // 防止右栏内容把 grid 撑出
+}
+
+.config-pick-list {
+  display: flex;
+  flex-direction: column;
+  gap: $space-3;
+}
+// provider 列表项较多时可滚动；平台列表项少不需要。
+// 限高 ~4 项（< 右侧表单常见高度）：让表单成为模态高度的下限，列表在其内滚动，
+// 既不把设置子模态撑高，也不在右侧表单下方留大片空白。向导里在大卡片中铺开，不传 scroll、不受此限。
+.config-pick-list-scroll {
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.config-pick-item {
+  display: flex;
+  align-items: center;
+  gap: $space-4;
+  width: 100%;
+  text-align: left;
+  padding: $space-4 $space-5;
+  border: 1px solid $border-default;
+  border-radius: $radius-lg;
+  background: $bg-panel;
+  color: $text-body;
+  cursor: pointer;
+
+  &:hover:not(.disabled):not(:disabled) {
+    background: $bg-hover;
+    border-color: $color-accent;
+  }
+  &.selected {
+    border-color: $color-accent;
+    box-shadow: inset 3px 0 0 $color-accent;
+    color: $text-primary;
+  }
+  // 置灰：未实现平台 / 只读态的非当前项。仅 .disabled 控制视觉淡化，
+  // 交互失效单独用 HTML disabled 属性 —— 这样只读态下「当前选中项」可保持高亮不被淡化。
+  &.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.config-pick-icon {
+  display: inline-flex;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px; // 固定宽度，保证各项图标占位一致、文字起点不漂移
+
+  &.muted-icon {
+    color: $text-muted;
+    filter: grayscale(1);
+  }
+}
+
+// 平台项：图标右侧名称 + 副标题居中
+.config-pick-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1px;
+  min-width: 0;
+}
+.config-pick-name {
+  color: $text-primary;
+  font-size: $fs-md;
+  font-weight: 500;
+}
+.config-pick-meta {
+  color: $text-muted;
+  font-size: $fs-sm;
+  white-space: nowrap; // 副标题始终单行，避免被拆词换行
+}
+// provider 项：名称占满图标右侧、过长省略号（无副标题，与平台项区分）
+.config-pick-name-fill {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.config-pick-arrow {
+  color: $text-muted;
+  font-size: $fs-lg;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .config-pick-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/desktop/src/renderer/src/styles/features/draft-zone.scss
+++ b/apps/desktop/src/renderer/src/styles/features/draft-zone.scss
@@ -154,9 +154,9 @@
 }
 
 .draft-zone-btn-danger:hover:not(:disabled) {
-  border-color: $color-danger;
-  color: $color-danger;
-  background: rgba(244, 135, 113, 0.08);
+  border-color: $color-danger-strong;
+  color: $color-danger-strong;
+  background: $color-danger-strong-fade;
 }
 
 // 图标按钮 (垃圾桶等)：方形紧凑，跟文字按钮高度对齐

--- a/apps/desktop/src/renderer/src/styles/features/onboarding.scss
+++ b/apps/desktop/src/renderer/src/styles/features/onboarding.scss
@@ -183,70 +183,8 @@
 }
 
 // ===== 平台步：左右布局 =====
-.onboarding-platform-grid {
-  display: grid;
-  // 左列固定 220px：容下最长副标题「gitlab.com / Self-Managed」单行不折行（见 PLATFORM_META）
-  grid-template-columns: 220px 1fr;
-  gap: $space-8;
-  align-items: start;
-}
-.onboarding-platform-list {
-  display: flex;
-  flex-direction: column;
-  gap: $space-3;
-}
-.onboarding-platform-item {
-  display: flex;
-  align-items: center;
-  gap: $space-4;
-  padding: $space-4 $space-5;
-  border: 1px solid $border-default;
-  border-radius: $radius-lg;
-  background: $bg-panel;
-
-  &.selected {
-    border-color: $color-accent;
-    box-shadow: inset 3px 0 0 $color-accent;
-  }
-  &.disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-.onboarding-platform-icon {
-  display: inline-flex;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 24px; // 固定宽度，保证各卡图标占位一致、文字起点不漂移
-
-  &.muted-icon {
-    color: $text-muted;
-    filter: grayscale(1);
-  }
-}
-.onboarding-platform-text {
-  flex: 1; // 占满图标右侧区域
-  display: flex;
-  flex-direction: column;
-  align-items: center; // 名称 / 副标题在右侧区域水平居中
-  text-align: center;
-  gap: 1px;
-  min-width: 0;
-}
-.onboarding-platform-name {
-  color: $text-primary;
-  font-size: $fs-md;
-  font-weight: 500;
-}
-.onboarding-platform-meta {
-  color: $text-muted;
-  font-size: $fs-sm;
-  white-space: nowrap; // 副标题始终单行，避免「Self-Managed」被拆词换行
-}
-
-.onboarding-platform-form {
-  min-width: 0;
-}
+// 平台选择列表 + 表单的左右两栏布局收敛到 config-picker.scss（.config-pick-grid / -list / -item …），
+// 由 PlatformStep 与设置面板「连接」子模态共用，本文件不再单独维护。
 
 // ===== 折叠的「缓存目录」高级入口 =====
 .onboarding-advanced {
@@ -295,51 +233,8 @@
   }
 }
 
-// provider 行（两阶段共用）：图标 + 名称 (+ 箭头/选中)
-.onboarding-provider-list {
-  display: flex;
-  flex-direction: column;
-  gap: $space-3;
-  max-height: 320px;
-  overflow-y: auto;
-}
-.onboarding-provider-item {
-  display: flex;
-  align-items: center;
-  gap: $space-4;
-  width: 100%;
-  text-align: left;
-  padding: $space-4 $space-5;
-  border: 1px solid $border-default;
-  border-radius: $radius-lg;
-  background: $bg-panel;
-  color: $text-body;
-  cursor: pointer;
-
-  &:hover {
-    background: $bg-hover;
-    border-color: $color-accent;
-  }
-  &.selected {
-    border-color: $color-accent;
-    box-shadow: inset 3px 0 0 $color-accent;
-    color: $text-primary;
-  }
-}
-.onboarding-provider-name {
-  flex: 1;
-  min-width: 0;
-  font-size: $fs-md;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.onboarding-provider-arrow {
-  color: $text-muted;
-  font-size: $fs-lg;
-  flex-shrink: 0;
-}
+// provider 选择列表（两阶段共用：图标 + 名称 + 箭头/选中）收敛到 config-picker.scss
+// （.config-pick-list / -item / -name / -arrow …），由 LlmStep 与设置面板「LLM」子模态共用。
 
 // 阶段一：居中的选择列表
 .onboarding-provider-pick {
@@ -359,7 +254,7 @@
   align-items: start;
 
   // 左侧列表：从右侧滑入到位（视觉上「收到左边」）
-  .onboarding-provider-list {
+  .config-pick-list {
     animation: onboarding-slide-left 0.28s ease both;
   }
 }
@@ -441,7 +336,7 @@
 }
 
 @media (max-width: 640px) {
-  .onboarding-platform-grid,
+  // .config-pick-grid 的窄屏单列回退在 config-picker.scss；此处仅 LLM 步的 grid
   .onboarding-llm-grid {
     grid-template-columns: 1fr;
   }

--- a/apps/desktop/src/renderer/src/styles/features/onboarding.scss
+++ b/apps/desktop/src/renderer/src/styles/features/onboarding.scss
@@ -241,26 +241,34 @@
   max-width: 360px;
   margin: 0 auto;
 }
-.onboarding-provider-pick-hint {
-  margin: 0 0 $space-4;
-  text-align: center;
+// 阶段一选择列表：与阶段二网格同高（190px），两步切换不跳动；provider 增多时在内滚动
+.onboarding-provider-pick .config-pick-list {
+  height: 190px;
+  overflow-y: auto;
 }
 
-// 阶段二：左列表 + 右配置
+// 阶段二：左列表 + 右配置。固定高度 + 两栏各自滚动，
+// 切换 provider 时模态高度恒定、不抖动，列表后续扩展也不撑高（同设置子模态）。
 .onboarding-llm-grid {
   display: grid;
   grid-template-columns: 220px 1fr;
   gap: $space-8;
-  align-items: start;
+  align-items: stretch;
+  height: 190px;
 
-  // 左侧列表：从右侧滑入到位（视觉上「收到左边」）
+  // 左侧列表：从右侧滑入到位（视觉上「收到左边」），并在固定高度内滚动
   .config-pick-list {
+    min-height: 0;
+    overflow-y: auto;
     animation: onboarding-slide-left 0.28s ease both;
   }
 }
-// 右侧配置：略微延迟后渐隐进入
+// 右侧配置：略微延迟后渐隐进入；固定高度内滚动，顶部留半行余白与左侧列表协调
 .onboarding-llm-form {
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding-top: $space-5;
   animation: onboarding-form-fade 0.3s ease 0.08s both;
 }
 

--- a/apps/desktop/src/renderer/src/styles/layout/main-pane.scss
+++ b/apps/desktop/src/renderer/src/styles/layout/main-pane.scss
@@ -822,9 +822,9 @@
   color: $text-muted;
   cursor: pointer;
   &:hover:not(:disabled) {
-    border-color: $color-danger;
-    color: $color-danger;
-    background: rgba(244, 135, 113, 0.08);
+    border-color: $color-danger-strong;
+    color: $color-danger-strong;
+    background: $color-danger-strong-fade;
   }
   &:disabled {
     opacity: 0.5;


### PR DESCRIPTION
## 背景
一组针对设置面板「连接 / LLM 配置」与首启向导的交互优化。

## 变更
1. **连接 / LLM 配置模态复用向导左右布局**：抽出 `PlatformPicker` / `LlmProviderPicker`（复用组件统一在 settings 域维护，首启向导同步复用），左侧选集成平台 / LLM provider，右侧填表单。
2. **危险按钮统一为高饱和度红**：新增 `$color-danger-strong` token，删除评论（评论 tab + 行内）/ 删除草稿 / 删除连接 / LLM、停止、拒绝 finding 等按钮 hover 统一切到饱和红描边（与模态删除按钮同色系，保留 ghost 风格）。
3. **配置模态退出脏检查**：连接 / LLM 配置模态在有未提交改动时关闭（背景点击 / 取消）弹 `ConfirmModal` 确认拦截，确认放弃才关闭（`ConfirmModal` 增 `nested` 入参以叠在子模态之上）。
4. **配置模态 UX 打磨**（评审反馈）：
   - LLM 模态与向导 LLM 步固定高度、两栏各自滚动 —— 切换 provider 不抖动，provider 列表后续扩展也不撑高；向导两子步等高、卡片图标尺寸对齐。
   - CLI 模式：provider 列表加「实验性」标记；名称 / 命令占位均提示 `claude / codex`；文案精简（去品牌名 / 子进程 /「不直连 API」等内部细节与重复授权说明）。
   - 必填校验改为只标红框（去掉错误文案），消除控件位置抖动。
   - 「测试连接」按钮收窄为 `btn-sm`，并修正其结果文案与按钮垂直居中对齐。

i18n 四语言（zh-CN / en-US / ja-JP / de-DE）同步新增 / 调整。

## 验证
`lint` / `typecheck` / `build` 通过；`test` 仅 `repo-mirror` 5 个 git-CLI 环境性失败（已知、与本改动无关）。

人工回归：连接 / LLM 增改删、平台 / provider 选择（含编辑只读）、退出未保存拦截、危险按钮 hover、首启向导平台步与 LLM 步两阶段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)