### PR TITLE
feat(chat): Diff 选中行作为隐式上下文引用进 agent/ask 提问

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Added
 
+- Diff 选中代码引用进提问：在 Diff 选中若干行后，聊天输入栏 AutoReview 按钮右侧出现「N 行已选中」角标（竖线分隔），点击可切换忽略态（eye-slash + 置灰）——忽略时本条消息不带引用。发送 `/ask` 或自然语言提问时，选中代码作为**隐式上下文**注入模型（带文件路径 + 行范围 + base/head 侧），不进入会话气泡、不落盘（`agent:ask` / `pragent:run` 增可选 `referencedContext`，经 EXTRA_INSTRUCTIONS / 规划当轮提示注入，且约束不透传给 pr-agent 工具）。引用不受「可评论区域」限制，未改动的上下文行同样可引用。统一(inline)视图下删除行无法被光标选中，但 head 选区跨到的删除 / 改动 hunk 会据 diff 映射从基线侧取出真实代码一并引用（删除内容也能像添加行一样被引用）；并排视图删除行可直接选中。切换 PR / 选区塌缩即清。
+
 - Diff 滚动条总览标尺：diff 增 / 改 / 删与「有评论的行」投影到滚动条旁的总览标尺（编辑模式风格，按 1/3 分道、中间留白，不启用 minimap），拖动滚动条即可快速定位变更与评论位置。增 / 改按行高显示；并排视图删除在左侧 original 编辑器标尺按行高标红，统一(inline)视图下删除行无 model 行号、以删除点标记。
 
 - Diff 标签支持按「变更范围」查看：文件树头部「<n> 个文件」补充范围信息，变为「<n> 个文件 · 全部变更」或「<n> 个文件 · <commit>」，整体可点击弹出下拉，选择查看「全部变更（PR base..head）」或某个 commit 的变更（该 commit 的 `parent..sha`）。提交 / 活动标签页点击 commit 不再跳浏览器，而是切到 Diff 标签本地渲染该 commit 的变更。commit 视图为只读 diff（行内评论 / 草稿锚定在 PR 全量 diff 行号上，不套用于单 commit）。`diff:listChangedFiles` / `getFileContent` / `getBlame` 增加可选 base/head 范围参数。

--- a/apps/desktop/src/main/agent-planning.ts
+++ b/apps/desktop/src/main/agent-planning.ts
@@ -88,6 +88,8 @@ export interface AgentPlanningDeps {
   matchedRule?: Rule | null;
   language: string;
   maxSteps: number;
+  /** 用户选中的代码引用（隐式上下文）：注入规划 LLM 当轮提示，不进持久化用户消息。 */
+  referencedContext?: string;
   signal?: AbortSignal;
   onStep?: (sessionId: string, step: AgentStep) => void;
   /** 持久化 Agent 主动记下的非隐私条目到各可写上下文文件（USER/MEMORY/AGENTS）。 */
@@ -137,6 +139,7 @@ export async function runAgentPlanning(
         language: deps.language,
         userRequest,
         history,
+        referencedContext: deps.referencedContext,
         maxSteps: deps.maxSteps,
       },
     );

