### PR TITLE
perf(agent): Agent 编排响应提速（并行追问 / 判读瘦身 / 低推理+输出封顶 / 1h 前缀缓存）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
 ### Changed
 
+- **Agent 编排响应提速**（评审微流程 / 自由规划）：一批降延迟与降成本优化，对用户行为不变。
+  - 条件追问并行：判读为「严重需追问」时，多个 `/ask` 由串行改为并行派发（同 describe + review 模式，错开起跑、保序），多追问场景明显更快。
+  - 追问判读瘦身为轻量路由：判「是否需追问」不再带整份 agent 系统上下文（SOUL / 记忆 / 用户档 / 工具目录 / 规则 / PR 元数据），仅凭 describe + review 结果判断，输入 token 大降；追问问题随会话语言书写（不再固定英文）。
+  - 编排通道（判读 / 收尾 / 规划）全模式低推理 + 判读输出封顶：CLI（claude→haiku、codex→reasoning_effort=low）之外，API / litellm 路径补 `reasoning_effort=low`（仅对 reasoning 类模型生效、其余无副作用），并给判读这类轻量路由封顶输出，避免一个 yes/no 决策吐大量 token；均仅作用于编排 chat，`/review` 等工具 run 仍满档推理。
+  - 全局系统前缀走 Anthropic 1h 提示缓存：系统上下文拆为「全局稳定前缀（SOUL / AGENTS / 工具目录 / 记忆 / 用户档）」+「PR/运行相关尾部」，稳定前缀标服务端提示缓存（ephemeral, 1h），跨 PR / 运行在窗口内命中、降延迟与成本；OpenAI / DeepSeek 自带自动前缀缓存、无需额外处理。
+
 - **前端代码结构重构（可维护性）**：纯结构调整，对外接口与界面 / 交互行为均不变。重点：
   - 组件按 `common/`（基础 UI）/ `layout/`（应用骨架）/ `features/`（业务领域）三层归类；样式 `styles/` 同构归并
   - 超大组件按「容器 + 领域组件 + hooks + 工具方法」分层拆分：ChatPane、SettingsModal、MainPane、StatusBar

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/chat.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/chat.py
@@ -4,27 +4,37 @@
 `LiteLLMAIHandler.chat_completion`——provider 路由、CLI 模式（MEEBOX_CLI_MODE）、Anthropic 去
 temperature、token usage 哨兵全部继承，无需在此重复实现。
 
