### PR TITLE
feat(agent): 评审微流程 plan 驱动 + autopilot 规则定制步骤

### DIFF
--- a/apps/desktop/src/main/services/agent/flows/autopilot.ts
+++ b/apps/desktop/src/main/services/agent/flows/autopilot.ts
@@ -1,4 +1,4 @@
-import { judgeAutopilotBatch, loadAgentContext } from '@meebox/agent';
+import { judgeAutopilotBatch, loadAgentContext, type ReviewPlan } from '@meebox/agent';
 import {
   getAutopilotLedger,
   hasReviewOutput,
@@ -64,8 +64,8 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
         agentsRules: agentContext.files.agents,
       });
       const byId = new Map(candidates.map((p) => [p.localId, p] as const));
-      // 先落「跳过」决策（无工具开销，顺序写盘即可）；收集「评审」决策待并行编排。
-      const toReview: StoredPullRequest[] = [];
+      // 先落「跳过」决策（无工具开销，顺序写盘即可）；收集「评审」决策（连同其执行计划）待并行编排。
+      const toReview: Array<{ pr: StoredPullRequest; plan?: ReviewPlan }> = [];
       for (const d of decisions) {
         const pr = byId.get(d.prLocalId);
         if (!pr) continue;
@@ -81,15 +81,16 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
           });
           continue;
         }
