### PR TITLE
refactor(ipc): 目录对话框标题改由前端提供，main i18n 收敛为仅 agent

### DIFF
--- a/apps/desktop/src/main/controllers/app.ts
+++ b/apps/desktop/src/main/controllers/app.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { app, BrowserWindow, dialog, shell } from 'electron';
 import type { Logger } from 'pino';
-import { t } from '../i18n/index.js';
 import { buildAppInfo, buildConnectionSummaries } from '../services/app.js';
 import { getContext } from '../services/context.js';
 import { sniffImageContentType } from '../utils/image.js';
@@ -193,14 +192,15 @@ export const openExternal: IpcController<'app:openExternal'> = async (_event, re
  */
 export const pickDirectory: IpcController<'dialog:pickDirectory'> = async (event, req) => {
   const win = BrowserWindow.fromWebContents(event.sender) ?? undefined;
+  // 标题由前端按 UI 语言提供（目录选择属交互领域文案，统一在渲染层 i18n 维护，主进程不再 localize）。
   const result = win
     ? await dialog.showOpenDialog(win, {
-        title: req.title ?? t('dialog.selectDirectory'),
+        title: req.title,
         defaultPath: req.defaultPath,
         properties: ['openDirectory', 'createDirectory'],
       })
     : await dialog.showOpenDialog({
-        title: req.title ?? t('dialog.selectDirectory'),
+        title: req.title,
         defaultPath: req.defaultPath,
         properties: ['openDirectory', 'createDirectory'],
       });

--- a/apps/desktop/src/main/i18n/locales/de-DE.json
+++ b/apps/desktop/src/main/i18n/locales/de-DE.json
@@ -19,8 +19,5 @@
       "aborted": "Vom Benutzer abgebrochen",
       "maxSteps": "Schrittlimit erreicht"
     }
-  },
-  "dialog": {
-    "selectDirectory": "Verzeichnis auswählen"
   }
 }

--- a/apps/desktop/src/main/i18n/locales/en-US.json
+++ b/apps/desktop/src/main/i18n/locales/en-US.json
@@ -19,8 +19,5 @@
       "aborted": "Paused by user",
       "maxSteps": "Step limit reached"
     }
-  },
-  "dialog": {
-    "selectDirectory": "Select directory"
   }
 }

--- a/apps/desktop/src/main/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/main/i18n/locales/ja-JP.json
@@ -18,8 +18,5 @@
       "aborted": "ユーザーが中断しました",
       "maxSteps": "ステップ上限に到達"
     }
-  },
-  "dialog": {
-    "selectDirectory": "ディレクトリを選択"
   }
 }

--- a/apps/desktop/src/main/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/main/i18n/locales/zh-CN.json
@@ -18,8 +18,5 @@
       "aborted": "用户暂停",
       "maxSteps": "步数上限中止"
     }
-  },
-  "dialog": {
-    "selectDirectory": "选择目录"
   }
 }

--- a/packages/ipc/src/app.ts
+++ b/packages/ipc/src/app.ts
@@ -41,7 +41,8 @@ export interface AppChannels {
    * defaultPath 可空，作为初始定位目录。
    */
   'dialog:pickDirectory': {
-    request: { defaultPath?: string; title?: string };
+    // title 由前端按 UI 语言提供（交互领域文案统一在渲染层 i18n 维护）；defaultPath 作初始定位目录。
+    request: { defaultPath?: string; title: string };
     response: { path: string | null };
   };
   /** 各连接的 ping 后缓存：当前用户 + display_name，Header 用 */


### PR DESCRIPTION
## 背景

「选择目录」标题属**交互领域文案**。前端其实早已在三处调用（设置页两个 + 首启向导）传渲染层 i18n
（`pickAgentDirTitle` / `pickCacheDirTitle` 等），主进程 `dialog:pickDirectory` 里的
`req.title ?? t('dialog.selectDirectory')` 是**永不命中的死兜底**——「交互文案统一在前端维护」已事实成立，只差清理。

## 改动

- `dialog:pickDirectory` 的 `title` 由**可选改必填**：契约上强制前端按 UI 语言提供，杜绝回退到主进程 localize。
- `app.ts` 去掉死兜底 `?? t('dialog.selectDirectory')` → 直接用 `req.title`，并移除 `t` 依赖。
- 移除 main i18n 的 `dialog` 命名空间（四语言）→ **main i18n 现仅剩 `agent`**（agent 步骤文案在主进程生成并注入 transcript，留主进程是合理特例）。

三处调用本就传 `title`，必填改动无需改调用方。

## 验证

ipc/desktop typecheck/lint、desktop build 全绿；无 `dialog.selectDirectory` 残留引用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)