### PR TITLE
refactor(desktop): PR 上下文注入的结构标签改用英语

### DIFF
--- a/apps/desktop/src/main/utils/pr-context.ts
+++ b/apps/desktop/src/main/utils/pr-context.ts
@@ -35,11 +35,11 @@ export async function buildPrContext({
 }: BuildPrContextOpts): Promise<string> {
   const sections: string[] = [];
 
-  sections.push(`**标题**: ${pr.title}`);
+  sections.push(`**Title**: ${pr.title}`);
 
   const desc = pr.description.trim();
   if (desc) {
-    sections.push(`**描述**:\n${desc}`);
+    sections.push(`**Description**:\n${desc}`);
   }
 
   let comments: PrComment[] = [];
@@ -57,7 +57,7 @@ export async function buildPrContext({
   const formatted = formatComments(comments, maxComments, maxCommentLen);
   if (formatted.length > 0) {
     sections.push(
-      `**已有评论** (${String(formatted.length)} 条，最新在前):\n${formatted.join('\n')}`,
+      `**Existing comments** (${String(formatted.length)}, newest first):\n${formatted.join('\n')}`,
     );
   }
 
@@ -66,7 +66,7 @@ export async function buildPrContext({
   if (sections.length === 1 && !desc && comments.length === 0) {
     return '';
   }
-  return `## PR 上下文\n\n${sections.join('\n\n')}`;
+  return `## PR context\n\n${sections.join('\n\n')}`;
 }
 
 /**


### PR DESCRIPTION
`buildPrContext` 拼给 pr-agent `EXTRA_INSTRUCTIONS` 的结构标签是**提示词文本**，不应硬编码中文——响应语言由 `CONFIG__RESPONSE_LANGUAGE` / 语言指令单独控制，且 bridge 其余提示指令（anchor marker / 排版等）本就是英语。

标题 / 描述 / 已有评论 / PR 上下文标题 → `Title` / `Description` / `Existing comments` / `PR context`。代码注释保持中文不变；行为不变，desktop typecheck/lint/build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)