### PR TITLE
refactor(desktop): agent 编排域归入 services/agent + orchestrator 拆 flows

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -3,7 +3,7 @@ import * as agent from './controllers/agent.js';
 import * as app from './controllers/app.js';
 import * as config from './controllers/config.js';
 import * as pr from './controllers/pr.js';
-import { AgentOrchestratorService } from './services/agent-orchestrator.js';
+import { Orchestrator } from './services/agent/index.js';
 import {
   createServiceContext,
   setControllerContext,
@@ -30,7 +30,7 @@ export function registerIpcHandlers(deps: RegisterDeps): {
   // run 队列：pragent:run（PR 域）、Agent 编排、AutoPilot 三方共用。
   const runQueue = new RunQueue(base);
   // Agent 编排：复用 run 队列派发工具 run（agent 低优先级泳道）。
-  const orchestrator = new AgentOrchestratorService(base, runQueue);
+  const orchestrator = new Orchestrator(base, runQueue);
   // controller 层统一上下文：基础上下文 + 两个跨域 service，安装为进程级单例（controller 经 getContext() 取用）。
   const ctx: ControllerContext = { ...base, runQueue, orchestrator };
   setControllerContext(ctx);

--- a/apps/desktop/src/main/services/agent/flows/autopilot.ts
+++ b/apps/desktop/src/main/services/agent/flows/autopilot.ts
@@ -1,0 +1,107 @@
+import { judgeAutopilotBatch, loadAgentContext } from '@meebox/agent';
+import {
+  getAutopilotLedger,
+  hasReviewOutput,
+  listStoredPullRequests,
+  writeAutopilotLedger,
+} from '@meebox/poller';
+import type { StoredPullRequest } from '@meebox/shared';
+import type { OrchestratorRuntime } from '../runtime.js';
+import { runReviewForPr } from './review.js';
+
+/**
+ * 跑一遍 AutoPilot pass（busy 锁置位 / 复位包住全程）。仅由 Orchestrator.runAutopilotIfDue 通过准入后触发。
+ * 候选准入（硬性门控，自上而下）：① 仅「待我评审 + 待处理」；② 已有 describe/review 产出（成功 / 进行中）
+ * → 已评审过 / 评审中，排除；③ 本版本已被判 skip 的台账去重。再按 batch_size 截断，批量判定后并行编排评审。
+ */
+export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void> {
+  const { bootstrap, stateStore, effectiveAgentDir, logger } = runtime.ctx;
+  const ap = bootstrap.config.agent.autopilot;
+  runtime.setAutopilotBusy(true);
+  try {
+    const prs = await listStoredPullRequests(stateStore);
+    const candidates: StoredPullRequest[] = [];
+    // 准入漏斗计数（用于 0 候选时定位卡在哪一道闸——便于排查「为何不再触发」）。
+    let reviewReqPending = 0; // 命中「待我评审 + 待处理」
+    let alreadyReviewed = 0; // 其中已有 describe/review 产出（成功 / 进行中）而被排除
+    let skipDeduped = 0; // 其中本版本已被判定跳过而被排除
+    for (const pr of prs) {
+      if (candidates.length >= ap.batch_size) break;
+      if (!pr.discoveryFilters.includes('review-requested')) continue;
+      if (pr.localStatus !== 'pending') continue;
+      reviewReqPending++;
+      if (await hasReviewOutput(stateStore, pr.localId)) {
+        alreadyReviewed++;
+        continue;
+      }
+      const ledger = await getAutopilotLedger(stateStore, pr.localId);
+      if (ledger?.decision === 'skipped' && ledger.autoReviewedUpdatedAt === pr.updatedAt) {
+        skipDeduped++;
+        continue;
+      }
+      candidates.push(pr);
+    }
+    if (candidates.length === 0) {
+      // 仍在按周期评估，只是当前无新合格 PR——把漏斗计数打出来，避免被误读成「没在跑」。
+      logger.info(
+        { total: prs.length, reviewReqPending, alreadyReviewed, skipDeduped },
+        'autopilot pass: no eligible candidates',
+      );
+      return;
+    }
+
+    const agentContext = await loadAgentContext(effectiveAgentDir(), {
+      onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
+    });
+    await runtime.withAgentChat(async (chat) => {
+      // 批量判定（例外规则来自 AGENTS.md）。
+      const { decisions } = await judgeAutopilotBatch(chat, {
+        candidates: candidates.map((p) => ({
+          prLocalId: p.localId,
+          title: p.title,
+          description: p.description,
+        })),
+        agentsRules: agentContext.files.agents,
+      });
+      const byId = new Map(candidates.map((p) => [p.localId, p] as const));
+      // 先落「跳过」决策（无工具开销，顺序写盘即可）；收集「评审」决策待并行编排。
+      const toReview: StoredPullRequest[] = [];
+      for (const d of decisions) {
+        const pr = byId.get(d.prLocalId);
+        if (!pr) continue;
+        if (!d.review) {
+          // 候选都已过准入闸、非「已评审」，故这里的原因都是 LLM 的领域判定（如分支合并 / 纯依赖升级）。
+          logger.info({ prLocalId: pr.localId, reason: d.reason }, 'autopilot judge skip');
+          await writeAutopilotLedger(stateStore, {
+            prLocalId: pr.localId,
+            autoReviewedUpdatedAt: pr.updatedAt,
+            decision: 'skipped',
+            reason: d.reason,
+            at: new Date().toISOString(),
+          });
+          continue;
+        }
+        toReview.push(pr);
+      }
+      // 多 PR 评审并行编排：各编排 await 自己的工具 run 时彼此不挡，让 run-queue 并发尽量被填满。
+      await Promise.all(
+        toReview.map(async (pr) => {
+          // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
+          runtime.markRunning(pr.localId);
+          try {
+            const session = await runReviewForPr(runtime,pr, agentContext, chat, undefined, true);
+            // done：落「评审总结」消息 + 台账（含 verdict）+ 广播（与手动评审一致）。失败 / 暂停不落台账。
+            await runtime.recordReviewSummaryMessage(pr, session);
+          } finally {
+            runtime.unmarkRunning(pr.localId);
+          }
+        }),
+      );
+    });
+    logger.info({ candidates: candidates.length }, 'autopilot pass done');
+  } catch (err) {
+    logger.warn({ err }, 'autopilot pass failed (ignored)');
+  } finally {
+    runtime.setAutopilotBusy(false);
+  }
+}

--- a/apps/desktop/src/main/services/agent/flows/planning.ts
+++ b/apps/desktop/src/main/services/agent/flows/planning.ts
@@ -1,0 +1,107 @@
+import { appendAgentNotes, buildToolCatalog, loadAgentContext } from '@meebox/agent';
+import type { AgentContext } from '@meebox/agent';
+import { appendAgentMessage, updateAgentSession } from '@meebox/poller';
+import { pickMatchingRule } from '@meebox/rules';
+import type { AgentSession, StoredPullRequest } from '@meebox/shared';
+import { getMainLanguage, t } from '../../../i18n/index.js';
+import { runPlanning } from '../planning.js';
+import type { AgentChat, OrchestratorRuntime } from '../runtime.js';
+
+/** 自由规划编排（agent:ask）：现读现装配上下文 + 注册 AbortController + 标记执行中，跑规划 ReAct。 */
+export async function planningFlow(
+  runtime: OrchestratorRuntime,
+  pr: StoredPullRequest,
+  question: string,
+  referencedContext?: string,
+): Promise<AgentSession> {
+  const { getPrAgentBridge, effectiveAgentDir, logger } = runtime.ctx;
+  if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
+  const agentContext = await loadAgentContext(effectiveAgentDir(), {
+    onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
+  });
+  const ac = new AbortController();
+  runtime.registerController(pr.localId, ac);
+  runtime.markRunning(pr.localId);
+  // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
+  logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
+  try {
+    const session = await runtime.withAgentChat(
+      (chat) => runPlanningForPr(runtime,pr, question, agentContext, chat, ac.signal, referencedContext),
+      ac.signal,
+    );
+    logger.info(
+      {
+        prLocalId: pr.localId,
+        status: session.status,
+        steps: session.stepCount,
+        terminationReason: session.terminationReason,
+      },
+      'agent chat done',
+    );
+    return session;
+  } finally {
+    runtime.clearController(pr.localId);
+    runtime.unmarkRunning(pr.localId);
+  }
+}
+
+/** 对一个 PR 跑自由规划（组装 PlanningDeps + 调 runner）：含中途输入 drain、计划持久化、主动记忆落盘。 */
+export function runPlanningForPr(
+  runtime: OrchestratorRuntime,
+  pr: StoredPullRequest,
+  userRequest: string,
+  agentContext: AgentContext,
+  chat: AgentChat,
+  signal: AbortSignal,
+  referencedContext?: string,
+): Promise<AgentSession> {
+  const { bootstrap, effectiveAgentDir, logger } = runtime.ctx;
+  const agentCfg = bootstrap.config.agent;
+  const matchedRule = pickMatchingRule(agentContext.rules, {
+    projectKey: pr.repo.projectKey,
+    repoSlug: pr.repo.repoSlug,
+    targetBranch: pr.targetRef.displayId,
+    tool: 'review',
+  });
+  return runPlanning(pr, userRequest, {
+    stateStore: runtime.ctx.stateStore,
+    enqueueRun: (p, tool, question) => runtime.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
+    referencedContext,
+    chat,
+    agentContext,
+    toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
+    matchedRule,
+    language: getMainLanguage(),
+    maxSteps: agentCfg.max_steps,
+    signal,
+    onStep: (sessionId, step) => runtime.emitStep(pr, sessionId, step),
+    // 中途输入转向：planner 每轮取出排队消息时在此落盘进会话 + 广播刷新（即时显示为用户气泡），
+    // planner 再把它们并入当轮 progress、据最新指令重排下一步。
+    drainPendingInput: async () => {
+      const msgs = runtime.takePending(pr.localId);
+      for (const m of msgs) {
+        await appendAgentMessage(runtime.ctx.stateStore, pr.localId, { role: 'user', content: m });
+      }
+      if (msgs.length) runtime.ctx.broadcast('agent:conversationChanged', { prLocalId: pr.localId });
+      return msgs;
+    },
+    // 计划（todo）更新：planner 给出 plan 即持久化进会话 + 广播刷新计划面板；切 PR / 重启经
+    // agent:getSession 水合。
+    recordPlan: async (todo) => {
+      await updateAgentSession(runtime.ctx.stateStore, pr.localId, { todo });
+      runtime.ctx.broadcast('agent:planUpdated', { prLocalId: pr.localId, todo });
+    },
+    // 持久化 Agent 主动记下的非隐私条目到当前 Agent 目录的各可写文件（USER/MEMORY/AGENTS）；
+    // SOUL.md 永不写。下一轮 loadAgentContext 现读即生效（跨会话记忆）。
+    recordMemory: async (notes) => {
+      const dir = effectiveAgentDir();
+      for (const kind of ['user', 'memory', 'agents'] as const) {
+        const added = await appendAgentNotes(dir, kind, notes[kind]).catch((err: unknown) => {
+          logger.warn({ err, kind }, 'record agent memory failed');
+          return [] as string[];
+        });
+        if (added.length) logger.info({ kind, added }, 'agent memory recorded');
+      }
+    },
+  });
+}

--- a/apps/desktop/src/main/services/agent/flows/review.ts
+++ b/apps/desktop/src/main/services/agent/flows/review.ts
@@ -1,0 +1,90 @@
+import { buildToolCatalog, loadAgentContext } from '@meebox/agent';
+import type { AgentContext } from '@meebox/agent';
+import { pickMatchingRule } from '@meebox/rules';
+import type { AgentSession, StoredPullRequest } from '@meebox/shared';
+import { getMainLanguage, t } from '../../../i18n/index.js';
+import { runReview } from '../review.js';
+import type { AgentChat, OrchestratorRuntime } from '../runtime.js';
+import { planningFlow } from './planning.js';
+
+/**
+ * 手动评审编排（agent:run）：现读现装配上下文 + 注册 AbortController + 标记执行中，跑评审微流程，收尾把
+ * 「评审总结」落多轮对话与台账。评审微流程是固定模板、无法中途转向：跑完后把运行期间排队的用户消息作为
+ * 一轮自由规划接续处理（fire-and-forget，本次评审会话照常返回）。
+ */
+export async function reviewFlow(
+  runtime: OrchestratorRuntime,
+  pr: StoredPullRequest,
+): Promise<AgentSession> {
+  const { getPrAgentBridge, effectiveAgentDir, logger } = runtime.ctx;
+  if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
+  // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存。
+  const agentContext = await loadAgentContext(effectiveAgentDir(), {
+    onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
+  });
+  // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
+  const ac = new AbortController();
+  runtime.registerController(pr.localId, ac);
+  runtime.markRunning(pr.localId);
+  logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
+  let session: AgentSession;
+  try {
+    session = await runtime.withAgentChat(
+      (chat) => runReviewForPr(runtime,pr, agentContext, chat, ac.signal),
+      ac.signal,
+    );
+    logger.info(
+      { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
+      'agent review done',
+    );
+    // 收尾总结计入多轮对话（assistant 评审消息）→ UI 渲染「评审总结」卡片。
+    await runtime.recordReviewSummaryMessage(pr, session);
+  } finally {
+    runtime.clearController(pr.localId);
+    runtime.unmarkRunning(pr.localId);
+  }
+  // 评审微流程无法中途转向：跑完后把排队的用户消息作为一轮自由规划接续处理（fire-and-forget）。
+  const pending = runtime.takePending(pr.localId);
+  if (pending.length) {
+    void planningFlow(runtime,pr, pending.join('\n\n')).catch((err: unknown) => {
+      logger.warn({ err, prLocalId: pr.localId }, 'post-review planning (queued input) failed');
+    });
+  }
+  return session;
+}
+
+/**
+ * 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。手动评审与 AutoPilot 背景评审共用。
+ * 编排派发的 run 走 agent 低优先级泳道；修改类工具按 grants 门控（红线见 buildToolCatalog）。
+ */
+export function runReviewForPr(
+  runtime: OrchestratorRuntime,
+  pr: StoredPullRequest,
+  agentContext: AgentContext,
+  chat: AgentChat,
+  signal?: AbortSignal,
+  autopilot = false,
+): Promise<AgentSession> {
+  const agentCfg = runtime.ctx.bootstrap.config.agent;
+  const matchedRule = pickMatchingRule(agentContext.rules, {
+    projectKey: pr.repo.projectKey,
+    repoSlug: pr.repo.repoSlug,
+    targetBranch: pr.targetRef.displayId,
+    tool: 'review',
+  });
+  return runReview(pr, {
+    stateStore: runtime.ctx.stateStore,
+    // 编排派发的 run 走 agent 低优先级泳道：用户随时点 /review 会插到它们之前。
+    enqueueRun: (p, tool, question) => runtime.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
+    chat,
+    agentContext,
+    matchedRule,
+    language: getMainLanguage(),
+    toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
+    maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
+    summaryMaxChars: agentCfg.summary_max_chars,
+    onStep: (sessionId, step) => runtime.emitStep(pr, sessionId, step),
+    signal,
+    autopilot,
+  });
+}

--- a/apps/desktop/src/main/services/agent/index.ts
+++ b/apps/desktop/src/main/services/agent/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Agent 编排域：会话 Agent（手动评审 / 自由规划 / AutoPilot）的主进程接线。Orchestrator 为对外能力入口，
+ * review / planning（微流程与规划的主进程 runner）+ labels（i18n 文案注入）为域内协作件，不外暴露。
+ */
+export { Orchestrator } from './orchestrator.js';

--- a/apps/desktop/src/main/services/agent/labels.ts
+++ b/apps/desktop/src/main/services/agent/labels.ts
@@ -1,5 +1,5 @@
 import type { AgentStepLabels } from '@meebox/agent';
-import { t } from './i18n/index.js';
+import { t } from '../../i18n/index.js';
 
 /**
  * 把 agent 步骤展示文案 / 总结骨架 / 中止原因从主进程 i18n 资源（locales/*.json 的 `agent.*`）解析出来，
@@ -8,7 +8,7 @@ import { t } from './i18n/index.js';
  */
 
 /** 从 i18n 资源构造步骤展示文案（judgeSevere 走 i18next 复数 count）。 */
-export function buildAgentStepLabels(): AgentStepLabels {
+export function buildStepLabels(): AgentStepLabels {
   return {
     describe: t('agent.steps.describe'),
     review: t('agent.steps.review'),

--- a/apps/desktop/src/main/services/agent/orchestrator.ts
+++ b/apps/desktop/src/main/services/agent/orchestrator.ts
@@ -19,14 +19,14 @@ import {
 import { buildChatEnv } from '@meebox/pr-agent-bridge';
 import { pickMatchingRule } from '@meebox/rules';
 import type { AgentSession, AgentStep, StoredPullRequest, TokenUsage } from '@meebox/shared';
-import { runAgentPlanning } from '../agent-planning.js';
-import { runAgentReview } from '../agent-review.js';
-import { getMainLanguage, t } from '../i18n/index.js';
-import { resolveActiveLlmProfile } from '../utils/agent.js';
-import { buildProxyEnv } from '../utils/proxy.js';
-import type { ServiceContext } from './context.js';
-import type { RunQueue } from './pr-agent/index.js';
-import { accumulateUsageSentinel, finalizeUsage, newUsageAcc } from './usage.js';
+import { getMainLanguage, t } from '../../i18n/index.js';
+import { resolveActiveLlmProfile } from '../../utils/agent.js';
+import { buildProxyEnv } from '../../utils/proxy.js';
+import type { ServiceContext } from '../context.js';
+import type { RunQueue } from '../pr-agent/index.js';
+import { accumulateUsageSentinel, finalizeUsage, newUsageAcc } from '../usage.js';
+import { runPlanning } from './planning.js';
+import { runReview } from './review.js';
 
 // 共享 chat 通道：system + user → 文本 + usage。agent:run 评审与 AutoPilot 都用。
 type AgentChat = (input: {
@@ -43,7 +43,7 @@ type AgentChat = (input: {
  * 运行态（每 PR 的 AbortController、「执行中」PR 集合、AutoPilot busy 锁）是实例可变状态，
  * 故以 class 封装；派发的工具 run 复用注入的 RunQueue（agent 低优先级泳道）。
  */
-export class AgentOrchestratorService {
+export class Orchestrator {
   // 编排 Agent（手动评审 agent:run + 自由规划 agent:ask）每 PR 至多一个在跑，AbortController 供
   // agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
   private readonly agentControllers = new Map<string, AbortController>();
@@ -410,7 +410,7 @@ export class AgentOrchestratorService {
       targetBranch: pr.targetRef.displayId,
       tool: 'review',
     });
-    return runAgentReview(pr, {
+    return runReview(pr, {
       stateStore: this.ctx.stateStore,
       // 编排派发的 run 走 agent 低优先级泳道：用户随时点 /review 会插到它们之前。
       enqueueRun: (p, tool, question) => this.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
@@ -444,7 +444,7 @@ export class AgentOrchestratorService {
       targetBranch: pr.targetRef.displayId,
       tool: 'review',
     });
-    return runAgentPlanning(pr, userRequest, {
+    return runPlanning(pr, userRequest, {
       stateStore: this.ctx.stateStore,
       enqueueRun: (p, tool, question) => this.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
       referencedContext,

--- a/apps/desktop/src/main/services/agent/orchestrator.ts
+++ b/apps/desktop/src/main/services/agent/orchestrator.ts
@@ -1,145 +1,56 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import {
-  appendAgentNotes,
-  buildToolCatalog,
-  judgeAutopilotBatch,
-  loadAgentContext,
-} from '@meebox/agent';
-import type { AgentContext } from '@meebox/agent';
-import {
-  appendAgentMessage,
-  getAutopilotLedger,
-  hasReviewOutput,
-  listStoredPullRequests,
-  updateAgentSession,
-  writeAutopilotLedger,
-} from '@meebox/poller';
+import { appendAgentMessage, listStoredPullRequests, writeAutopilotLedger } from '@meebox/poller';
 import { buildChatEnv } from '@meebox/pr-agent-bridge';
-import { pickMatchingRule } from '@meebox/rules';
-import type { AgentSession, AgentStep, StoredPullRequest, TokenUsage } from '@meebox/shared';
+import type { AgentSession, AgentStep, StoredPullRequest } from '@meebox/shared';
 import { getMainLanguage, t } from '../../i18n/index.js';
 import { resolveActiveLlmProfile } from '../../utils/agent.js';
 import { buildProxyEnv } from '../../utils/proxy.js';
 import type { ServiceContext } from '../context.js';
 import type { RunQueue } from '../pr-agent/index.js';
 import { accumulateUsageSentinel, finalizeUsage, newUsageAcc } from '../usage.js';
-import { runPlanning } from './planning.js';
-import { runReview } from './review.js';
-
-// 共享 chat 通道：system + user → 文本 + usage。agent:run 评审与 AutoPilot 都用。
-type AgentChat = (input: {
-  system: string;
-  user: string;
-  /** 输出 token 上限（轻量路由判读封顶用，见 ChatRunOptions.maxOutputTokens）。 */
-  maxOutputTokens?: number;
-}) => Promise<{ text: string; usage?: TokenUsage }>;
+import { autopilotPass } from './flows/autopilot.js';
+import { planningFlow } from './flows/planning.js';
+import { reviewFlow } from './flows/review.js';
+import type { AgentChat, OrchestratorRuntime } from './runtime.js';
 
 /**
- * Agent 编排服务：手动评审（agent:run）、自由规划（agent:ask）、AutoPilot 后台预评审，
- * 以及随 poll tick 清理已消失 PR 的在跑操作。
- *
- * 运行态（每 PR 的 AbortController、「执行中」PR 集合、AutoPilot busy 锁）是实例可变状态，
- * 故以 class 封装；派发的工具 run 复用注入的 RunQueue（agent 低优先级泳道）。
+ * Agent 编排服务（有状态协调器）：手动评审（agent:run）、自由规划（agent:ask）、AutoPilot 后台预评审，
+ * 以及随 poll tick 清理已消失 PR 的在跑操作。运行态（每 PR 的 AbortController、「执行中」集合、AutoPilot
+ * busy 锁、中途输入队列）是实例可变状态，故以 class 封装并实现 OrchestratorRuntime——把状态访问 + 共享
+ * helper（withAgentChat / 收尾落地 / 步骤广播等）暴露给按「一任务一文件」拆分的各 flow（见 ./flows）。
  */
-export class Orchestrator {
-  // 编排 Agent（手动评审 agent:run + 自由规划 agent:ask）每 PR 至多一个在跑，AbortController 供
-  // agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
+export class Orchestrator implements OrchestratorRuntime {
+  // 编排 Agent 每 PR 至多一个在跑，AbortController 供 agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
   private readonly agentControllers = new Map<string, AbortController>();
-  // 运行中（思考或派发工具）的编排 Agent 所属 PR 集合，向 renderer 广播「执行中」。区别于
-  // agentControllers（仅手动可停会话）：这里**手动 run/ask 与 AutoPilot 后台评审一并计入**，
-  // 让 PR 列表项在纯思考阶段（无活跃工具 run）也显示执行中标记。
+  // 运行中（思考或派发工具）的编排 Agent 所属 PR 集合，向 renderer 广播「执行中」。手动 run/ask 与
+  // AutoPilot 后台评审一并计入，让 PR 列表项在纯思考阶段（无活跃工具 run）也显示执行中标记。
   private readonly runningAgentPrs = new Set<string>();
   // Agent 编排层全局单并发：一次只跑一遍 AutoPilot pass（busy 锁），防止上一遍未完又叠跑。
   private autopilotBusy = false;
-  // 中途输入转向：每 PR 一个待处理用户消息队列。运行中追加 → 入队，下一主 Agent 周期 drain 注入并据
-  // 最新指令重排；评审微流程跑完后接续处理；无在跑则直接起一轮规划（竞态兜底，不丢消息）。
+  // 中途输入转向：每 PR 一个待处理用户消息队列（运行中追加 → 入队，下一周期 drain 注入）。
   private readonly pendingInputByPr = new Map<string, string[]>();
 
   constructor(
-    private readonly ctx: ServiceContext,
-    private readonly runQueue: RunQueue,
+    readonly ctx: ServiceContext,
+    readonly runQueue: RunQueue,
   ) {}
 
-  /**
-   * 对指定 PR 跑评审微流程（agent:run）：现读现装配上下文 + 注册 AbortController + 标记执行中，
-   * 收尾把「评审总结」落多轮对话与台账。
-   */
-  async runReview(pr: StoredPullRequest): Promise<AgentSession> {
-    const { getPrAgentBridge, effectiveAgentDir, logger } = this.ctx;
-    if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
-    // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存。
-    const agentContext = await loadAgentContext(effectiveAgentDir(), {
-      onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
-    });
-    // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
-    const ac = new AbortController();
-    this.agentControllers.set(pr.localId, ac);
-    this.markAgentRunning(pr.localId);
-    logger.info({ prLocalId: pr.localId }, 'agent review start (manual)');
-    let session: AgentSession;
-    try {
-      session = await this.withAgentChat(
-        (chat) => this.runReviewForPr(pr, agentContext, chat, ac.signal),
-        ac.signal,
-      );
-      logger.info(
-        { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
-        'agent review done',
-      );
-      // 收尾总结计入多轮对话（assistant 评审消息）→ UI 渲染「评审总结」卡片。
-      await this.recordReviewSummaryMessage(pr, session);
-    } finally {
-      this.agentControllers.delete(pr.localId);
-      this.unmarkAgentRunning(pr.localId);
-    }
-    // 评审微流程是固定模板、无法中途转向：跑完后把运行期间排队的用户消息作为一轮自由规划接续处理
-    // （runPlanning 会把它们落盘进会话；fire-and-forget，本次评审会话照常返回）。
-    const pending = this.takePending(pr.localId);
-    if (pending.length) {
-      void this.runPlanning(pr, pending.join('\n\n')).catch((err: unknown) => {
-        logger.warn({ err, prLocalId: pr.localId }, 'post-review planning (queued input) failed');
-      });
-    }
-    return session;
+  // ── 公共 API（IPC 入口；委托给 ./flows 下按任务拆分的各 flow）──
+
+  /** 对指定 PR 跑评审微流程（agent:run）。 */
+  runReview(pr: StoredPullRequest): Promise<AgentSession> {
+    return reviewFlow(this, pr);
   }
 
   /** 对指定 PR 跑自由规划 Agent（agent:ask）。 */
-  async runPlanning(
+  runPlanning(
     pr: StoredPullRequest,
     question: string,
     referencedContext?: string,
   ): Promise<AgentSession> {
-    const { getPrAgentBridge, effectiveAgentDir, logger } = this.ctx;
-    if (!getPrAgentBridge()) throw new Error(t('prAgent.notReadyDetail'));
-    const agentContext = await loadAgentContext(effectiveAgentDir(), {
-      onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
-    });
-    const ac = new AbortController();
-    this.agentControllers.set(pr.localId, ac);
-    this.markAgentRunning(pr.localId);
-    // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
-    logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
-    try {
-      const session = await this.withAgentChat(
-        (chat) => this.runPlanningForPr(pr, question, agentContext, chat, ac.signal, referencedContext),
-        ac.signal,
-      );
-      logger.info(
-        {
-          prLocalId: pr.localId,
-          status: session.status,
-          steps: session.stepCount,
-          terminationReason: session.terminationReason,
-        },
-        'agent chat done',
-      );
-      return session;
-    } finally {
-      this.agentControllers.delete(pr.localId);
-      this.unmarkAgentRunning(pr.localId);
-    }
+    return planningFlow(this, pr, question, referencedContext);
   }
 
   /**
@@ -166,14 +77,6 @@ export class Orchestrator {
     return { queued: false };
   }
 
-  /** 取出并清空某 PR 的待处理用户消息队列。 */
-  private takePending(localId: string): string[] {
-    const q = this.pendingInputByPr.get(localId);
-    if (!q || q.length === 0) return [];
-    this.pendingInputByPr.delete(localId);
-    return q;
-  }
-
   /** 暂停某 PR 的 Agent 运行（agent:stop）：abort 其 AbortController。 */
   stop(localId: string): { ok: boolean } {
     const ac = this.agentControllers.get(localId);
@@ -183,120 +86,14 @@ export class Orchestrator {
   }
 
   /**
-   * poll tick：满足开关 + 候选时跑一遍 AutoPilot pass（内部门控）。见 docs/arch/06-agent.md「AutoPilot」。
-   * Agent 编排层全局单并发：busy 锁防止上一遍未完又叠跑；派发的工具 run 在共享队列并行。
-   * 触发节奏对齐轮询（每个 onTick 评估一遍）；准入门控 + 台账去重防止重复评审 / 打爆 LLM。
+   * poll tick：满足开关 + 未在跑 + bridge 就绪时跑一遍 AutoPilot pass（准入门控 + 台账去重在 autopilotPass
+   * 内）。busy 锁防止上一遍未完又叠跑。见 docs/arch/06-agent.md「AutoPilot」。
    */
   runAutopilotIfDue(): void {
     const ap = this.ctx.bootstrap.config.agent.autopilot;
     if (!ap.enabled || this.autopilotBusy || !this.ctx.getPrAgentBridge()) return;
-    // 准入通过 → fire-and-forget 异步 pass（poll tick 不阻塞）；busy 锁在 runAutopilotPass 内成对管理。
-    void this.runAutopilotPass();
-  }
-
-  /** 跑一遍 AutoPilot pass（busy 锁置位 / 复位包住全程）。仅由 runAutopilotIfDue 通过准入后触发。 */
-  private async runAutopilotPass(): Promise<void> {
-    const { bootstrap, stateStore, effectiveAgentDir, logger } = this.ctx;
-    const ap = bootstrap.config.agent.autopilot;
-    this.autopilotBusy = true;
-    try {
-      // 候选准入（硬性门控，自上而下）：
-      //   1. 仅「待我评审」分类（discoveryFilters 含 review-requested）下、「待处理」状态（localStatus
-      //      === 'pending'）的 PR —— 已通过 / 标记需修改、或非待我评审的一律不自动评审。
-      //      （不支持发现分类的平台 discoveryFilters 为空 → 不命中，自然不自动触发。）
-      //   2. 会话中已有 /describe 或 /review 产出（成功 / 正在跑，手动或自动）→ 判定已评审过 / 评审中，
-      //      不再自动触发（评审失败无产出 → 不算，下轮可重试）。
-      //   3. 仅排除「本版本已被判定跳过」的 PR（台账 decision='skipped'）——避免对判过 skip 的 PR 反复
-      //      重判；无产出又未被 skip 的待评审 PR 一律放行（不再因台账有任意记录就拦下）。
-      //   再按 batch_size 截断。
-      const prs = await listStoredPullRequests(stateStore);
-      const candidates: StoredPullRequest[] = [];
-      // 准入漏斗计数（用于 0 候选时定位卡在哪一道闸——便于排查「为何不再触发」）。
-      let reviewReqPending = 0; // 命中「待我评审 + 待处理」
-      let alreadyReviewed = 0; // 其中已有 describe/review 产出（成功 / 进行中）而被排除
-      let skipDeduped = 0; // 其中本版本已被判定跳过而被排除
-      for (const pr of prs) {
-        if (candidates.length >= ap.batch_size) break;
-        if (!pr.discoveryFilters.includes('review-requested')) continue;
-        if (pr.localStatus !== 'pending') continue;
-        reviewReqPending++;
-        if (await hasReviewOutput(stateStore, pr.localId)) {
-          alreadyReviewed++;
-          continue;
-        }
-        const ledger = await getAutopilotLedger(stateStore, pr.localId);
-        if (ledger?.decision === 'skipped' && ledger.autoReviewedUpdatedAt === pr.updatedAt) {
-          skipDeduped++;
-          continue;
-        }
-        candidates.push(pr);
-      }
-      if (candidates.length === 0) {
-        // 仍在按周期评估，只是当前无新合格 PR——把漏斗计数打出来，避免被误读成「没在跑」。
-        logger.info(
-          { total: prs.length, reviewReqPending, alreadyReviewed, skipDeduped },
-          'autopilot pass: no eligible candidates',
-        );
-        return;
-      }
-
-      const agentContext = await loadAgentContext(effectiveAgentDir(), {
-        onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
-      });
-      await this.withAgentChat(async (chat) => {
-        // 批量判定（例外规则来自 AGENTS.md）。
-        const { decisions } = await judgeAutopilotBatch(chat, {
-          candidates: candidates.map((p) => ({
-            prLocalId: p.localId,
-            title: p.title,
-            description: p.description,
-          })),
-          agentsRules: agentContext.files.agents,
-        });
-        const byId = new Map(candidates.map((p) => [p.localId, p] as const));
-        // 先落「跳过」决策（无工具开销，顺序写盘即可）；收集「评审」决策待并行编排。
-        const toReview: StoredPullRequest[] = [];
-        for (const d of decisions) {
-          const pr = byId.get(d.prLocalId);
-          if (!pr) continue;
-          if (!d.review) {
-            // 输出判定 skip 的原因（候选都已过准入闸、非「已评审」，故这里的原因都是 LLM 的领域判定，
-            // 如分支合并 / 纯依赖升级 — 打出来便于核对「为何没评审这个 PR」）。
-            logger.info({ prLocalId: pr.localId, reason: d.reason }, 'autopilot judge skip');
-            await writeAutopilotLedger(stateStore, {
-              prLocalId: pr.localId,
-              autoReviewedUpdatedAt: pr.updatedAt,
-              decision: 'skipped',
-              reason: d.reason,
-              at: new Date().toISOString(),
-            });
-            continue;
-          }
-          toReview.push(pr);
-        }
-        // 多 PR 评审并行编排：各编排 await 自己的工具 run 时彼此不挡，让工具的并发队列
-        // （run-queue maxConcurrency）尽量被填满，而非逐 PR 串行空等。各 PR 写各自的文件，无竞争。
-        await Promise.all(
-          toReview.map(async (pr) => {
-            // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
-            this.markAgentRunning(pr.localId);
-            try {
-              const session = await this.runReviewForPr(pr, agentContext, chat, undefined, true);
-              // done：落「评审总结」消息 + 台账（含 verdict）+ 广播会话变更（与手动评审一致）。
-              // 失败 / 暂停不落台账 → 无产出，下轮可重试（准入闸 2 用 hasReviewOutput 判，不再靠台账拦）。
-              await this.recordReviewSummaryMessage(pr, session);
-            } finally {
-              this.unmarkAgentRunning(pr.localId);
-            }
-          }),
-        );
-      });
-      logger.info({ candidates: candidates.length }, 'autopilot pass done');
-    } catch (err) {
-      logger.warn({ err }, 'autopilot pass failed (ignored)');
-    } finally {
-      this.autopilotBusy = false;
-    }
+    // 准入通过 → fire-and-forget 异步 pass（poll tick 不阻塞）；busy 锁在 autopilotPass 内成对管理。
+    void autopilotPass(this);
   }
 
   /**
@@ -318,21 +115,65 @@ export class Orchestrator {
     }
   }
 
+  // ── OrchestratorRuntime 实现（供 ./flows 复用的状态访问 + 共享 helper）──
+
+  registerController(localId: string, ac: AbortController): void {
+    this.agentControllers.set(localId, ac);
+  }
+
+  clearController(localId: string): void {
+    this.agentControllers.delete(localId);
+  }
+
+  markRunning(localId: string): void {
+    this.runningAgentPrs.add(localId);
+    this.broadcastAgentRunning();
+  }
+
+  unmarkRunning(localId: string): void {
+    if (this.runningAgentPrs.delete(localId)) this.broadcastAgentRunning();
+  }
+
+  setAutopilotBusy(busy: boolean): void {
+    this.autopilotBusy = busy;
+  }
+
+  /** 取出并清空某 PR 的待处理用户消息队列。 */
+  takePending(localId: string): string[] {
+    const q = this.pendingInputByPr.get(localId);
+    if (!q || q.length === 0) return [];
+    this.pendingInputByPr.delete(localId);
+    return q;
+  }
+
+  /**
+   * 每个编排步骤的统一出口：① 后台日志（kind / tool / 用时，便于排障与离线回看；thought 与 result 不入
+   * 日志避免刷屏 + 泄漏，完整步骤已落 transcript.json）；② 广播给渲染层（agent:stepProgress）做过程化展示。
+   */
+  emitStep(pr: StoredPullRequest, sessionId: string, step: AgentStep): void {
+    this.ctx.logger.info(
+      {
+        prLocalId: pr.localId,
+        sessionId,
+        kind: step.kind,
+        tool: step.toolCall?.tool,
+        thinkMs: step.thinkMs,
+      },
+      'agent step',
+    );
+    this.ctx.broadcast('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
+  }
+
   /** 设置 LLM env + 临时 chat cwd + chat 函数，运行 fn，收尾清理临时目录。
    *  signal：用户停止时 abort → 杀掉在跑的 LLM chat 子进程，让思考阶段也能立即中止（不必等模型返回）。 */
-  private async withAgentChat<T>(
-    fn: (chat: AgentChat) => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T> {
+  async withAgentChat<T>(fn: (chat: AgentChat) => Promise<T>, signal?: AbortSignal): Promise<T> {
     const { getPrAgentBridge, bootstrap } = this.ctx;
     const bridge = getPrAgentBridge();
     if (!bridge) throw new Error(t('prAgent.notReadyDetail'));
-    // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。
+    // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。代理 env 先铺底（非
+    // pr-agent 范畴）；LLM 凭据/模型 + 编排 chat 专属档（响应语言 / 低推理档 / 提示缓存）由 buildChatEnv 按
+    // 意图组装。低档与缓存仅作用于本 chat spawn：pr-agent 工具 run（/review 等）的 env 不含 → 仍满档推理。
     const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
-    // 代理 env 先铺底（非 pr-agent 范畴）；LLM 凭据/模型 + 编排 chat 专属档（响应语言 / 低推理档 /
-    // 提示缓存）由 bridge 的 buildChatEnv 按意图组装——这些 pr-agent / shim 契约 key 收口在
-    // @meebox/pr-agent-bridge，主服务只表达意图。低推理档与缓存仅作用于本 chat spawn：pr-agent 工具 run
-    // （/review 等）的 env 不含 → /review 仍满档推理（编排通道是路由 + 轻量综合，故降档提速）。
     const env: Record<string, string> = {
       ...buildProxyEnv(bootstrap.config.proxy),
       ...buildChatEnv(activeLlm, {
@@ -357,146 +198,11 @@ export class Orchestrator {
   }
 
   /**
-   * 每个编排步骤的统一出口：① 后台日志（工具选择 / 判读 / 收尾各落一条，便于排障与离线回看）；
-   * ② 广播给渲染层（agent:stepProgress）做过程化展示。
-   * 后台日志只留骨架（kind / tool / 用时）：thought 与 result（含用户输入 / 总结正文）不入日志，
-   * 避免刷屏 + 泄漏内容；完整步骤已落 transcript.json，需要时从那里回看。
-   */
-  private emitAgentStep(pr: StoredPullRequest, sessionId: string, step: AgentStep): void {
-    this.ctx.logger.info(
-      {
-        prLocalId: pr.localId,
-        sessionId,
-        kind: step.kind,
-        tool: step.toolCall?.tool,
-        thinkMs: step.thinkMs,
-      },
-      'agent step',
-    );
-    this.ctx.broadcast('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
-  }
-
-  private broadcastAgentRunning(): void {
-    this.ctx.broadcast('agent:runningChanged', { prLocalIds: [...this.runningAgentPrs] });
-  }
-
-  private markAgentRunning(localId: string): void {
-    this.runningAgentPrs.add(localId);
-    this.broadcastAgentRunning();
-  }
-
-  private unmarkAgentRunning(localId: string): void {
-    if (this.runningAgentPrs.delete(localId)) this.broadcastAgentRunning();
-  }
-
-  /** 终止某 PR 上的全部 agent 操作：中止编排（agent:run/ask）+ 取消其派发的工具 run。 */
-  private terminateAgentForPr(localId: string): void {
-    this.agentControllers.get(localId)?.abort();
-    this.runQueue.cancelRunsForPr(localId);
-  }
-
-  /** 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。 */
-  private runReviewForPr(
-    pr: StoredPullRequest,
-    agentContext: AgentContext,
-    chat: AgentChat,
-    signal?: AbortSignal,
-    autopilot = false,
-  ): Promise<AgentSession> {
-    const agentCfg = this.ctx.bootstrap.config.agent;
-    const matchedRule = pickMatchingRule(agentContext.rules, {
-      projectKey: pr.repo.projectKey,
-      repoSlug: pr.repo.repoSlug,
-      targetBranch: pr.targetRef.displayId,
-      tool: 'review',
-    });
-    return runReview(pr, {
-      stateStore: this.ctx.stateStore,
-      // 编排派发的 run 走 agent 低优先级泳道：用户随时点 /review 会插到它们之前。
-      enqueueRun: (p, tool, question) => this.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
-      chat,
-      agentContext,
-      matchedRule,
-      language: getMainLanguage(),
-      // 工具目录注入：修改类工具按 grants 门控（默认全禁，红线见 buildToolCatalog）。
-      toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
-      maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
-      summaryMaxChars: agentCfg.summary_max_chars,
-      onStep: (sessionId, step) => this.emitAgentStep(pr, sessionId, step),
-      signal,
-      autopilot,
-    });
-  }
-
-  private runPlanningForPr(
-    pr: StoredPullRequest,
-    userRequest: string,
-    agentContext: AgentContext,
-    chat: AgentChat,
-    signal: AbortSignal,
-    referencedContext?: string,
-  ): Promise<AgentSession> {
-    const { bootstrap, effectiveAgentDir, logger } = this.ctx;
-    const agentCfg = bootstrap.config.agent;
-    const matchedRule = pickMatchingRule(agentContext.rules, {
-      projectKey: pr.repo.projectKey,
-      repoSlug: pr.repo.repoSlug,
-      targetBranch: pr.targetRef.displayId,
-      tool: 'review',
-    });
-    return runPlanning(pr, userRequest, {
-      stateStore: this.ctx.stateStore,
-      enqueueRun: (p, tool, question) => this.runQueue.enqueuePragentRun(p, tool, question, 'agent'),
-      referencedContext,
-      chat,
-      agentContext,
-      toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
-      matchedRule,
-      language: getMainLanguage(),
-      maxSteps: agentCfg.max_steps,
-      signal,
-      onStep: (sessionId, step) => this.emitAgentStep(pr, sessionId, step),
-      // 中途输入转向：planner 每轮取出排队消息时在此落盘进会话 + 广播刷新（即时显示为用户气泡），
-      // planner 再把它们并入当轮 progress、据最新指令重排下一步。
-      drainPendingInput: async () => {
-        const msgs = this.takePending(pr.localId);
-        for (const m of msgs) {
-          await appendAgentMessage(this.ctx.stateStore, pr.localId, { role: 'user', content: m });
-        }
-        if (msgs.length) this.ctx.broadcast('agent:conversationChanged', { prLocalId: pr.localId });
-        return msgs;
-      },
-      // 计划（todo）更新：planner 给出 plan 即持久化进会话 + 广播刷新计划面板；切 PR / 重启经
-      // agent:getSession 水合。
-      recordPlan: async (todo) => {
-        await updateAgentSession(this.ctx.stateStore, pr.localId, { todo });
-        this.ctx.broadcast('agent:planUpdated', { prLocalId: pr.localId, todo });
-      },
-      // 持久化 Agent 主动记下的非隐私条目到当前 Agent 目录的各可写文件（USER/MEMORY/AGENTS）；
-      // SOUL.md 永不写。下一轮 loadAgentContext 现读即生效（跨会话记忆）。
-      recordMemory: async (notes) => {
-        const dir = effectiveAgentDir();
-        for (const kind of ['user', 'memory', 'agents'] as const) {
-          const added = await appendAgentNotes(dir, kind, notes[kind]).catch((err: unknown) => {
-            logger.warn({ err, kind }, 'record agent memory failed');
-            return [] as string[];
-          });
-          if (added.length) logger.info({ kind, added }, 'agent memory recorded');
-        }
-      },
-    });
-  }
-
-  /**
    * 评审收尾的统一落地（手动一键评审与 AutoPilot 背景评审共用）：仅成功收尾（done）且有总结时——
    * ① 追加一条 assistant 评审消息（UI 渲染「评审总结」卡片）；② 写评审台账（recommendation + 当前
-   *    updatedAt）。台账既给 PR 列表的建议徽标（★，手动 / 自动一视同仁），也供 AutoPilot 同版本去重。
-   * 失败 / 用户停止（paused）不落，便于后续重试。
+   *    updatedAt，给 PR 列表建议徽标 + AutoPilot 同版本去重）。失败 / 用户停止（paused）不落，便于重试。
    */
-  private async recordReviewSummaryMessage(
-    pr: StoredPullRequest,
-    session: AgentSession,
-  ): Promise<void> {
+  async recordReviewSummaryMessage(pr: StoredPullRequest, session: AgentSession): Promise<void> {
     if (session.status !== 'done' || !session.summary) return;
     await appendAgentMessage(this.ctx.stateStore, pr.localId, {
       role: 'assistant',
@@ -512,5 +218,17 @@ export class Orchestrator {
     });
     // 通知渲染层：若正打开该 PR，重载会话让后台评审的「评审总结」卡片即时出现（手动评审自行重载，重复无害）。
     this.ctx.broadcast('agent:conversationChanged', { prLocalId: pr.localId });
+  }
+
+  // ── 私有 helper ──
+
+  private broadcastAgentRunning(): void {
+    this.ctx.broadcast('agent:runningChanged', { prLocalIds: [...this.runningAgentPrs] });
+  }
+
+  /** 终止某 PR 上的全部 agent 操作：中止编排（agent:run/ask）+ 取消其派发的工具 run。 */
+  private terminateAgentForPr(localId: string): void {
+    this.agentControllers.get(localId)?.abort();
+    this.runQueue.cancelRunsForPr(localId);
   }
 }

--- a/apps/desktop/src/main/services/agent/planning.ts
+++ b/apps/desktop/src/main/services/agent/planning.ts
@@ -23,7 +23,7 @@ import type {
   ToolCatalogEntry,
 } from '@meebox/shared';
 import type { StateStore } from '@meebox/state-store';
-import { buildAgentStepLabels, buildSummarySections, mapTerminationReason } from './agent-labels.js';
+import { buildStepLabels, buildSummarySections, mapTerminationReason } from './labels.js';
 
 /**
  * 把自由规划编排器（runPlanningAgent）接到主进程：自然语言入口的「对话即委派」。
@@ -49,8 +49,8 @@ const COMPACT_SYSTEM =
 
 /** 存储超阈值时，把较早消息摘要为一条 digest 替换之；未超阈值 / 失败则原样保留。 */
 async function maybeCompactConversation(
-  stateStore: AgentPlanningDeps['stateStore'],
-  chat: AgentPlanningDeps['chat'],
+  stateStore: PlanningDeps['stateStore'],
+  chat: PlanningDeps['chat'],
   prLocalId: string,
   now: () => Date,
 ): Promise<void> {
@@ -77,7 +77,7 @@ async function maybeCompactConversation(
   }
 }
 
-export interface AgentPlanningDeps {
+export interface PlanningDeps {
   stateStore: StateStore;
   enqueueRun: (
     pr: StoredPullRequest,
@@ -105,10 +105,10 @@ export interface AgentPlanningDeps {
   recordPlan?: (todo: AgentTodoItem[]) => void | Promise<void>;
 }
 
-export async function runAgentPlanning(
+export async function runPlanning(
   pr: StoredPullRequest,
   userRequest: string,
-  deps: AgentPlanningDeps,
+  deps: PlanningDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
   // 多轮对话：先读既往消息（注入规划上下文），再把本轮用户输入追加为一条消息（持久化）。
@@ -148,7 +148,7 @@ export async function runAgentPlanning(
         toolCatalog: deps.toolCatalog,
         matchedRule: deps.matchedRule,
         language: deps.language,
-        labels: buildAgentStepLabels(),
+        labels: buildStepLabels(),
         summarySections: buildSummarySections(),
         userRequest,
         history,

--- a/apps/desktop/src/main/services/agent/review.ts
+++ b/apps/desktop/src/main/services/agent/review.ts
@@ -10,7 +10,7 @@ import type {
   ToolCatalogEntry,
 } from '@meebox/shared';
 import type { StateStore } from '@meebox/state-store';
-import { buildAgentStepLabels, buildSummarySections, mapTerminationReason } from './agent-labels.js';
+import { buildStepLabels, buildSummarySections, mapTerminationReason } from './labels.js';
 
 /**
  * 把纯逻辑的 `runReviewMicroflow` 接到主进程能力上（见 docs/arch/06-agent.md
@@ -27,7 +27,7 @@ function reviewRunText(run: ReviewRun): string {
   return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
 }
 
-export interface AgentReviewDeps {
+export interface ReviewDeps {
   stateStore: StateStore;
   /** 入队一个 pr-agent run，resolve 完成的 ReviewRun（与用户手动 run 共用队列）。 */
   enqueueRun: (
@@ -56,9 +56,9 @@ export interface AgentReviewDeps {
  * 对一个 PR 跑评审微流程并落盘会话。返回收尾后的 AgentSession（成功 done / 失败 failed）。
  * 微流程内部工具失败会抛错，这里兜成 failed 会话而非向上抛（背景自动化不该崩主流程）。
  */
-export async function runAgentReview(
+export async function runReview(
   pr: StoredPullRequest,
-  deps: AgentReviewDeps,
+  deps: ReviewDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
   // 步数上限按微流程模板推导：describe + review + ≤N 追问 + 总结（+判定余量）。
@@ -94,7 +94,7 @@ export async function runAgentReview(
         pr: { title: pr.title, description: pr.description, targetBranch: pr.targetRef.displayId },
         matchedRule: deps.matchedRule,
         language: deps.language,
-        labels: buildAgentStepLabels(),
+        labels: buildStepLabels(),
         summarySections: buildSummarySections(),
         toolCatalog: deps.toolCatalog,
         maxFollowupAsks: deps.maxFollowupAsks,

--- a/apps/desktop/src/main/services/agent/runtime.ts
+++ b/apps/desktop/src/main/services/agent/runtime.ts
@@ -1,0 +1,39 @@
+import type { AgentSession, AgentStep, StoredPullRequest, TokenUsage } from '@meebox/shared';
+import type { ServiceContext } from '../context.js';
+import type { RunQueue } from '../pr-agent/index.js';
+
+/** 共享 chat 通道：system + user → 文本 + usage。agent:run 评审与 AutoPilot 都用。 */
+export type AgentChat = (input: {
+  system: string;
+  user: string;
+  /** 输出 token 上限（轻量路由判读封顶用，见 ChatRunOptions.maxOutputTokens）。 */
+  maxOutputTokens?: number;
+}) => Promise<{ text: string; usage?: TokenUsage }>;
+
+/**
+ * 编排运行时：有状态协调器（Orchestrator）暴露给各 flow（review / planning / autopilot）的状态访问 +
+ * 共享 helper 面。flow 以自由函数形式按「一任务一文件」拆分，经此 runtime 复用协调器的运行态与公共能力，
+ * 而不各自持有可变状态。Orchestrator 实现本接口、把 `this` 作为 runtime 传入各 flow。
+ */
+export interface OrchestratorRuntime {
+  readonly ctx: ServiceContext;
+  readonly runQueue: RunQueue;
+  /** 注册某 PR 的 AbortController（停止按钮 agent:stop 用）。 */
+  registerController(localId: string, ac: AbortController): void;
+  /** 清除某 PR 的 AbortController（收尾）。 */
+  clearController(localId: string): void;
+  /** 标记某 PR「执行中」并广播（纯思考阶段也显示）。 */
+  markRunning(localId: string): void;
+  /** 取消某 PR「执行中」标记并广播。 */
+  unmarkRunning(localId: string): void;
+  /** 步骤统一出口：后台日志 + agent:stepProgress 广播。 */
+  emitStep(pr: StoredPullRequest, sessionId: string, step: AgentStep): void;
+  /** 取出并清空某 PR 的待处理用户消息（中途输入转向）。 */
+  takePending(localId: string): string[];
+  /** 设置 LLM env + 临时 chat cwd + chat 函数后运行 fn，收尾清理临时目录。 */
+  withAgentChat<T>(fn: (chat: AgentChat) => Promise<T>, signal?: AbortSignal): Promise<T>;
+  /** 评审收尾统一落地：成功且有总结时追加 assistant 总结消息 + 写台账 + 广播会话变更。 */
+  recordReviewSummaryMessage(pr: StoredPullRequest, session: AgentSession): Promise<void>;
+  /** AutoPilot 单并发 busy 锁置位 / 复位。 */
+  setAutopilotBusy(busy: boolean): void;
+}

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -6,7 +6,7 @@ import type { RepoMirrorManager } from '@meebox/repo-mirror';
 import type { PrAgentStatus } from '@meebox/shared';
 import type { JsonFileStateStore } from '@meebox/state-store';
 import type { ConnectionRuntime } from '../adapters.js';
-import type { AgentOrchestratorService } from './agent-orchestrator.js';
+import type { Orchestrator } from './agent/index.js';
 import { broadcast } from './broadcast.js';
 import { PrService } from './pr-service.js';
 import type { RunQueue } from './pr-agent/index.js';
@@ -50,7 +50,7 @@ export interface ServiceContext extends RegisterDeps {
  */
 export interface ControllerContext extends ServiceContext {
   runQueue: RunQueue;
-  orchestrator: AgentOrchestratorService;
+  orchestrator: Orchestrator;
 }
 
 export function createServiceContext(deps: RegisterDeps): ServiceContext {


### PR DESCRIPTION
## 背景

agent 编排相关文件散在 `main/`（agent-review/planning/labels）与 `services/agent-orchestrator.ts`；orchestrator 是 516 行的有状态 god-class。本 PR 归域 + 拆任务（**纯搬运 / 拆分，行为不变**）。

## 改动（按 commit）

1. **归入 services/agent + 命名对齐**（`cbe4bdb`）：把 `agent-review.ts` / `agent-planning.ts` / `agent-labels.ts`（原在 `main/`）与 `agent-orchestrator.ts`（原在 `services/`）归到 `services/agent/`，去冗余 `agent` 前缀（目录已表）：`review.ts` / `planning.ts` / `labels.ts` / `orchestrator.ts`；符号 `runReview` / `runPlanning` / `buildStepLabels` / `class Orchestrator`（+ `ReviewDeps` / `PlanningDeps`）。新增 `index.ts` 桶导出（对外只 `Orchestrator`）。ipc / context 改从 `./services/agent` 引用。

2. **orchestrator 拆 flows**（`725a22e`）：把预编排任务从 god-class 方法拆成 `flows/` 下自由函数，经 `OrchestratorRuntime`（runtime.ts）复用协调器的运行态与共享 helper：
   - `flows/review.ts`（reviewFlow + runReviewForPr）、`flows/planning.ts`（planningFlow + runPlanningForPr）、`flows/autopilot.ts`（autopilotPass）。
   - `orchestrator.ts` 退为瘦协调器：实例可变状态 + 公共 API（委托 flow）+ runtime helper 实现，`implements OrchestratorRuntime`（把 `this` 作 runtime 传入 flow）。

## 验证

纯搬运 / 拆分、行为不变；desktop typecheck / lint / build 全绿。外部消费方均经 index / 公共方法，公共 API 不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)