--- a/apps/desktop/src/main/controllers/agent.ts
+++ b/apps/desktop/src/main/controllers/agent.ts
@@ -59,7 +59,11 @@ export const runReview: IpcController<'agent:run'> = async (_event, req) => {
  */
 export const runPlanning: IpcController<'agent:ask'> = async (_event, req) => {
   const ctx = getContext();
-  return ctx.orchestrator.runPlanning(await ctx.pr.findPrOrThrow(req.localId), req.question);
+  return ctx.orchestrator.runPlanning(
+    await ctx.pr.findPrOrThrow(req.localId),
+    req.question,
+    req.referencedContext,
+  );
 };
 
 /**
@@ -117,7 +121,7 @@ export const runPragent: IpcController<'pragent:run'> = async (_event, req) => {
     throw new Error(t('prAgent.askNeedsQuestion'));
   }
   const pr = await ctx.pr.findPrOrThrow(req.localId);
-  return ctx.runQueue.enqueuePragentRun(pr, req.tool, req.question);
+  return ctx.runQueue.enqueuePragentRun(pr, req.tool, req.question, 'user', req.referencedContext);
 };
 
 /**

--- a/apps/desktop/src/main/services/agent-orchestrator.ts
+++ b/apps/desktop/src/main/services/agent-orchestrator.ts
@@ -90,7 +90,11 @@ export class AgentOrchestratorService {
   }
 
   /** 对指定 PR 跑自由规划 Agent（agent:ask）。 */
-  async runPlanning(pr: StoredPullRequest, question: string): Promise<AgentSession> {
+  async runPlanning(
+    pr: StoredPullRequest,
+    question: string,
+    referencedContext?: string,
+  ): Promise<AgentSession> {
     const { getPrAgentBridge, effectiveAgentDir, logger } = this.ctx;
     if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
     const agentContext = await loadAgentContext(effectiveAgentDir(), {
@@ -103,7 +107,7 @@ export class AgentOrchestratorService {
     logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
     try {
       const session = await this.withAgentChat(
-        (chat) => this.runPlanningForPr(pr, question, agentContext, chat, ac.signal),
+        (chat) => this.runPlanningForPr(pr, question, agentContext, chat, ac.signal, referencedContext),
         ac.signal,
       );
       logger.info(
@@ -380,6 +384,7 @@ export class AgentOrchestratorService {
     agentContext: AgentContext,
     chat: AgentChat,
     signal: AbortSignal,
+    referencedContext?: string,
   ): Promise<AgentSession> {
     const { bootstrap, effectiveAgentDir, logger } = this.ctx;
     const agentCfg = bootstrap.config.agent;
@@ -392,6 +397,7 @@ export class AgentOrchestratorService {
     return runAgentPlanning(pr, userRequest, {
       stateStore: this.ctx.stateStore,
       enqueueRun: (p, tool, question) => this.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
+      referencedContext,
       chat,
       agentContext,
       toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),

--- a/apps/desktop/src/main/services/pragent-prompts.ts
+++ b/apps/desktop/src/main/services/pragent-prompts.ts
@@ -139,12 +139,15 @@ export function buildExtraInstructions(input: {
   language: string;
   prContext: string;
   matchedRuleInstructions: string;
+  /** 用户在 Diff 里选中的代码片段（自描述引用块，渲染层已拼好），仅 /ask 注入。 */
+  referencedContext?: string;
 }): string | undefined {
   const parts = [
     languageDirectiveFor(input.language),
     anchorMarkerDirective(input.tool),
     reviewLayoutDirective(input.tool),
     input.prContext,
+    input.referencedContext ?? '',
     input.matchedRuleInstructions,
   ].filter((s) => s.trim());
   return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;

--- a/apps/desktop/src/main/services/run-queue.ts
+++ b/apps/desktop/src/main/services/run-queue.ts
@@ -43,7 +43,7 @@ export type RunPriority = 'user' | 'agent';
 /** 队列项：一次入队的 pr-agent run 的全部上下文（含 resolve/reject 回原始调用方）。 */
 interface QueueItem {
   info: PragentRunInfo;
-  req: { localId: string; tool: ReviewRunTool; question?: string };
+  req: { localId: string; tool: ReviewRunTool; question?: string; referencedContext?: string };
   pr: StoredPullRequest;
   resolve: (run: ReviewRun) => void;
   reject: (err: Error) => void;
@@ -91,6 +91,7 @@ export class RunQueueService {
     tool: ReviewRunTool,
     question?: string,
     priority: RunPriority = 'user',
+    referencedContext?: string,
   ): Promise<ReviewRun> {
     const { logger } = this.ctx;
     if (tool !== 'ask') {
@@ -114,7 +115,8 @@ export class RunQueueService {
           enqueuedAt: new Date().toISOString(),
           startedAt: null,
         },
-        req: { localId: pr.localId, tool, question },
+        // referencedContext 仅入 req（内存态，不进 info/PragentRunInfo）→ 不落盘、不进队列广播。
+        req: { localId: pr.localId, tool, question, referencedContext: tool === 'ask' ? referencedContext : undefined },
         pr,
         priority,
         resolve,
@@ -390,6 +392,8 @@ export class RunQueueService {
         language: getMainLanguage(),
         prContext,
         matchedRuleInstructions,
+        // /ask 选中行引用：经 EXTRA_INSTRUCTIONS 注入（不进问题位置参数，故不污染回答 echo）。
+        referencedContext: req.tool === 'ask' ? req.referencedContext : undefined,
       });
       if (extraInstructions) env[extraInstructionsEnvKey(req.tool)] = extraInstructions;
       if (matchedRuleId) {

--- a/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
@@ -4,6 +4,11 @@ import type { LocalPrStatus, PrAgentStatus, StoredPullRequest } from '@meebox/sh
 import { ChatIcon, TrashIcon, ConfirmModal, PaneLoading } from '../../common';
 import { useChatRunStore } from '../../../stores/chat-run-store';
 import { useDraftsForPr } from '../../../stores/drafts-store';
+import {
+  formatReferencedContext,
+  selectionStore,
+  useDiffSelection,
+} from '../../../stores/selection-store';
 import { CHAT_MAX_WIDTH, CHAT_MIN_WIDTH } from './constants';
 import { useChatSession } from './hooks/useChatSession';
 import { useChatActions } from './hooks/useChatActions';
@@ -121,6 +126,12 @@ export function ChatPane({
 
   // M4 草稿池：从 main 进程拉本 PR 的草稿，跟 finding 通过 source 字段反查关联
   const drafts = useDraftsForPr(prLocalId);
+
+  // Diff 选区（归属当前 PR）：用于输入栏「N 行已选中」角标 + 把选中代码作为隐式上下文带进提问。
+  const { selection: diffSelection, ignored: selectionIgnored } = useDiffSelection(prLocalId);
+  // 未忽略时把选区拼成引用串；/ask 与自然语言提问共用。忽略 / 无选区 → undefined（本条不带引用）。
+  const referencedContext =
+    diffSelection && !selectionIgnored ? formatReferencedContext(diffSelection) : undefined;
 
   // 会话态 + 生命周期（切 PR 重载 / 流式步骤 / 分页 / 自动滚动）
   const session = useChatSession(prLocalId, myActiveIds);
@@ -319,14 +330,21 @@ export function ChatPane({
         // 队列模型下输入永远开启 (新提交进队列 / 并发执行)；runningTool 仅决定是否额外
         // 渲染 stop 按钮 (本 PR 有运行中 run 时可点终止)。多并发时 stop 终止最近一条。
         runningTool={myActiveRuns[myActiveRuns.length - 1]?.tool ?? null}
-        onRun={(tool, q) => void actions.handleRun(tool, q)}
-        onAgentAsk={(q) => void actions.handleAgentAsk(q)}
+        // referencedContext 仅 /ask 与自然语言提问携带选区引用（describe/review 不带）。
+        onRun={(tool, q) =>
+          void actions.handleRun(tool, q, tool === 'ask' ? referencedContext : undefined)
+        }
+        onAgentAsk={(q) => void actions.handleAgentAsk(q, referencedContext)}
         onCancel={hasMyActive || agentRunningHere ? actions.handleStopAll : undefined}
         onSetReviewStatus={onSetReviewStatus}
         // 一键自动评审：图标按钮置于 `/` 命令触发器右侧。runningHere=跑在当前 PR（高亮 / 运行中文案 +
         // 禁用重复发起）；其它 PR 在跑不禁用本 PR 的触发（可并发 / 排队）。
         agentRunningHere={agentRunningHere}
         onAgentReview={() => void actions.handleAgentReview()}
+        // Diff 选区角标：N 行已选中 / 点击切忽略；无选区时 null（不渲染）。
+        selectionLineCount={diffSelection?.lineCount ?? null}
+        selectionIgnored={selectionIgnored}
+        onToggleSelection={() => selectionStore.toggleIgnored()}
       />
 
       {showRulePreview && matchedRule && (

--- a/apps/desktop/src/renderer/src/components/features/chat/components/ChatInputBar.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/ChatInputBar.tsx
@@ -5,7 +5,7 @@ import type {
   ReviewRunTool,
   StoredPullRequest,
 } from '@meebox/shared';
-import { AutoReviewIcon, SendIcon, StopIcon } from '../../../common';
+import { AutoReviewIcon, EyeOffIcon, FileTreeIcon, SendIcon, StopIcon } from '../../../common';
 import { COMMANDS } from '../commands';
 import { useChatInput } from '../hooks/useChatInput';
 import { useTextareaAutosizeDrag } from '../hooks/useTextareaAutosizeDrag';
@@ -34,6 +34,15 @@ interface ChatInputBarProps {
   agentRunningHere: boolean;
   /** 触发一键自动评审微流程（describe→review→条件追问→总结）。 */
   onAgentReview: () => void;
+  /**
+   * 当前 Diff 选区行数；null = 无选区（不渲染选区角标）。角标位于 AutoReview 右侧，提示「N 行已选中」，
+   * 发送时把选中代码作为隐式上下文带进提问。
+   */
+  selectionLineCount: number | null;
+  /** 选区忽略态：true 时本条消息不带选区引用（角标置灰 + eye-slash）。 */
+  selectionIgnored: boolean;
+  /** 点击选区角标 → 切换忽略态。 */
+  onToggleSelection: () => void;
 }
 
 /**
@@ -54,6 +63,9 @@ export function ChatInputBar({
   onSetReviewStatus,
   agentRunningHere,
   onAgentReview,
+  selectionLineCount,
+  selectionIgnored,
+  onToggleSelection,
 }: ChatInputBarProps) {
   const { t } = useTranslation();
   const {
@@ -204,6 +216,26 @@ export function ChatInputBar({
             >
               <AutoReviewIcon />
             </button>
+          )}
+          {/* Diff 选区角标：竖线分隔后展示「N 行已选中」。点击切忽略态（eye-slash + 置灰）——忽略时
+              本条消息不带选区引用。选中代码以隐式上下文随提问发出，不进入会话气泡。 */}
+          {selectionLineCount !== null && (
+            <>
+              <span className="chat-cmd-divider" aria-hidden="true" />
+              <button
+                type="button"
+                className={`chat-selection-chip${selectionIgnored ? ' ignored' : ''}`}
+                onClick={onToggleSelection}
+                title={
+                  selectionIgnored
+                    ? t('chatPane.selection.ignoredTitle')
+                    : t('chatPane.selection.attachedTitle')
+                }
+              >
+                {selectionIgnored ? <EyeOffIcon /> : <FileTreeIcon />}
+                <span>{t('chatPane.selection.linesSelected', { lines: selectionLineCount })}</span>
+              </button>
+            </>
           )}
         </div>
         {/* 队列模型下 send 永远在 (新提交进队列)；本 PR active 时 stop 紧贴 send 左侧。

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
@@ -47,9 +47,13 @@ export interface ChatActions {
   runningPrs: Map<string, number>;
   /** 仅「跑在当前 PR」才在本会话显示运行态 / 思考中。 */
   agentRunningHere: boolean;
-  handleRun: (tool: ReviewRunTool, question?: string) => Promise<void>;
+  handleRun: (
+    tool: ReviewRunTool,
+    question?: string,
+    referencedContext?: string,
+  ) => Promise<void>;
   handleAgentReview: () => Promise<void>;
-  handleAgentAsk: (question: string) => Promise<void>;
+  handleAgentAsk: (question: string, referencedContext?: string) => Promise<void>;
   handleClearRuns: () => Promise<void>;
   handleCancel: (runId: string) => Promise<void>;
   handleStopAll: () => void;
@@ -93,7 +97,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
   // 触发 /describe / /review / /ask。队列模型下 active 非空也允许提交，新 run 进
   // 队列，main 端先后串行执行。失败抛 banner；成功不需要手动 setRuns，session effect
   // 会在 active 切换时自动 refresh
-  const handleRun = async (tool: ReviewRunTool, question?: string): Promise<void> => {
+  const handleRun = async (
+    tool: ReviewRunTool,
+    question?: string,
+    referencedContext?: string,
+  ): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured) return;
     // 去重（即时反馈）：同一 PR 同一工具已在执行 / 排队 → 阻止重复触发（main 端亦有
     // 权威校验兜底）。/ask 每次问题不同，不限制。
@@ -106,7 +114,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     }
     setError(null);
     try {
-      await invoke('pragent:run', { localId: pr.localId, tool, question });
+      await invoke('pragent:run', { localId: pr.localId, tool, question, referencedContext });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -142,7 +150,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
 
   // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。用户输入即时 optimistic 回显，
   // 收尾后以落盘对话（含用户 + 助手消息）整体对齐。
-  const handleAgentAsk = async (question: string): Promise<void> => {
+  const handleAgentAsk = async (question: string, referencedContext?: string): Promise<void> => {
     // 仅禁止对同一 PR 重复发起；其它 PR 在跑不阻塞（并发 / 排队）。
     if (!pr || !prAgent.available || !llmConfigured || runningPrs.has(pr.localId)) return;
     const startedId = pr.localId;
@@ -154,7 +162,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     ]);
     setRunningPrs((m) => new Map(m).set(startedId, Date.now()));
     try {
-      const session = await invoke('agent:ask', { localId: startedId, question });
+      const session = await invoke('agent:ask', { localId: startedId, question, referencedContext });
       await reloadConversation(startedId);
       if (currentPrIdRef.current === startedId && session.status === 'failed') {
         setError(session.terminationReason ?? t('chatPane.agent.failed'));

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
@@ -132,7 +132,7 @@ export function DiffView({
     triggerAutoEdit,
   });
   // 捕获 Diff 选区 → selectionStore，供 ChatPane 把选中代码作为隐式上下文带进 agent/ask 提问。
-  useSelectionCapture({ diffEditor, selected, prLocalId: pr.localId });
+  useSelectionCapture({ diffEditor, selected, prLocalId: pr.localId, renderSideBySide });
 
   // sidebar 模式：'tree' (文件树) / 'search' (跨文件搜索)，默认进文件树。PR 切换时回到 'tree'。
   const [sidebarMode, setSidebarMode] = useState<'tree' | 'search'>('tree');

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
@@ -27,6 +27,7 @@ import {
   useFileContent,
   useFileListWidth,
   useLineCommentAdder,
+  useSelectionCapture,
   useSyncProgress,
 } from './hooks';
 
@@ -130,6 +131,8 @@ export function DiffView({
     onNavConsumed,
     triggerAutoEdit,
   });
+  // 捕获 Diff 选区 → selectionStore，供 ChatPane 把选中代码作为隐式上下文带进 agent/ask 提问。
+  useSelectionCapture({ diffEditor, selected, prLocalId: pr.localId });
 
   // sidebar 模式：'tree' (文件树) / 'search' (跨文件搜索)，默认进文件树。PR 切换时回到 'tree'。
   const [sidebarMode, setSidebarMode] = useState<'tree' | 'search'>('tree');

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/index.ts
@@ -13,3 +13,4 @@ export { useCommentZones } from './useCommentZones';
 export { useDiffOverviewMarks } from './useDiffOverviewMarks';
 export { useDraftZones } from './useDraftZones';
 export { useLineCommentAdder } from './useLineCommentAdder';
+export { useSelectionCapture } from './useSelectionCapture';

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
@@ -11,18 +11,61 @@ const DEBOUNCE_MS = 120;
  * 监听内层两个子编辑器的 onDidChangeCursorSelection（modified=新/head、original=基线/old）；选区空
  * （塌缩成光标、无文本）→ clear，否则去抖 ~120ms 后写入。Monaco diff 子编辑器的行号即该侧显示文件
  * 行号，无需 hunk 映射。文件 / PR 切换或卸载时（依赖变更触发 cleanup）一并清空，避免陈旧选区残留。
+ *
+ * 刻意**不**接「可评论区域」守卫（useLineCommentAdder 的 isAllowed）：行内评论受平台 anchor 约束、
+ * 只能挂在 diff 命中行；而选区引用只作模型上下文、不回写远端，任意可选代码（含未改动上下文行）皆可
+ * 引用——恰恰这些上下文对提问最有用，不应被评论约束挡掉。
+ *
+ * 统一（inline）视图下，Monaco 经典 inline diff 把删除行渲染为 modified 编辑器内的 view-zone（非任何
+ * model 的文本行），original 编辑器宽度归 0 → 删除行无法被光标选中。为让删除内容也能「像添加行一样」被
+ * 引用：head 选区跨到删除/改动 hunk 时，据 getLineChanges() 把对应基线行从 original model 取出，作为
+ * removed 一并写入选区（见 spannedDeletions）。并排视图删除行可直接在 original 编辑器选中，故不做此增补。
  */
 export function useSelectionCapture(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
   selected: DiffChangedFile | null;
   prLocalId: string;
+  renderSideBySide: boolean;
 }): void {
-  const { diffEditor, selected, prLocalId } = opts;
+  const { diffEditor, selected, prLocalId, renderSideBySide } = opts;
   useEffect(() => {
     if (!diffEditor || !selected) return;
     const modified = diffEditor.getModifiedEditor();
     const original = diffEditor.getOriginalEditor();
     let timer: ReturnType<typeof setTimeout> | null = null;
+
+    // 统一视图：求 head 选区 [s,e] 跨到的删除/改动 hunk 的基线侧原始行（含真实代码）。
+    const spannedDeletions = (
+      s: number,
+      e: number,
+    ): { startLine: number; endLine: number; text: string } | undefined => {
+      const origModel = original.getModel();
+      if (!origModel) return undefined;
+      const segs: Array<{ oStart: number; oEnd: number }> = [];
+      for (const c of diffEditor.getLineChanges() ?? []) {
+        // 有删除/改动的基线行（纯新增 originalEndLineNumber===0 → 跳过）。
+        if (c.originalStartLineNumber <= 0 || c.originalEndLineNumber <= 0) continue;
+        const modStart = c.modifiedStartLineNumber;
+        const modEnd = c.modifiedEndLineNumber > 0 ? c.modifiedEndLineNumber : c.modifiedStartLineNumber;
+        // 该 hunk 在 modified 侧的落点与选区 [s,e] 有交叠 → 视为被选区跨到。
+        if (modEnd < s || modStart > e) continue;
+        segs.push({ oStart: c.originalStartLineNumber, oEnd: c.originalEndLineNumber });
+      }
+      if (segs.length === 0) return undefined;
+      const oStart = Math.min(...segs.map((x) => x.oStart));
+      const oEnd = Math.max(...segs.map((x) => x.oEnd));
+      const text = segs
+        .map((x) =>
+          origModel.getValueInRange({
+            startLineNumber: x.oStart,
+            startColumn: 1,
+            endLineNumber: x.oEnd,
+            endColumn: origModel.getLineMaxColumn(x.oEnd),
+          }),
+        )
+        .join('\n');
+      return { startLine: oStart, endLine: oEnd, text };
+    };
 
     const capture = (ed: MonacoEditor.ICodeEditor, side: 'old' | 'new'): void => {
       const sel = ed.getSelection();
@@ -38,6 +81,9 @@ export function useSelectionCapture(opts: {
           ? sel.endLineNumber - 1
           : sel.endLineNumber;
       const startLine = sel.startLineNumber;
+      // 统一视图 + head 选区：增补跨到的基线删除行（并排视图删除行可直接选中，不增补）。
+      const removed =
+        side === 'new' && !renderSideBySide ? spannedDeletions(startLine, endLine) : undefined;
       selectionStore.set({
         prLocalId,
         path: side === 'old' ? (selected.oldPath ?? selected.path) : selected.path,
@@ -46,6 +92,7 @@ export function useSelectionCapture(opts: {
         endLine,
         lineCount: endLine - startLine + 1,
         text: model.getValueInRange(sel),
+        removed,
       });
     };
 
@@ -63,5 +110,5 @@ export function useSelectionCapture(opts: {
       for (const d of disposables) d.dispose();
       selectionStore.clear();
     };
-  }, [diffEditor, selected, prLocalId]);
+  }, [diffEditor, selected, prLocalId, renderSideBySide]);
 }

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { type editor as MonacoEditor } from 'monaco-editor';
+import type { DiffChangedFile } from '@meebox/ipc';
+import { selectionStore } from '../../../../../../stores/selection-store';
+
+const DEBOUNCE_MS = 120;
+
+/**
+ * 捕获 Diff 里的代码选区 → 写入 selectionStore，供 ChatPane 把选中代码作为隐式上下文带进提问。
+ *
+ * 监听内层两个子编辑器的 onDidChangeCursorSelection（modified=新/head、original=基线/old）；选区空
+ * （塌缩成光标、无文本）→ clear，否则去抖 ~120ms 后写入。Monaco diff 子编辑器的行号即该侧显示文件
+ * 行号，无需 hunk 映射。文件 / PR 切换或卸载时（依赖变更触发 cleanup）一并清空，避免陈旧选区残留。
+ */
+export function useSelectionCapture(opts: {
+  diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
+  selected: DiffChangedFile | null;
+  prLocalId: string;
+}): void {
+  const { diffEditor, selected, prLocalId } = opts;
+  useEffect(() => {
+    if (!diffEditor || !selected) return;
+    const modified = diffEditor.getModifiedEditor();
+    const original = diffEditor.getOriginalEditor();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const capture = (ed: MonacoEditor.ICodeEditor, side: 'old' | 'new'): void => {
+      const sel = ed.getSelection();
+      const model = ed.getModel();
+      // 空选区（光标塌缩、无选中文本）→ 清空。
+      if (!sel || !model || (sel.startLineNumber === sel.endLineNumber && sel.startColumn === sel.endColumn)) {
+        selectionStore.clear();
+        return;
+      }
+      // 选到下一行行首（endColumn===1）时该行无实际文本，不计入行数。
+      const endLine =
+        sel.endColumn === 1 && sel.endLineNumber > sel.startLineNumber
+          ? sel.endLineNumber - 1
+          : sel.endLineNumber;
+      const startLine = sel.startLineNumber;
+      selectionStore.set({
+        prLocalId,
+        path: side === 'old' ? (selected.oldPath ?? selected.path) : selected.path,
+        side,
+        startLine,
+        endLine,
+        lineCount: endLine - startLine + 1,
+        text: model.getValueInRange(sel),
+      });
+    };
+
+    const onChange = (ed: MonacoEditor.ICodeEditor, side: 'old' | 'new'): void => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => capture(ed, side), DEBOUNCE_MS);
+    };
+
+    const disposables = [
+      modified.onDidChangeCursorSelection(() => onChange(modified, 'new')),
+      original.onDidChangeCursorSelection(() => onChange(original, 'old')),
+    ];
+    return () => {
+      if (timer) clearTimeout(timer);
+      for (const d of disposables) d.dispose();
+      selectionStore.clear();
+    };
+  }, [diffEditor, selected, prLocalId]);
+}

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -135,6 +135,11 @@
     "sectionSummary": "Zusammenfassung",
     "sectionTitle": "Titelvorschlag",
     "sectionWalkthrough": "Dateiänderungen",
+    "selection": {
+      "attachedTitle": "Ausgewählte Zeilen an die nächste Frage angehängt – zum Ignorieren klicken",
+      "ignoredTitle": "Ausgewählte Zeilen ignoriert – zum Anhängen an die nächste Frage klicken",
+      "linesSelected": "{{lines}} Zeilen ausgewählt"
+    },
     "sendAria": "Senden",
     "sendQueuedTitle": "Senden (neue Aufgabe wird eingereiht)",
     "sendTitle": "Senden (Enter)",

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -135,6 +135,11 @@
     "sectionSummary": "Summary",
     "sectionTitle": "Suggested title",
     "sectionWalkthrough": "File changes",
+    "selection": {
+      "attachedTitle": "Selected lines attached to your next question — click to ignore",
+      "ignoredTitle": "Selected lines ignored — click to attach to your next question",
+      "linesSelected": "{{lines}} lines selected"
+    },
     "sendAria": "Send",
     "sendQueuedTitle": "Send (new task will be queued)",
     "sendTitle": "Send (Enter)",

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -135,6 +135,11 @@
     "sectionSummary": "まとめ",
     "sectionTitle": "タイトル候補",
     "sectionWalkthrough": "ファイル変更",
+    "selection": {
+      "attachedTitle": "選択行を次の質問に添付 — クリックで無視",
+      "ignoredTitle": "選択行を無視中 — クリックで次の質問に添付",
+      "linesSelected": "{{lines}} 行を選択中"
+    },
     "sendAria": "送信",
     "sendQueuedTitle": "送信（新しいタスクはキューに入ります）",
     "sendTitle": "送信 (Enter)",

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -135,6 +135,11 @@
     "sectionSummary": "总结",
     "sectionTitle": "建议标题",
     "sectionWalkthrough": "文件变更",
+    "selection": {
+      "attachedTitle": "选中行将随下一次提问发送 — 点击忽略",
+      "ignoredTitle": "已忽略选中行 — 点击随下一次提问发送",
+      "linesSelected": "已选中 {{lines}} 行"
+    },
     "sendAria": "发送",
     "sendQueuedTitle": "发送 (新任务会进队列)",
     "sendTitle": "发送 (Enter)",

--- a/apps/desktop/src/renderer/src/stores/selection-store.ts
+++ b/apps/desktop/src/renderer/src/stores/selection-store.ts
@@ -21,10 +21,16 @@ export interface DiffSelection {
   /** 起止行（含两端，1 基，即该侧显示文件行号）。 */
   startLine: number;
   endLine: number;
-  /** 行数（endLine - startLine + 1）。 */
+  /** 行数（endLine - startLine + 1）。指 head/old 主选区的行数，不含下方 removed 附带行。 */
   lineCount: number;
   /** 选中文本快照（选区产生时即取，发送时直接用，无需回查 model）。 */
   text: string;
+  /**
+   * 内联（统一）视图专属：head 选区跨到的删除/改动 hunk 的**基线侧**原始行（含真实代码）。统一视图下
+   * 删除行是 Monaco view-zone、无法被光标选中，故据 getLineChanges() 映射、从 original model 取出，与
+   * 所选 head 行一并引用——让删除内容也能「像添加行一样」被引用。side==='new' 且非并排视图时可能有。
+   */
+  removed?: { startLine: number; endLine: number; text: string };
 }
 
 interface SelectionStoreState {
@@ -82,18 +88,38 @@ export function useDiffSelection(prLocalId: string | null | undefined): {
   return snap;
 }
 
+/** 行范围标签：单行 `Lx`，多行 `Lx-Ly`。 */
+function rangeLabel(startLine: number, endLine: number): string {
+  return startLine === endLine
+    ? `L${String(startLine)}`
+    : `L${String(startLine)}-L${String(endLine)}`;
+}
+
 /**
  * 把选区拼成自描述的引用块（路径 + 行范围 + 侧 + 代码围栏），渲染层拼一次作为 referencedContext 发出。
  * 两条注入路径（pragent /ask 与 planner）共用此串。用四个反引号围栏，避免选中代码内含三反引号时破栏。
+ *
+ * 内联视图带 removed 时分两块列出：所选 head 行 + 跨到的基线删除行，让删除内容也能被引用。
  */
 export function formatReferencedContext(sel: DiffSelection): string {
   const sideLabel = sel.side === 'old' ? 'base' : 'head';
-  const range =
-    sel.startLine === sel.endLine
-      ? `L${String(sel.startLine)}`
-      : `L${String(sel.startLine)}-L${String(sel.endLine)}`;
+  if (sel.removed) {
+    return [
+      `The user has selected a region in \`${sel.path}\` and is asking about it.`,
+      '',
+      `Selected lines (${rangeLabel(sel.startLine, sel.endLine)}, head side):`,
+      '````',
+      sel.text,
+      '````',
+      '',
+      `Removed lines spanned by the selection (${rangeLabel(sel.removed.startLine, sel.removed.endLine)}, base side):`,
+      '````',
+      sel.removed.text,
+      '````',
+    ].join('\n');
+  }
   return [
-    `The user has selected these lines from \`${sel.path}\` (${range}, ${sideLabel} side) and is asking about them:`,
+    `The user has selected these lines from \`${sel.path}\` (${rangeLabel(sel.startLine, sel.endLine)}, ${sideLabel} side) and is asking about them:`,
     '',
     '````',
     sel.text,

--- a/apps/desktop/src/renderer/src/stores/selection-store.ts
+++ b/apps/desktop/src/renderer/src/stores/selection-store.ts
@@ -1,0 +1,102 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * 跨组件共享的「Diff 选区」池（渲染层内部态，不走 IPC）。DiffView 在用户于 Diff 里选中代码时写入，
+ * ChatPane / ChatInputBar 读出，用于把选中代码作为**隐式上下文**带进 agent/ask 提问。
+ *
+ * 数据流：
+ *   DiffView 监听 Monaco onDidChangeCursorSelection → set(选区) / clear() →
+ *   notify → useDiffSelection 重渲染 → 输入栏角标更新 →
+ *   发送时（未忽略）formatReferencedContext(选区) → 作为 referencedContext 发给 main
+ *
+ * 与 drafts-store 同模（模块级状态 + Set<subscriber> + useSyncExternalStore），但纯本地、无 hydrate。
+ */
+export interface DiffSelection {
+  /** 选区归属 PR（防跨 PR 串台：useDiffSelection 不匹配当前 PR 时对外呈 null）。 */
+  prLocalId: string;
+  /** 文件路径（head 侧用新路径，old 侧用基线路径）。 */
+  path: string;
+  /** 选区所在 Diff 子编辑器：old=基线(original) / new=变更(modified)。 */
+  side: 'old' | 'new';
+  /** 起止行（含两端，1 基，即该侧显示文件行号）。 */
+  startLine: number;
+  endLine: number;
+  /** 行数（endLine - startLine + 1）。 */
+  lineCount: number;
+  /** 选中文本快照（选区产生时即取，发送时直接用，无需回查 model）。 */
+  text: string;
+}
+
+interface SelectionStoreState {
+  selection: DiffSelection | null;
+  /** 忽略态：用户点角标切到「不附带」，本条消息不带选区引用（角标仍显示，置灰 + eye-slash）。 */
+  ignored: boolean;
+}
+
+let state: SelectionStoreState = { selection: null, ignored: false };
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const cb of subscribers) cb();
+}
+
+export const selectionStore = {
+  getSnapshot: (): SelectionStoreState => state,
+  subscribe: (cb: () => void): (() => void) => {
+    subscribers.add(cb);
+    return () => {
+      subscribers.delete(cb);
+    };
+  },
+  /** 写入新选区。每次新选区默认「附带」（ignored 复位为 false）。 */
+  set: (selection: DiffSelection): void => {
+    state = { selection, ignored: false };
+    notify();
+  },
+  /** 清空选区（选区塌缩 / 切 PR / 文件切换）。 */
+  clear: (): void => {
+    if (state.selection === null && !state.ignored) return;
+    state = { selection: null, ignored: false };
+    notify();
+  },
+  /** 切换忽略态（角标点击）。 */
+  toggleIgnored: (): void => {
+    if (!state.selection) return;
+    state = { ...state, ignored: !state.ignored };
+    notify();
+  },
+};
+
+/**
+ * 读取「归属当前 PR」的选区快照。选区 prLocalId 与传入不符（切到别的 PR / 无 PR）→ 返回 null 选区，
+ * 避免把别 PR 的选区误带进本会话。
+ */
+export function useDiffSelection(prLocalId: string | null | undefined): {
+  selection: DiffSelection | null;
+  ignored: boolean;
+} {
+  const snap = useSyncExternalStore(selectionStore.subscribe, selectionStore.getSnapshot);
+  if (!prLocalId || snap.selection?.prLocalId !== prLocalId) {
+    return { selection: null, ignored: false };
+  }
+  return snap;
+}
+
+/**
+ * 把选区拼成自描述的引用块（路径 + 行范围 + 侧 + 代码围栏），渲染层拼一次作为 referencedContext 发出。
+ * 两条注入路径（pragent /ask 与 planner）共用此串。用四个反引号围栏，避免选中代码内含三反引号时破栏。
+ */
+export function formatReferencedContext(sel: DiffSelection): string {
+  const sideLabel = sel.side === 'old' ? 'base' : 'head';
+  const range =
+    sel.startLine === sel.endLine
+      ? `L${String(sel.startLine)}`
+      : `L${String(sel.startLine)}-L${String(sel.endLine)}`;
+  return [
+    `The user has selected these lines from \`${sel.path}\` (${range}, ${sideLabel} side) and is asking about them:`,
+    '',
+    '````',
+    sel.text,
+    '````',
+  ].join('\n');
+}

--- a/apps/desktop/src/renderer/src/styles/features/chat/pane.scss
+++ b/apps/desktop/src/renderer/src/styles/features/chat/pane.scss
@@ -245,6 +245,53 @@
   }
 }
 
+// AutoReview 与「选区角标」之间的竖线分隔：居中、定高（略低于按钮，不顶满）；
+// 额外左间距，与左侧按钮拉开（在组 gap 基础上再加）。
+.chat-cmd-divider {
+  width: 1px;
+  height: 18px;
+  align-self: center;
+  flex-shrink: 0;
+  margin-left: $space-2;
+  background: $border-default;
+}
+
+// Diff 选区角标：图标 + 「N 行已选中」。点击切忽略态——忽略时置灰 + 删除线 + eye-slash 图标。
+.chat-selection-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: $space-2;
+  max-width: 180px;
+  padding: $space-2 $space-2;
+  background: transparent;
+  border: none;
+  border-radius: $radius-sm;
+  color: $text-muted;
+  font-size: $fs-md;
+  line-height: 1;
+  cursor: pointer;
+
+  svg {
+    flex-shrink: 0;
+  }
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  &:hover {
+    background: $bg-hover;
+    color: $text-primary;
+  }
+  &.ignored {
+    opacity: 0.55;
+
+    span {
+      text-decoration: line-through;
+    }
+  }
+}
+
 // `/` 按钮弹出的菜单：在按钮正上方展开
 .chat-cmd-menu {
   @include popover;

--- a/packages/agent/src/planner.ts
+++ b/packages/agent/src/planner.ts
@@ -56,6 +56,11 @@ export interface PlanningInput {
    * Agent 跨轮记住此前交流；**绝不**透传给 pr-agent 工具（工具只看 PR + 当轮问题）。
    */
   history?: AgentMessage[];
+  /**
+   * 用户在 Diff 里选中的代码引用（自描述块）。注入当轮规划上下文，让 Agent 知道用户正盯着哪段代码；
+   * **绝不**透传给 pr-agent 工具（同 history 约束）。省略 = 本轮无选区引用。
+   */
+  referencedContext?: string;
   /** 步数上限（默认 8）。 */
   maxSteps?: number;
 }
@@ -276,6 +281,9 @@ export async function runPlanningAgent(
         ? `Conversation so far (your context only — NEVER pass any of it to tools):\n${convo}\n`
         : '',
       `User request: ${input.userRequest}`,
+      input.referencedContext
+        ? `\nReferenced selection (your context only — NEVER pass any of it to tools):\n${input.referencedContext}`
+        : '',
       history.length ? `\nProgress so far:\n${history.join('\n')}` : '',
       '\nReply with the next JSON action.',
     ]

--- a/packages/ipc/src/agent.ts
+++ b/packages/ipc/src/agent.ts
@@ -39,7 +39,11 @@ export interface AgentChannels {
    * agent:stepProgress 推送；返回收尾会话（summary = Agent 最终回答）。
    */
   'agent:ask': {
-    request: { localId: string; question: string };
+    /**
+     * referencedContext：用户在 Diff 里选中的代码片段（含路径 + 行范围 + 代码），作为**隐式上下文**
+     * 注入规划 LLM 的当轮提示，不进入持久化的用户消息正文。省略 = 本轮不带选区引用。
+     */
+    request: { localId: string; question: string; referencedContext?: string };
     response: AgentSession;
   };
   /** 暂停当前 PR 的 Agent 运行（abort）；会话置 paused、保态。 */
@@ -77,8 +81,15 @@ export interface AgentChannels {
     /**
      * tool='ask' 时 question 必填，作为 pr-agent CLI 的位置参数传给 ask 子命令。
      * tool='describe'/'review' 时 question 字段被忽略。
+     * referencedContext：用户在 Diff 里选中的代码片段（隐式上下文），仅 tool='ask' 时生效——经
+     * EXTRA_INSTRUCTIONS 注入，不进入问题位置参数（故不污染回答 echo / 会话气泡）。
      */
-    request: { localId: string; tool: ReviewRunTool; question?: string };
+    request: {
+      localId: string;
+      tool: ReviewRunTool;
+      question?: string;
+      referencedContext?: string;
+    };
     response: ReviewRun;
   };
   /**


### PR DESCRIPTION
## 背景

在 Diff 里选中代码后，没法把这段代码直接带进聊天提问——`/ask` 与自然语言提问发给模型时只有问题文本，模型看不到用户正盯着的那几行。本 PR 新增「选中即引用」：选中后聊天输入栏出现角标，发送时把选中代码作为**隐式上下文**注入模型，不进会话气泡、不落盘。对齐 Claude Code「attach selected text」交互。

## 改动

- **角标 UI**：聊天输入栏 AutoReview 按钮右侧（竖线分隔）出现「N 行已选中」角标；点击切「忽略」态（eye-slash + 置灰），忽略时本条消息不带引用。角标实时反映当前 Diff 选区，切 PR / 选区塌缩即清。
- **隐式上下文递送**：`agent:ask` / `pragent:run` 增可选 `referencedContext`；`/ask` 经 `buildExtraInstructions`（EXTRA_INSTRUCTIONS）注入，自然语言经 planner 当轮提示注入并约束「不透传给工具」。会话气泡 / 落盘用户消息保持纯问题文本。
- **不受可评论区域限制**：引用只作模型上下文、不回写远端，故未改动的上下文行同样可引用（与行内评论的 `isAllowed` 约束区分）。
- **统一视图删除行**：inline 视图下删除行是 Monaco view-zone、无法被光标选中；head 选区跨到删除 / 改动 hunk 时，据 `getLineChanges()` 从 original model 取出真实基线代码一并引用（删除内容也能像添加行一样被引用）。并排视图删除行可直接选中。
- 新增渲染层 `selection-store`（useSyncExternalStore）+ `useSelectionCapture`（Monaco 选区捕获，去抖）；i18n 四语言 `chatPane.selection`；SCSS `chat-cmd-divider` / `chat-selection-chip`。

## 验证

`lint` / `typecheck` / `test`（agent + pr-agent-bridge）、`build desktop`、四语言 locale 解析、`prepare:pragent` 冒烟全绿；已合入最新 `dev`（#89）并复跑全部门。

🤖 Generated with [Claude Code](https://claude.com/claude-code)