-约定：stdin 收一段 JSON `{"system": ..., "user": ..., "temperature"?: ...}`，回复正文写 stdout，
-token 用量经 `@@MEEBOX_USAGE@@` 哨兵打到 stderr（主进程与 pr-agent run 同一套累加，见 ipc.ts）。
+约定：stdin 收一段 JSON `{"system": ..., "user": ..., "temperature"?: ..., "max_output_tokens"?: ...}`，
+回复正文写 stdout，token 用量经 `@@MEEBOX_USAGE@@` 哨兵打到 stderr（主进程与 pr-agent run 同一套累加，
+见 ipc.ts）。max_output_tokens 封顶输出（轻量路由判读用），经 env 中转给 litellm_handler 补丁注入 litellm
+max_tokens——仅嵌入式 litellm 路径生效，CLI provider 忽略。
 """
 import asyncio
 import json
+import os
 import sys
 
 
 def _read_payload() -> dict:
     raw = sys.stdin.read()
     if not raw.strip():
-        return {"system": "", "user": "", "temperature": None}
+        return {"system": "", "user": "", "temperature": None, "max_output_tokens": None}
     data = json.loads(raw)
     return {
         "system": data.get("system") or "",
         "user": data.get("user") or "",
         "temperature": data.get("temperature"),
+        "max_output_tokens": data.get("max_output_tokens"),
     }
 
 
 async def _run(payload: dict) -> str:
+    # 输出封顶：每次 chat 独立子进程，故置环境变量即「本次调用」级别——litellm_handler 补丁里
+    # 的 _get_completion 包装读它注入 litellm max_tokens（见 patches/litellm_handler）。
+    mot = payload.get("max_output_tokens")
+    if isinstance(mot, int) and mot > 0:
+        os.environ["MEEBOX_CHAT_MAX_TOKENS"] = str(mot)
+
     # 惰性 import：触发 shim 注册的 post-import 补丁（CLI 模式替换 / _get_completion usage 包装）。
     from pr_agent.algo.ai_handlers.litellm_ai_handler import LiteLLMAIHandler
     from pr_agent.config_loader import get_settings

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/install.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/cli/install.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from ..runtime import _debug
+from ..runtime import _debug, strip_cache_break
 from ..usage import _emit_usage_tokens
 from .specs import _CLI_SPECS
 
@@ -61,6 +61,9 @@ def _install_cli_chat_completion(handler_cls, bin_name) -> None:
                 f"找不到本地 CLI 命令 '{bin_name}'：请确认已安装、已登录，且 '{bin_name}' 在 PATH 中。"
             )
         argv = _build_argv()
+        # CLI 单轮无独立 system 槽：system+user 拼一段。先剥除缓存断点标记（仅 Anthropic litellm 路径用于
+        # 分块缓存；CLI 不缓存、标记不得进入 prompt）。
+        system = strip_cache_break(system) if system else system
         prompt = f"{system}\n\n\n{user}" if system else user
         # 基于 os.environ 拷贝再剔除计费 key——其余（PATH/HOME/代理变量等）原样保留。
         child_env = {k: v for k, v in os.environ.items() if k not in spec["strip_env"]}

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/litellm_handler.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/litellm_handler.py
@@ -7,8 +7,68 @@
 import os
 
 from ..cli.install import _install_cli_chat_completion
-from ..runtime import _EXPECTED_PRAGENT_VERSION, _debug, _pragent_version
+from ..runtime import (
+    _EXPECTED_PRAGENT_VERSION,
+    _debug,
+    _pragent_version,
+    split_cache_break,
+)
 from ..usage import _emit_usage
+
+# Anthropic 提示缓存最小可缓存粒度约 1k token；稳定前缀低于此不标缓存（含极小的判读 system）。
+_CACHE_MIN_CHARS = 4000
+# 全局稳定前缀用 1h 扩展 TTL：跨所有 PR/运行在 1h 内命中，写入 2× 由大量命中摊薄；需带 beta 头。
+_CACHE_TTL = "1h"
+_CACHE_BETA_FLAG = "extended-cache-ttl-2025-04-11"
+
+
+def _add_cache_beta_header(kwargs: dict) -> None:
+    """合入 1h 缓存所需 anthropic-beta 头（不覆盖既有标志）。"""
+    headers = kwargs.get("extra_headers")
+    if not isinstance(headers, dict):
+        headers = {}
+    existing = headers.get("anthropic-beta")
+    if not existing:
+        headers["anthropic-beta"] = _CACHE_BETA_FLAG
+    elif _CACHE_BETA_FLAG not in existing:
+        headers["anthropic-beta"] = f"{existing},{_CACHE_BETA_FLAG}"
+    kwargs["extra_headers"] = headers
+
+
+def _apply_chat_system_cache(kwargs: dict) -> None:
+    """编排 chat 通道为 Anthropic 缓存「全局稳定前缀」(1h)；并在任何情况下剥除缓存断点标记。
+
+    assembleSystemContext 在全局稳定段（SOUL/AGENTS/工具/记忆/用户）与 PR/运行相关尾部之间插了 CACHE_BREAK。
+    Anthropic 提示缓存按**前缀**生效、**服务端**缓存（不依赖暖会话）：把稳定前缀单独标 cache_control(1h)，
+    则跨所有 PR/运行在 1h 内命中（写入 2× 由大量命中摊薄），尾部（每 PR 不同）保持纯文本。仅作用于编排
+    chat（MEEBOX_CHAT_CACHE 置位）；OpenAI/DeepSeek 自带自动前缀缓存、无需此标，但仍须剥除标记。
+    无断点的 system（如精简判读 system）原样放过。
+    """
+    msgs = kwargs.get("messages")
+    if not isinstance(msgs, list):
+        return
+    is_anthropic = (kwargs.get("model") or "").lower().startswith("anthropic/")
+    cache_on = bool(os.environ.get("MEEBOX_CHAT_CACHE"))
+    for m in msgs:
+        if m.get("role") != "system" or not isinstance(m.get("content"), str):
+            continue
+        stable, variable = split_cache_break(m["content"])
+        if stable is None:
+            return  # 无断点：不缓存、原样
+        if cache_on and is_anthropic and len(stable) >= _CACHE_MIN_CHARS:
+            m["content"] = [
+                {
+                    "type": "text",
+                    "text": stable,
+                    "cache_control": {"type": "ephemeral", "ttl": _CACHE_TTL},
+                },
+                {"type": "text", "text": variable},
+            ]
+            _add_cache_beta_header(kwargs)
+        else:
+            # 非 anthropic / 未开缓存 / 前缀过小：去标记拼回纯文本（自动前缀缓存仍可命中）。
+            m["content"] = f"{stable}\n\n---\n\n{variable}"
+        return
 
 
 def patch(module) -> None:
@@ -70,6 +130,7 @@ def patch(module) -> None:
                     kwargs["max_tokens"] = int(mt)
                 except (TypeError, ValueError):
                     _debug(f"ignore invalid MEEBOX_CHAT_MAX_TOKENS={mt!r}")
+            _apply_chat_system_cache(kwargs)
             result = await _orig_get_completion(self, **kwargs)
             try:
                 if isinstance(result, tuple) and len(result) >= 3:

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/litellm_handler.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/patches/litellm_handler.py
@@ -61,6 +61,15 @@ def patch(module) -> None:
         _orig_get_completion = handler_cls._get_completion
 
         async def _get_completion_with_usage(self, **kwargs):
+            # 输出封顶（编排器 chat 通道经 MEEBOX_CHAT_MAX_TOKENS 设；pr-agent 工具 run 的 env 不含
+            # 该项，故 /describe /review 不受限）。"thinking" 在场（Claude 扩展思考）时不覆盖其 max_tokens
+            # （否则会低于 thinking budget 报错）；已有 max_tokens 也不覆盖。
+            mt = os.environ.get("MEEBOX_CHAT_MAX_TOKENS")
+            if mt and "thinking" not in kwargs and "max_tokens" not in kwargs:
+                try:
+                    kwargs["max_tokens"] = int(mt)
+                except (TypeError, ValueError):
+                    _debug(f"ignore invalid MEEBOX_CHAT_MAX_TOKENS={mt!r}")
             result = await _orig_get_completion(self, **kwargs)
             try:
                 if isinstance(result, tuple) and len(result) >= 3:

--- a/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/runtime.py
+++ b/apps/desktop/scripts/pragent-shim/meebox_pragent_shim/runtime.py
@@ -16,6 +16,25 @@ import sys
 # （assemble 脚本会校验两者一致，并据本文件抽取该常量），并重新验证 patch 行为。
 _EXPECTED_PRAGENT_VERSION = "0.36.0"
 
+# 系统上下文「缓存断点」标记：assembleSystemContext（TS, packages/agent/src/assemble.ts）在**全局稳定
+# 前缀**（SOUL/AGENTS/工具目录/记忆/用户档）与 **PR/运行相关尾部** 之间插入此串（连同两侧 --- 分隔）。
+# shim 据此把稳定前缀单独标 Anthropic 提示缓存（1h），尾部保持纯文本；消费端（litellm 分块 / CLI 拼接）
+# 分割或剥除后，标记**绝不**进入发给模型的 prompt。两处常量须逐字一致。
+CACHE_BREAK = "\n\n---\n\n[[MEEBOX:CACHE_BREAK]]\n\n---\n\n"
+
+
+def split_cache_break(system):
+    """按缓存断点切分 system → (stable_prefix, variable_tail)。无断点返回 (None, system)。"""
+    stable, sep, variable = system.partition(CACHE_BREAK)
+    if not sep:
+        return None, system
+    return stable, variable
+
+
+def strip_cache_break(system):
+    """剥除缓存断点标记（不分块的消费端用，如 CLI prompt 拼接），塌成单个 --- 分隔。"""
+    return system.replace(CACHE_BREAK, "\n\n---\n\n")
+
 
 def _debug(msg) -> None:
     if os.environ.get("MEEBOX_SHIM_DEBUG"):

--- a/apps/desktop/src/main/services/agent-orchestrator.ts
+++ b/apps/desktop/src/main/services/agent-orchestrator.ts
@@ -30,6 +30,8 @@ import { accumulateUsageSentinel, finalizeUsage, newUsageAcc } from './usage.js'
 type AgentChat = (input: {
   system: string;
   user: string;
+  /** 输出 token 上限（轻量路由判读封顶用，见 ChatRunOptions.maxOutputTokens）。 */
+  maxOutputTokens?: number;
 }) => Promise<{ text: string; usage?: TokenUsage }>;
 
 /**
@@ -282,16 +284,20 @@ export class AgentOrchestratorService {
       ...(activeLlm ? buildPragentEnv(activeLlm) : {}),
       CONFIG__RESPONSE_LANGUAGE: getMainLanguage(),
       // Agent 编排通道（规划 / 判读 / 收尾 / 对话）是路由 + 轻量综合，非深度代码分析（那在
-      // pr-agent /review 里）。本机 CLI 模式下调低推理档（codex: model_reasoning_effort=low）
-      // 提速；仅作用于本 chat spawn，pr-agent 工具 run 的 env 不含此项 → /review 仍满档推理。
-      // 非 CLI 模式（API）由 CLI handler 之外的路径处理，该 env 无副作用。
+      // pr-agent /review 里）。两条路径都调低推理档提速，且仅作用于本 chat spawn——pr-agent 工具 run
+      // 的 env 不含这两项 → /review 仍满档推理。
+      // - 本机 CLI 模式：codex → model_reasoning_effort=low、claude → haiku（见 cli/specs）。
       MEEBOX_CLI_REASONING: 'low',
+      // - API / litellm 模式：对 reasoning 类模型（o 系 / deepseek-reasoner 等）设 reasoning_effort=low
+      //   （pr-agent 仅对 support_reasoning_models 应用，非 reasoning 模型该项无副作用），避免编排里
+      //   一个 yes/no 路由判读也吐大量思考 token、拖慢响应。
+      CONFIG__REASONING_EFFORT: 'low',
     };
     // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
     const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
     try {
-      const chat: AgentChat = async ({ system, user }) => {
-        const r = await bridge.chat({ system, user, env, cwd: chatCwd, signal });
+      const chat: AgentChat = async ({ system, user, maxOutputTokens }) => {
+        const r = await bridge.chat({ system, user, maxOutputTokens, env, cwd: chatCwd, signal });
         const acc = newUsageAcc();
         for (const line of (r.stderr ?? '').split('\n')) accumulateUsageSentinel(line, acc);
         return { text: r.stdout.trim(), usage: finalizeUsage(acc) };

--- a/apps/desktop/src/main/services/agent-orchestrator.ts
+++ b/apps/desktop/src/main/services/agent-orchestrator.ts
@@ -292,6 +292,10 @@ export class AgentOrchestratorService {
       //   （pr-agent 仅对 support_reasoning_models 应用，非 reasoning 模型该项无副作用），避免编排里
       //   一个 yes/no 路由判读也吐大量思考 token、拖慢响应。
       CONFIG__REASONING_EFFORT: 'low',
+      // 提示缓存（服务端、5min TTL）：为编排 chat 的大块 system 前缀打 cache_control。多轮规划逐轮共享
+      // 同一 system → 第 2 轮起命中、降延迟/成本（仅 Anthropic 需显式标；OpenAI/DeepSeek 自动前缀缓存）。
+      // 仅作用于本 chat spawn；判读 system 过小不达缓存粒度自动跳过（见 litellm_handler）。
+      MEEBOX_CHAT_CACHE: '1',
     };
     // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
     const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));

--- a/packages/agent/src/assemble.ts
+++ b/packages/agent/src/assemble.ts
@@ -74,25 +74,40 @@ function renderLanguage(language: string | undefined): string {
 }
 
 /**
- * 现读现装配：按「上下文注入」固定次序拼接系统上下文。空段跳过。
- * 次序：SOUL → AGENTS → 工具目录 → 命中规则 → MEMORY + USER → PR 元数据
- *      → 会话快照 → 语言行为指令。
+ * 缓存断点标记：插在「全局稳定前缀」与「PR/运行相关尾部」之间（含两侧 --- 分隔）。嵌入式 shim 据此把
+ * 稳定前缀单独标 Anthropic 提示缓存（1h）、跨 PR/运行命中，尾部保持纯文本；消费端分割 / 剥除后标记绝不
+ * 进入发给模型的 prompt（litellm 分块、CLI 拼接均处理）。
+ * **须与 scripts/pragent-shim/meebox_pragent_shim/runtime.py 的 `CACHE_BREAK` 逐字一致。**
+ */
+const CACHE_BREAK = '\n\n---\n\n[[MEEBOX:CACHE_BREAK]]\n\n---\n\n';
+
+/**
+ * 现读现装配：按「上下文注入」固定次序拼接系统上下文，并按缓存友好分两段：
+ * - 全局稳定前缀（跨 PR/运行一致，置最前供 1h 缓存）：SOUL → AGENTS → 工具目录 → MEMORY → USER。
+ * - PR/运行相关尾部（每次不同，置最后）：命中规则 → PR 元数据 → 会话快照 → 语言行为指令。
+ * 两段间插 CACHE_BREAK；任一段为空则不插标记。空段跳过。
  */
 export function assembleSystemContext(input: AssembleInput): string {
   const { context, pr, toolCatalog, matchedRule, language, session } = input;
   const { files } = context;
 
-  const blocks: Array<string | null> = [
+  const stable: Array<string | null> = [
     section('Soul', files.soul),
     section('Working agreement', files.agents),
     renderToolCatalog(toolCatalog),
-    matchedRule ? section('Matched rule', matchedRule.instructions) : null,
     section('Memory', files.memory),
     section('User profile', files.user),
+  ];
+  const variable: Array<string | null> = [
+    matchedRule ? section('Matched rule', matchedRule.instructions) : null,
     renderPr(pr),
     session ? renderSession(session) : null,
     renderLanguage(language),
   ];
 
-  return blocks.filter((b): b is string => b !== null).join('\n\n---\n\n');
+  const stableStr = stable.filter((b): b is string => b !== null).join('\n\n---\n\n');
+  const variableStr = variable.filter((b): b is string => b !== null).join('\n\n---\n\n');
+  if (!stableStr) return variableStr;
+  if (!variableStr) return stableStr;
+  return stableStr + CACHE_BREAK + variableStr;
 }

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -358,13 +358,17 @@ export async function runReviewMicroflow(
     usage: judge.usage,
   });
 
-  const askResults: string[] = [];
-  for (const q of questions) {
-    checkAbort();
-    const ask = await deps.runTool({ tool: 'ask', question: q });
+  // 多个追问同属一个阶段、彼此独立（各自只读 PR、互不依赖），故并行派发——与上面 describe + review
+  // 同模式：runStaggered 保序（askResults 与 questions 一一对应）、错开 100~200ms 起跑，实际并发度仍受
+  // 运行队列 max_concurrency 兜底。questions 为空时不触发任何调用。
+  checkAbort();
+  const asks = questions.length
+    ? await runStaggered(questions, (q) => deps.runTool({ tool: 'ask', question: q }))
+    : [];
+  const askResults = asks.map((ask, i) => {
     usage = addUsage(usage, ask.usage);
-    askResults.push(`Q: ${q}\nA: ${ask.text}`);
-  }
+    return `Q: ${questions[i]}\nA: ${ask.text}`;
+  });
 
   // 3. 收尾总结 + 建议
   checkAbort();

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -164,14 +164,23 @@ export function salvageProse(raw: string): string {
   return raw.trim();
 }
 
-function judgePrompt(reviewText: string, maxAsks: number): string {
+/** 追问判断用的精简系统提示：不带 agent 完整上下文（SOUL / 记忆 / 用户档 / 工具目录 / 规则 / PR 元数据）。
+ *  这是一次轻量路由判读，仅凭 describe + review 结果判「是否有严重问题需追问」，与 AutoPilot 初判
+ *  （judgeAutopilotBatch）同思路——砍掉无关前缀大幅降输入 token、提速；产物只是结构化布尔 + 问题列表。 */
+const JUDGE_SYSTEM =
+  'You are a senior code reviewer triaging review findings for follow-up. Be decisive and terse; reply with JSON only, no reasoning.';
+
+function judgePrompt(describeText: string, reviewText: string, maxAsks: number): string {
   return [
-    'You just produced the review findings below. Decide whether any finding is a',
+    'You just produced the PR description and review findings below. Decide whether any finding is a',
     '*particularly severe* issue (e.g. likely security hole, data loss, serious logic bug)',
     `that genuinely needs a clarifying follow-up question. Default to NO follow-up.`,
     `Ask at most ${String(maxAsks)} questions, and only for severe issues.`,
     '',
-    'Reply with JSON only: {"severe": boolean, "questions": string[]}.',
+    'Reply with JSON only: {"severe": boolean, "questions": string[]}. No explanation, no reasoning.',
+    '',
+    '--- PR description ---',
+    describeText,
     '',
     '--- Review findings ---',
     reviewText,
@@ -345,7 +354,10 @@ export async function runReviewMicroflow(
   // 2. 仅严重问题条件性追问
   checkAbort();
   const judgeStart = Date.now();
-  const judge = await deps.chat({ system, user: judgePrompt(review.text, maxAsks) });
+  const judge = await deps.chat({
+    system: JUDGE_SYSTEM,
+    user: judgePrompt(describe.text, review.text, maxAsks),
+  });
   const judgeMs = Date.now() - judgeStart;
   usage = addUsage(usage, judge.usage);
   const verdict = extractJson<{ severe?: boolean; questions?: string[] }>(judge.text);

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -173,12 +173,22 @@ const JUDGE_SYSTEM =
 /** 追问判读的输出 token 上限：产物是极小 JSON（severe + 至多数条问题），无需大额度。 */
 const JUDGE_MAX_OUTPUT_TOKENS = 1024;
 
-function judgePrompt(describeText: string, reviewText: string, maxAsks: number): string {
+function judgePrompt(
+  describeText: string,
+  reviewText: string,
+  maxAsks: number,
+  language: string,
+): string {
+  // 与 renderLanguage 同策略：空 / 未知回落 en-US。
+  const lang = language.trim() || 'en-US';
   return [
     'You just produced the PR description and review findings below. Decide whether any finding is a',
     '*particularly severe* issue (e.g. likely security hole, data loss, serious logic bug)',
     `that genuinely needs a clarifying follow-up question. Default to NO follow-up.`,
     `Ask at most ${String(maxAsks)} questions, and only for severe issues.`,
+    // 精简 system 不再带 assembleSystemContext 的语言指令，故在此显式要求：追问问题须用会话语言书写
+    // （否则模型默认英文，追问气泡不随 locale）。问题最终会作为 /ask 的 user turn 展示并发给模型。
+    `Write every question in ${lang} (the user's language).`,
     '',
     'Reply with JSON only: {"severe": boolean, "questions": string[]}. No explanation, no reasoning.',
     '',
@@ -359,7 +369,7 @@ export async function runReviewMicroflow(
   const judgeStart = Date.now();
   const judge = await deps.chat({
     system: JUDGE_SYSTEM,
-    user: judgePrompt(describe.text, review.text, maxAsks),
+    user: judgePrompt(describe.text, review.text, maxAsks, input.language ?? ''),
     // 判读产物只是极小的结构化 JSON（severe + 至多数条问题），封顶输出避免模型对 yes/no 决策狂吐 token。
     maxOutputTokens: JUDGE_MAX_OUTPUT_TOKENS,
   });

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -27,8 +27,8 @@ export interface ToolText {
 export interface ReviewOrchestratorDeps {
   /** 分发一个只读 pr-agent 工具，返回文本结果（描述 / findings / 回答）。 */
   runTool(call: { tool: 'describe' | 'review' | 'ask'; question?: string }): Promise<ToolText>;
-  /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
-  chat(input: { system: string; user: string }): Promise<ToolText>;
+  /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。maxOutputTokens 可给轻量路由判读封顶输出。 */
+  chat(input: { system: string; user: string; maxOutputTokens?: number }): Promise<ToolText>;
   /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
   onStep?(step: AgentStep): void | Promise<void>;
   /** 用户停止：每步边界检查，已 abort 即抛 `用户暂停` 中止微流程（思考阶段也能立即终止）。 */
@@ -169,6 +169,9 @@ export function salvageProse(raw: string): string {
  *  （judgeAutopilotBatch）同思路——砍掉无关前缀大幅降输入 token、提速；产物只是结构化布尔 + 问题列表。 */
 const JUDGE_SYSTEM =
   'You are a senior code reviewer triaging review findings for follow-up. Be decisive and terse; reply with JSON only, no reasoning.';
+
+/** 追问判读的输出 token 上限：产物是极小 JSON（severe + 至多数条问题），无需大额度。 */
+const JUDGE_MAX_OUTPUT_TOKENS = 1024;
 
 function judgePrompt(describeText: string, reviewText: string, maxAsks: number): string {
   return [
@@ -357,6 +360,8 @@ export async function runReviewMicroflow(
   const judge = await deps.chat({
     system: JUDGE_SYSTEM,
     user: judgePrompt(describe.text, review.text, maxAsks),
+    // 判读产物只是极小的结构化 JSON（severe + 至多数条问题），封顶输出避免模型对 yes/no 决策狂吐 token。
+    maxOutputTokens: JUDGE_MAX_OUTPUT_TOKENS,
   });
   const judgeMs = Date.now() - judgeStart;
   usage = addUsage(usage, judge.usage);

--- a/packages/agent/tests/assemble.test.ts
+++ b/packages/agent/tests/assemble.test.ts
@@ -54,6 +54,23 @@ describe('assembleSystemContext', () => {
     expect(def).toContain('Respond to the user in en-US');
   });
 
+  it('inserts the cache-break marker between the stable prefix and the PR/variable tail', () => {
+    const out = assembleSystemContext({
+      context: { files: { soul: 'I am soul', agents: 'work rules', memory: '', user: 'terse' }, rules: [] },
+      pr,
+      toolCatalog: tools,
+      language: 'zh-CN',
+    });
+    // 标记须与 shim runtime.py 的 CACHE_BREAK 逐字一致；稳定前缀在标记前、PR/语言在标记后。
+    const marker = '\n\n---\n\n[[MEEBOX:CACHE_BREAK]]\n\n---\n\n';
+    expect(out).toContain(marker);
+    const at = out.indexOf(marker);
+    expect(out.indexOf('# Soul')).toBeLessThan(at);
+    expect(out.indexOf('# User profile')).toBeLessThan(at);
+    expect(out.indexOf('# Current PR')).toBeGreaterThan(at);
+    expect(out.indexOf('# Output & memory language')).toBeGreaterThan(at);
+  });
+
   it('renders the session snapshot when provided', () => {
     const out = assembleSystemContext({
       context: emptyContext,

--- a/packages/pr-agent-bridge/src/bridge.ts
+++ b/packages/pr-agent-bridge/src/bridge.ts
@@ -52,6 +52,7 @@ abstract class BaseBridge implements PrAgentBridge {
       system: opts.system ?? '',
       user: opts.user,
       ...(opts.temperature != null ? { temperature: opts.temperature } : {}),
+      ...(opts.maxOutputTokens != null ? { max_output_tokens: opts.maxOutputTokens } : {}),
     });
     return this.exec(cmd, args, {
       timeoutMs: opts.timeoutMs ?? DEFAULT_CHAT_TIMEOUT_MS,

--- a/packages/pr-agent-bridge/src/types.ts
+++ b/packages/pr-agent-bridge/src/types.ts
@@ -98,6 +98,12 @@ export interface ChatRunOptions {
   user: string;
   /** 采样温度；anthropic 经 shim 自动剔除。 */
   temperature?: number;
+  /**
+   * 输出 token 上限（litellm max_tokens）。用于轻量路由判读（如追问判读）封顶输出、避免模型
+   * 对一个 yes/no 决策吐大量 token 拖慢响应。仅嵌入式 litellm 路径生效；CLI provider 忽略。
+   * 省略 = 不封顶（总结 / 规划收尾等需完整篇幅者不传）。
+   */
+  maxOutputTokens?: number;
   /** 注入子进程的 env（LLM key / model / 代理，复用 buildPragentEnv）。 */
   env?: Record<string, string>;
   /** 子进程工作目录；建议传中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。 */


### PR DESCRIPTION
## 背景

Agent 编排通道（评审微流程的判读 / 收尾、自由规划）响应偏慢——一次「是否需追问」的路由判读可达数十秒（输入带整份 agent 系统上下文 + 模型对 yes/no 决策吐大量 token）。本批针对**编排 chat 通道**做降延迟 / 降成本优化，**不改用户可见行为**；pr-agent 工具 run（`/describe` `/review`）满档推理不变。

## 改动

- **条件追问并行**：判读为「严重需追问」时，多个 `/ask` 由串行改为并行派发（同 describe + review 模式，错开起跑、保序）。
- **追问判读瘦身为轻量路由**：判读不再带整份 agent 系统上下文（SOUL / 记忆 / 用户档 / 工具目录 / 规则 / PR 元数据），仅凭 describe + review 结果判断，输入 token 大降；追问问题随会话语言书写（修复瘦身引入的「问题固定英文」回归）。
- **全模式低推理 + 判读输出封顶**：CLI（claude→haiku、codex→reasoning_effort=low）之外，API / litellm 路径补 `reasoning_effort=low`（仅对 reasoning 类模型生效、其余无副作用）；判读这类轻量路由封顶输出，避免 yes/no 决策狂吐 token。均仅作用于编排 chat。
- **全局系统前缀 1h 提示缓存**：系统上下文拆为「全局稳定前缀（SOUL / AGENTS / 工具目录 / 记忆 / 用户档）」+「PR/运行相关尾部」，稳定前缀标 Anthropic 服务端提示缓存（ephemeral, 1h），跨 PR / 运行在窗口内命中、降延迟与成本；OpenAI / DeepSeek 自带自动前缀缓存、无需额外处理；CLI 仅剥除缓存断点标记。

## 验证

`lint` / `typecheck` / `test`（agent + pr-agent-bridge）、`build desktop` 全绿；`prepare:pragent` 冒烟 OK；缓存断点 split/strip + 1h 转换逐情形实测通过（Anthropic 双块 1h+beta、OpenAI 剥标记、小前缀不缓存、判读不动）。实跑命中以 usage 的 `cache_read_input_tokens` 为准。

🤖 Generated with [Claude Code](https://claude.com/claude-code)