-        toReview.push(pr);
+        // d.plan 为本期判定恒省略 → 微流程走默认全集；预留规则驱动计划的注入点（见 JudgeDecision.plan）。
+        toReview.push({ pr, plan: d.plan });
       }
       // 多 PR 评审并行编排：各编排 await 自己的工具 run 时彼此不挡，让 run-queue 并发尽量被填满。
       await Promise.all(
-        toReview.map(async (pr) => {
+        toReview.map(async ({ pr, plan }) => {
           // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
           runtime.markRunning(pr.localId);
           try {
-            const session = await runReviewForPr(runtime,pr, agentContext, chat, undefined, true);
+            const session = await runReviewForPr(runtime, pr, agentContext, chat, undefined, true, plan);
             // done：落「评审总结」消息 + 台账（含 verdict）+ 广播（与手动评审一致）。失败 / 暂停不落台账。
             await runtime.recordReviewSummaryMessage(pr, session);
           } finally {

--- a/apps/desktop/src/main/services/agent/flows/review.ts
+++ b/apps/desktop/src/main/services/agent/flows/review.ts
@@ -1,5 +1,5 @@
 import { buildToolCatalog, loadAgentContext } from '@meebox/agent';
-import type { AgentContext } from '@meebox/agent';
+import type { AgentContext, ReviewPlan } from '@meebox/agent';
 import { pickMatchingRule } from '@meebox/rules';
 import type { AgentSession, StoredPullRequest } from '@meebox/shared';
 import { getMainLanguage, t } from '../../../i18n/index.js';
@@ -64,6 +64,8 @@ export function runReviewForPr(
   chat: AgentChat,
   signal?: AbortSignal,
   autopilot = false,
+  /** 评审执行计划（仅 AutoPilot 按规则注入）；省略 → 微流程走默认全集。 */
+  plan?: ReviewPlan,
 ): Promise<AgentSession> {
   const agentCfg = runtime.ctx.bootstrap.config.agent;
   const matchedRule = pickMatchingRule(agentContext.rules, {
@@ -81,6 +83,7 @@ export function runReviewForPr(
     matchedRule,
     language: getMainLanguage(),
     toolCatalog: buildToolCatalog(agentCfg.autopilot.grants),
+    plan,
     maxFollowupAsks: agentCfg.autopilot.max_followup_asks,
     summaryMaxChars: agentCfg.summary_max_chars,
     onStep: (sessionId, step) => runtime.emitStep(pr, sessionId, step),

--- a/apps/desktop/src/main/services/agent/review.ts
+++ b/apps/desktop/src/main/services/agent/review.ts
@@ -1,4 +1,4 @@
-import { runReviewMicroflow, type AgentContext } from '@meebox/agent';
+import { runReviewMicroflow, type AgentContext, type ReviewPlan } from '@meebox/agent';
 import { appendAgentStep, startAgentSession, updateAgentSession } from '@meebox/poller';
 import type { Rule } from '@meebox/rules';
 import type {
@@ -44,6 +44,8 @@ export interface ReviewDeps {
   toolCatalog?: ToolCatalogEntry[];
   maxFollowupAsks: number;
   summaryMaxChars: number;
+  /** 评审执行计划（步骤序列）；省略 / 非法时微流程回落默认全集。仅 AutoPilot 按规则注入，手动评审省略。 */
+  plan?: ReviewPlan;
   /** 步骤流式回调（广播给渲染层）。 */
   onStep?: (sessionId: string, step: AgentStep) => void;
   /** 用户停止：透传给微流程，思考 / 执行任意阶段都能立即中止（停止按钮 → agent:stop）。 */
@@ -97,6 +99,7 @@ export async function runReview(
         labels: buildStepLabels(),
         summarySections: buildSummarySections(),
         toolCatalog: deps.toolCatalog,
+        plan: deps.plan,
         maxFollowupAsks: deps.maxFollowupAsks,
         summaryMaxChars: deps.summaryMaxChars,
       },

--- a/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
@@ -286,6 +286,7 @@ export function ChatPane({
                 key={entry.key}
                 tool={entry.active.tool}
                 runId={entry.active.runId}
+                question={entry.active.question}
                 lines={linesByRunId.get(entry.active.runId) ?? []}
                 startedAt={new Date(entry.active.startedAt ?? entry.active.enqueuedAt).getTime()}
                 model={currentLlmModel ?? null}

--- a/apps/desktop/src/renderer/src/components/features/chat/components/RunningView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/RunningView.tsx
@@ -2,17 +2,20 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ReviewRunTool } from '@meebox/shared';
 import { formatElapsed, formatStartTime, inferPhase, runStatusLabel } from '../utils/format';
-import { AnsiPre, Spinner } from './shared';
+import { AnsiPre, AskQuestion, Spinner } from './shared';
 
 export function RunningView({
   tool,
   runId,
+  question,
   lines,
   startedAt,
   model,
 }: {
   tool: ReviewRunTool;
   runId: string;
+  /** /ask 的提问：执行中也直接展示（与排队 / 完成态一致；问题在派发时已生成）。 */
+  question?: string;
   lines: ReadonlyArray<string>;
   startedAt: number;
   /** 当前 active LLM profile.model — 跟 RunMeta 同源放在 chip 行，让 running
@@ -69,6 +72,8 @@ export function RunningView({
           {formatStartTime(startedAt)}
         </span>
       </header>
+      {/* /ask 的提问执行中也直接展示（问题已生成，不必等排队 / 完成才可见）。 */}
+      {tool === 'ask' && question?.trim() && <AskQuestion text={question.trim()} />}
       {phase && (
         <div className="chat-chip chat-chip-md chat-chip-quiet chat-chip-accent chat-run-phase">
           {phase}

--- a/packages/agent/resources/prompts/autopilot-judge.md
+++ b/packages/agent/resources/prompts/autopilot-judge.md
@@ -1,1 +1,12 @@
-You decide whether each pull request below is worth an automated pre-review. Default to reviewing, but SKIP PRs that are not worth it — e.g. branch merges / back-merges, pure dependency bumps, or trivial mechanical changes.
+You decide, for each pull request below, whether an automated pre-review is worth running and (optionally) which review steps to run.
+
+For each PR return:
+- `review`: true to run the review, false to SKIP it. Default to reviewing; SKIP PRs not worth it — e.g. branch merges / back-merges, pure dependency bumps, or trivial mechanical changes.
+- `reason`: a short reason.
+- `plan` (optional): a custom ordered list of review-step ids. OMIT it to run the full default flow (`describe-review` → `judge` → `asks` → `summary`). Only set it when a project rule asks to customize the steps. Available step ids:
+  - `describe-review`: generate the PR description and the code-review findings (REQUIRED whenever `judge` or `summary` is included)
+  - `judge`: decide whether follow-up questions are needed
+  - `asks`: ask the follow-up questions deemed necessary
+  - `summary`: synthesize the review summary + recommendation
+
+  Example — a rule "for config-only PRs, describe and review but skip the follow-up": `["describe-review","summary"]`. To skip a PR entirely use `review: false` (not an empty plan).

--- a/packages/agent/src/autopilot-judge.ts
+++ b/packages/agent/src/autopilot-judge.ts
@@ -1,8 +1,16 @@
 import type { TokenUsage } from '@meebox/shared';
 import { DESC_CLAMP } from './constants.js';
 import { PROMPT_TEMPLATES } from './prompts.js';
-import type { ReviewPlan } from './steps/review/index.js';
+import { isValidReviewPlan, type ReviewPlan, type ReviewStepKind } from './steps/review/index.js';
 import { extractJson, fillTemplate } from './utils/index.js';
+
+/** 解析 judge 给出的步骤计划：非数组 / 含非法 kind / 缺前置 describe-review → undefined（回落默认全集）。 */
+function parseReviewPlan(raw: unknown): ReviewPlan | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const steps = raw.filter((s): s is ReviewStepKind => typeof s === 'string') as ReviewStepKind[];
+  const plan: ReviewPlan = { steps };
+  return isValidReviewPlan(plan) ? plan : undefined;
+}
 
 /**
  * AutoPilot 批量判定（见 docs/arch/06-agent.md「AutoPilot」的例外规则）：把一批候选 PR 的
@@ -62,25 +70,28 @@ export async function judgeAutopilotBatch(
     .join('\n\n');
 
   const user = [
-    'For each PR decide review (true) or skip (false) with a short reason.',
-    'Reply with JSON only: {"decisions": [{"prLocalId": string, "review": boolean, "reason": string}]}.',
+    'For each PR decide review (true) or skip (false) with a short reason; optionally add a custom step "plan" (see system).',
+    'Reply with JSON only: {"decisions": [{"prLocalId": string, "review": boolean, "reason": string, "plan"?: string[]}]}.',
     '',
     list,
   ].join('\n');
 
   const r = await chat({ system, user });
   const parsed = extractJson<{
-    decisions?: Array<{ prLocalId?: unknown; review?: unknown; reason?: unknown }>;
+    decisions?: Array<{ prLocalId?: unknown; review?: unknown; reason?: unknown; plan?: unknown }>;
   }>(r.text);
 
   const byId = new Map<string, JudgeDecision>();
   for (const d of parsed?.decisions ?? []) {
     if (typeof d.prLocalId === 'string') {
+      // plan 非法 / 省略 → undefined（评审走默认全集）；合法才带上，由 autopilot 透传给微流程。
+      const plan = parseReviewPlan(d.plan);
       byId.set(d.prLocalId, {
         prLocalId: d.prLocalId,
         // 缺省 / 非显式 false → 评审（保守：宁可多评不漏）
         review: d.review !== false,
         reason: typeof d.reason === 'string' ? d.reason : '',
+        ...(plan ? { plan } : {}),
       });
     }
   }

--- a/packages/agent/src/autopilot-judge.ts
+++ b/packages/agent/src/autopilot-judge.ts
@@ -1,6 +1,7 @@
 import type { TokenUsage } from '@meebox/shared';
 import { DESC_CLAMP } from './constants.js';
 import { PROMPT_TEMPLATES } from './prompts.js';
+import type { ReviewPlan } from './steps/review/index.js';
 import { extractJson, fillTemplate } from './utils/index.js';
 
 /**
@@ -19,6 +20,11 @@ export interface JudgeDecision {
   prLocalId: string;
   review: boolean;
   reason: string;
+  /**
+   * 该 PR 的评审执行计划（步骤序列）。本期判定**不产出**（恒省略 → 走 DEFAULT_REVIEW_PLAN）；预留为后续
+   * 「规则驱动步骤选择」的注入点：judge 提示词 + AGENTS.md 规则可逐 PR 给出计划（跳过 / 重排 / 增删步骤）。
+   */
+  plan?: ReviewPlan;
 }
 
 export interface AutopilotJudgeInput {

--- a/packages/agent/src/constants.ts
+++ b/packages/agent/src/constants.ts
@@ -3,7 +3,7 @@ import type { AgentContextFiles } from './types.js';
 
 /**
  * 包内常量统一收口：所有值常量（标量 / 字符串 / 纯数据数组与映射）集中于此，便于复用与调参。
- * 不收的两类（非「值常量」）：step 注册表（steps/review/index.ts 的 REVIEW_STEPS，实例化各 step 类的组合根）、
+ * 不收的两类（非「值常量」）：step 注册表（steps/review/index.ts 的 REVIEW_STEP_REGISTRY，实例化各 step 类的组合根）、
  * ?raw 资源载入对象（prompts.ts 的 PROMPT_TEMPLATES、templates.ts 的 AGENT_TEMPLATES）——它们是各自模块的本体。
  */
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -17,6 +17,8 @@ export type {
   AssembleSessionSnapshot,
 } from './prompts.js';
 export { runReviewMicroflow } from './orchestrator.js';
+export { DEFAULT_REVIEW_PLAN, isValidReviewPlan } from './steps/review/index.js';
+export type { ReviewPlan, ReviewStepKind } from './steps/review/index.js';
 export { extractJson } from './utils/index.js';
 export { runPlanningAgent } from './planner.js';
 export type {

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -2,7 +2,13 @@ import type { Rule } from '@meebox/rules';
 import type { AgentRecommendation, AgentStep, TokenUsage, ToolCatalogEntry } from '@meebox/shared';
 import { assembleSystemContext, type AssemblePrMeta } from './prompts.js';
 import { createStepRecorder } from './steps/context.js';
-import { REVIEW_STEPS, type ReviewStepCtx } from './steps/review/index.js';
+import {
+  DEFAULT_REVIEW_PLAN,
+  assembleReviewSteps,
+  isValidReviewPlan,
+  type ReviewPlan,
+  type ReviewStepCtx,
+} from './steps/review/index.js';
 import type { AgentContext } from './types.js';
 
 /**
@@ -45,6 +51,11 @@ export interface ReviewOrchestratorInput {
   maxFollowupAsks?: number;
   /** 总结篇幅的**参考**上限（默认 800 字符）：仅作提示词里的软约束引导 LLM 收敛，**不**对产出做硬截断。 */
   summaryMaxChars?: number;
+  /**
+   * 执行计划（步骤序列）。省略 / 非法时用 DEFAULT_REVIEW_PLAN（即 describe-review → judge → asks →
+   * summary，与拆 plan 前一致）。仅 AutoPilot 路径会按规则注入自定义计划；手动评审恒省略走默认。
+   */
+  plan?: ReviewPlan;
 }
 
 export interface ReviewOrchestratorResult {
@@ -97,8 +108,9 @@ export const DEFAULT_STEP_LABELS: AgentStepLabels = {
 };
 
 /**
- * 跑一次评审微流程：describe → review →（仅严重问题）条件追问 ≤N → 收尾总结 + 建议。只用只读工具
- * （describe/review/ask），不碰修改类操作。驱动顺序跑 REVIEW_STEPS、与各步共享 StepRecorder。
+ * 跑一次评审微流程：默认 describe → review →（仅严重问题）条件追问 ≤N → 收尾总结 + 建议。只用只读工具
+ * （describe/review/ask），不碰修改类操作。驱动按 input.plan（省略 / 非法回落 DEFAULT_REVIEW_PLAN）经
+ * assembleReviewSteps 顺序跑各步、与各步共享 StepRecorder。
  */
 export async function runReviewMicroflow(
   deps: ReviewOrchestratorDeps,
@@ -130,7 +142,9 @@ export async function runReviewMicroflow(
     bag: { questions: [], askResults: [] },
   };
 
-  for (const step of REVIEW_STEPS) await step.run(ctx);
+  // 计划：省略 / 非法（如 judge/summary 缺前置 describe-review）一律回落默认全集，避免坏计划崩在步骤里。
+  const plan = input.plan && isValidReviewPlan(input.plan) ? input.plan : DEFAULT_REVIEW_PLAN;
+  for (const step of assembleReviewSteps(plan)) await step.run(ctx);
 
   return {
     steps: rec.steps,

--- a/packages/agent/src/steps/review/index.ts
+++ b/packages/agent/src/steps/review/index.ts
@@ -7,10 +7,48 @@ import { SummaryStep } from './summary-step.js';
 
 export type { ReviewBag, ReviewStepCtx } from './shared.js';
 
-/** 评审微流程的步骤注册表（有序执行，无状态步骤以单例入表）。新增 / 调整阶段在此组合，驱动无需改动。 */
-export const REVIEW_STEPS: ReadonlyArray<Step<ReviewStepCtx>> = [
-  new DescribeReviewStep(),
-  new JudgeStep(),
-  new AsksStep(),
-  new SummaryStep(),
-];
+/**
+ * 评审微流程可用步骤的稳定标识（与各 step.name 对应）。一份评审计划即由这些 kind 有序组成。
+ * 新增工具步（如 'improve'）= 在 REVIEW_STEP_REGISTRY 登记 + 在此并上 kind，驱动与默认计划无需改动。
+ */
+export type ReviewStepKind = 'describe-review' | 'judge' | 'asks' | 'summary';
+
+/**
+ * 评审微流程执行计划：一组**有序**步骤 kind。AutoPilot 后续可据用户 agent 上下文规则给出自定义计划
+ * （跳过 / 重排 / 增删步骤）；手动评审恒用 DEFAULT_REVIEW_PLAN。计划来源（规则 → 计划）是后续工作，
+ * 本层只提供「按计划组装并执行」的基础能力。
+ */
+export interface ReviewPlan {
+  steps: ReviewStepKind[];
+}
+
+/** 步骤注册表（kind → 无状态单例）。各 step 运行态全在 ctx，故单例可复用。 */
+export const REVIEW_STEP_REGISTRY: Record<ReviewStepKind, Step<ReviewStepCtx>> = {
+  'describe-review': new DescribeReviewStep(),
+  judge: new JudgeStep(),
+  asks: new AsksStep(),
+  summary: new SummaryStep(),
+};
+
+/** 默认计划：与拆 plan 前的固定序列完全一致（describe-review → judge → asks → summary）。 */
+export const DEFAULT_REVIEW_PLAN: ReviewPlan = {
+  steps: ['describe-review', 'judge', 'asks', 'summary'],
+};
+
+/**
+ * 计划合法性：① 非空；② 各 kind 须在注册表内；③ judge / summary 读 describe·review 的产物（bag.describe /
+ * bag.review），故计划含二者时必须先含 describe-review。非法计划由驱动回落 DEFAULT_REVIEW_PLAN
+ * （见 runReviewMicroflow），避免规则给出坏计划时崩在步骤里。
+ */
+export function isValidReviewPlan(plan: ReviewPlan): boolean {
+  if (plan.steps.length === 0) return false;
+  if (plan.steps.some((k) => !(k in REVIEW_STEP_REGISTRY))) return false;
+  const set = new Set<ReviewStepKind>(plan.steps);
+  if ((set.has('judge') || set.has('summary')) && !set.has('describe-review')) return false;
+  return true;
+}
+
+/** 把计划组装成有序步骤实例（驱动据此顺序执行）。调用方须先经 isValidReviewPlan 校验。 */
+export function assembleReviewSteps(plan: ReviewPlan): Step<ReviewStepCtx>[] {
+  return plan.steps.map((k) => REVIEW_STEP_REGISTRY[k]);
+}

--- a/packages/agent/tests/autopilot-judge.test.ts
+++ b/packages/agent/tests/autopilot-judge.test.ts
@@ -45,4 +45,27 @@ describe('judgeAutopilotBatch', () => {
     });
     expect(system).toContain('Skip docs-only PRs.');
   });
+
+  it('parses a valid per-PR plan and drops an omitted / invalid one', async () => {
+    const chat = vi.fn(async () => ({
+      text: JSON.stringify({
+        decisions: [
+          { prLocalId: 'a', review: true, reason: 'config only', plan: ['describe-review', 'summary'] },
+          { prLocalId: 'b', review: true, reason: 'invalid', plan: ['summary'] },
+          { prLocalId: 'c', review: true, reason: 'no plan' },
+        ],
+      }),
+    }));
+    const r = await judgeAutopilotBatch(chat, {
+      candidates: [
+        { prLocalId: 'a', title: 'A' },
+        { prLocalId: 'b', title: 'B' },
+        { prLocalId: 'c', title: 'C' },
+      ],
+    });
+    const byId = Object.fromEntries(r.decisions.map((d) => [d.prLocalId, d]));
+    expect(byId.a?.plan).toEqual({ steps: ['describe-review', 'summary'] });
+    expect(byId.b?.plan).toBeUndefined(); // summary 缺前置 describe-review → 非法回落
+    expect(byId.c?.plan).toBeUndefined(); // 省略 → 默认全集
+  });
 });

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runReviewMicroflow } from '../src/orchestrator.js';
 import type { ReviewOrchestratorDeps } from '../src/orchestrator.js';
+import { DEFAULT_REVIEW_PLAN, isValidReviewPlan } from '../src/steps/review/index.js';
 import type { AgentContext } from '../src/types.js';
 import { extractJson, salvageProse, stripTrailingJson } from '../src/utils/index.js';
 
@@ -147,5 +148,46 @@ describe('runReviewMicroflow', () => {
     };
     await runReviewMicroflow(deps, { context, pr });
     expect(seen).toEqual(['plan', 'judge', 'plan']);
+  });
+
+  it('runs a custom plan (skip judge/asks)', async () => {
+    const { deps, toolCalls } = makeDeps({
+      chatReplies: ['{"summary": "ok", "recommendation": {"verdict": "approve", "reason": "r"}}'],
+    });
+    const r = await runReviewMicroflow(deps, {
+      context,
+      pr,
+      plan: { steps: ['describe-review', 'summary'] },
+    });
+    // describe-review 步两只读工具仍并行跑；judge / asks 被跳过。
+    expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review']);
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'plan']);
+    expect(r.summary).toBe('ok');
+  });
+
+  it('falls back to the default plan when the plan is invalid (summary without describe-review)', async () => {
+    const { deps, toolCalls } = makeDeps({
+      chatReplies: [
+        '{"severe": false, "questions": []}',
+        '{"summary": "all good", "recommendation": {"verdict": "approve", "reason": "ok"}}',
+      ],
+    });
+    const r = await runReviewMicroflow(deps, { context, pr, plan: { steps: ['summary'] } });
+    // 非法计划回落 DEFAULT：describe-review → judge → asks(空) → summary。
+    expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review']);
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'judge', 'plan']);
+  });
+});
+
+describe('isValidReviewPlan', () => {
+  it('accepts the default plan', () => {
+    expect(isValidReviewPlan(DEFAULT_REVIEW_PLAN)).toBe(true);
+  });
+  it('rejects empty / unknown-kind / judge|summary lacking describe-review', () => {
+    expect(isValidReviewPlan({ steps: [] })).toBe(false);
+    expect(isValidReviewPlan({ steps: ['nope' as never] })).toBe(false);
+    expect(isValidReviewPlan({ steps: ['judge'] })).toBe(false);
+    expect(isValidReviewPlan({ steps: ['summary'] })).toBe(false);
+    expect(isValidReviewPlan({ steps: ['describe-review', 'summary'] })).toBe(true);
   });
 });


### PR DESCRIPTION
## 概述

让 AutoPilot 的评审步骤序列可由用户 agent 上下文规则（AGENTS.md）定制——把微流程从硬编码改为按 `ReviewPlan` 组装，并让判定器据规则产出 per-PR 计划。**手动评审按钮不受影响**（不经 judge、永远跑默认全集）。3 commits。

## 改动

1. **`feat(agent)` 评审微流程 plan 驱动基础能力**（`fccfd0c`）
   - `steps/review/index.ts`：`ReviewStepKind` / `ReviewPlan` 类型 + `REVIEW_STEP_REGISTRY`（kind→step 单例）+ `DEFAULT_REVIEW_PLAN`（= 原固定序列）+ `isValidReviewPlan`（依赖守卫：judge/summary 须前置 describe-review）+ `assembleReviewSteps`。
   - `runReviewMicroflow` 由固定 `REVIEW_STEPS` 改为按 `input.plan` 组装；省略 / 非法回落 DEFAULT，避免坏计划崩在步骤里。
   - 透传：`review.ReviewDeps.plan` → `flows/review.runReviewForPr(plan?)` → `autopilotPass` 传 `d.plan`；手动 `reviewFlow` 不传 → 默认全集（门控：仅 autopilot 可定制）。

2. **`fix(chat)` /ask 提问在执行中也直接展示**（`ad88f3c`）
   - RunningView 原缺 `question` prop——排队 / 完成都显示提问、唯独执行中不显示。补上后三态一致直显。

3. **`feat(agent)` autopilot judge 据规则产出评审步骤计划**（`231e324`）
   - 判定器从二元 review/skip 升级为可给出 per-PR `plan`：提示词说明 plan + 步骤 id；解析 `parseReviewPlan`（经 `isValidReviewPlan` 守卫，非法/省略→默认）。
   - 全链路打通：judge `d.plan` → autopilot 透传 → 微流程 `assembleReviewSteps`（parse + 驱动双重守卫）。

## 行为

- **默认零变化**：未写规则时，judge 不产出 plan → autopilot 与手动均跑默认全集（describe-review → judge → asks → summary）。
- 写规则后：autopilot 按计划裁剪 / 重排步骤；手动按钮恒默认。

## 后续（未在本 PR）

新增工具步（如 `/improve`）：扩 `ReviewStepKind` + 注册表 + 放宽 `runTool` 工具类型。

## 验证

`nx test agent` 54/54（含自定义 plan 跳步 / 非法 plan 回落 / `isValidReviewPlan` / judge plan 解析）；agent + desktop typecheck/lint、desktop build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)