### PR TITLE
feat(agent): autopilot 分支合并判定 + 工具层统一注册表

### DIFF
--- a/apps/desktop/src/main/services/agent/flows/autopilot.ts
+++ b/apps/desktop/src/main/services/agent/flows/autopilot.ts
@@ -1,4 +1,9 @@
-import { judgeAutopilotBatch, loadAgentContext, type ReviewPlan } from '@meebox/agent';
+import {
+  classifyBranchMerge,
+  judgeAutopilotBatch,
+  loadAgentContext,
+  type ReviewPlan,
+} from '@meebox/agent';
 import {
   getAutopilotLedger,
   hasReviewOutput,
@@ -53,13 +58,41 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
     const agentContext = await loadAgentContext(effectiveAgentDir(), {
       onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
     });
+    // 第一步 judge 的背景输入：逐候选用元数据判「纯分支合并」——(c) 分支约定零成本先判，拿不准再 (b)
+    // 调一次 commits API 看「提交是否全为 merge」。并行跑，整体约一轮 round-trip。失败不阻断（按非合并处理）。
+    const branchMergeByPr = new Map<string, boolean>();
+    await Promise.all(
+      candidates.map(async (p) => {
+        const sourceBranch = p.sourceRef.displayId;
+        const targetBranch = p.targetRef.displayId;
+        let verdict = classifyBranchMerge({ sourceBranch, targetBranch });
+        if (verdict.basis === 'inconclusive') {
+          try {
+            const commits = await runtime.ctx.pr
+              .adapterFor(p)
+              ?.listPullRequestCommits(p.repo, p.remoteId);
+            if (commits) verdict = classifyBranchMerge({ sourceBranch, targetBranch, commits });
+          } catch (err) {
+            logger.debug(
+              { err, prLocalId: p.localId },
+              'branch-merge commits check failed (ignored)',
+            );
+          }
+        }
+        branchMergeByPr.set(p.localId, verdict.isBranchMerge);
+      }),
+    );
+
     await runtime.withAgentChat(async (chat) => {
-      // 批量判定（例外规则来自 AGENTS.md）。
+      // 批量判定（例外规则来自 AGENTS.md；分支信息 + 分支合并信号作背景输入）。
       const { decisions } = await judgeAutopilotBatch(chat, {
         candidates: candidates.map((p) => ({
           prLocalId: p.localId,
           title: p.title,
           description: p.description,
+          sourceBranch: p.sourceRef.displayId,
+          targetBranch: p.targetRef.displayId,
+          branchMerge: branchMergeByPr.get(p.localId),
         })),
         agentsRules: agentContext.files.agents,
       });
@@ -69,9 +102,18 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
       for (const d of decisions) {
         const pr = byId.get(d.prLocalId);
         if (!pr) continue;
+        // 每条决策都记日志（含 review/skip + 原因 + 计划 + 分支合并信号），便于排查「judge 是否在按规则跑」。
+        logger.info(
+          {
+            prLocalId: pr.localId,
+            review: d.review,
+            reason: d.reason,
+            plan: d.plan?.steps,
+            branchMerge: branchMergeByPr.get(pr.localId) ?? false,
+          },
+          'autopilot judge decision',
+        );
         if (!d.review) {
-          // 候选都已过准入闸、非「已评审」，故这里的原因都是 LLM 的领域判定（如分支合并 / 纯依赖升级）。
-          logger.info({ prLocalId: pr.localId, reason: d.reason }, 'autopilot judge skip');
           await writeAutopilotLedger(stateStore, {
             prLocalId: pr.localId,
             autoReviewedUpdatedAt: pr.updatedAt,
@@ -81,7 +123,7 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
           });
           continue;
         }
-        // d.plan 为本期判定恒省略 → 微流程走默认全集；预留规则驱动计划的注入点（见 JudgeDecision.plan）。
+        // d.plan 省略 → 微流程走默认全集；规则驱动计划的注入点（见 JudgeDecision.plan）。
         toReview.push({ pr, plan: d.plan });
       }
       // 多 PR 评审并行编排：各编排 await 自己的工具 run 时彼此不挡，让 run-queue 并发尽量被填满。
@@ -90,7 +132,15 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
           // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
           runtime.markRunning(pr.localId);
           try {
-            const session = await runReviewForPr(runtime, pr, agentContext, chat, undefined, true, plan);
+            const session = await runReviewForPr(
+              runtime,
+              pr,
+              agentContext,
+              chat,
+              undefined,
+              true,
+              plan,
+            );
             // done：落「评审总结」消息 + 台账（含 verdict）+ 广播（与手动评审一致）。失败 / 暂停不落台账。
             await runtime.recordReviewSummaryMessage(pr, session);
           } finally {

--- a/apps/desktop/src/main/services/agent/planning.ts
+++ b/apps/desktop/src/main/services/agent/planning.ts
@@ -12,13 +12,14 @@ import {
   updateAgentSession,
   writeAgentConversation,
 } from '@meebox/poller';
-import type { AgentMessage } from '@meebox/shared';
+import { READ_RUN_TOOL_IDS, type AgentMessage } from '@meebox/shared';
 import type { Rule } from '@meebox/rules';
 import type {
   AgentSession,
   AgentStep,
   AgentTodoItem,
   ReviewRun,
+  ReviewRunTool,
   StoredPullRequest,
   ToolCatalogEntry,
 } from '@meebox/shared';
@@ -35,8 +36,6 @@ const STDOUT_LOG_SEP = '\n\n---\n[pr-agent stdout log]\n';
 function reviewRunText(run: ReviewRun): string {
   return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
 }
-
-const READ_TOOLS = new Set(['describe', 'review', 'ask']);
 
 // 会话压缩：存储超阈值时把较早消息摘要成一条 digest、仅留最近若干条原文，控制存储与后续注入规模
 // （约定会话上下文不超 LLM 半窗：先压缩/裁剪再注入）。阈值高于注入预算，超出才触发、不频繁。
@@ -79,11 +78,7 @@ async function maybeCompactConversation(
 
 export interface PlanningDeps {
   stateStore: StateStore;
-  enqueueRun: (
-    pr: StoredPullRequest,
-    tool: 'describe' | 'review' | 'ask',
-    question?: string,
-  ) => Promise<ReviewRun>;
+  enqueueRun: (pr: StoredPullRequest, tool: ReviewRunTool, question?: string) => Promise<ReviewRun>;
   chat: (input: { system: string; user: string }) => Promise<PlanningToolResult>;
   agentContext: AgentContext;
   toolCatalog: ToolCatalogEntry[];
@@ -113,7 +108,12 @@ export async function runPlanning(
 ): Promise<AgentSession> {
   // 多轮对话：先读既往消息（注入规划上下文），再把本轮用户输入追加为一条消息（持久化）。
   const history = await getAgentConversation(deps.stateStore, pr.localId);
-  await appendAgentMessage(deps.stateStore, pr.localId, { role: 'user', content: userRequest }, now);
+  await appendAgentMessage(
+    deps.stateStore,
+    pr.localId,
+    { role: 'user', content: userRequest },
+    now,
+  );
 
   const session = await startAgentSession(
     deps.stateStore,
@@ -127,8 +127,8 @@ export async function runPlanning(
         chat: deps.chat,
         runTool: async ({ tool, question }) => {
           const bare = tool.replace(/^\//, '');
-          if (!READ_TOOLS.has(bare)) throw new Error(`不支持的工具：${tool}`);
-          const run = await deps.enqueueRun(pr, bare as 'describe' | 'review' | 'ask', question);
+          if (!READ_RUN_TOOL_IDS.has(bare)) throw new Error(`不支持的工具：${tool}`);
+          const run = await deps.enqueueRun(pr, bare as ReviewRunTool, question);
           if (run.status !== 'succeeded') {
             throw new Error(`pr-agent ${bare} 未成功：${run.errorMessage ?? run.status}`);
           }

--- a/docs/arch/06-agent.md
+++ b/docs/arch/06-agent.md
@@ -233,6 +233,10 @@ flowchart TD
 LLM「越权」产出一个 `/approve` 调用，运行时也拒绝并记入 transcript。这样「提示词被绕过」
 不等于「操作被执行」。
 
+**工具清单单一真相源**：所有工具（id / 命令名 / 读改分类 / grant / 是否运行队列工具）集中声明在共享层的
+**统一注册表 `TOOLS`（tool-registry）**；运行工具枚举 `ReviewRunTool`、工具目录 `buildToolCatalog`、规划红线
+允许集均由它派生——新增 / 调整工具只改注册表一处。
+
 ### 5. 会话隔离与规则共享
 
 - **规则 / 上下文共享**：`agent.dir`（SOUL / AGENTS / MEMORY / USER / rules）是**全局单份**，所有

--- a/packages/agent/resources/prompts/autopilot-judge.md
+++ b/packages/agent/resources/prompts/autopilot-judge.md
@@ -1,6 +1,9 @@
 You decide, for each pull request below, whether an automated pre-review is worth running and (optionally) which review steps to run.
 
+Each PR may show `branches: <source> -> <target>`. A PR flagged `[detected branch merge]` is a same-repo integration / back-merge that brings already-reviewed changes — **skip it** (`review: false`) unless the title/description clearly indicate original work that warrants review.
+
 For each PR return:
+
 - `review`: true to run the review, false to SKIP it. Default to reviewing; SKIP PRs not worth it — e.g. branch merges / back-merges, pure dependency bumps, or trivial mechanical changes.
 - `reason`: a short reason.
 - `plan` (optional): a custom ordered list of review-step ids. OMIT it to run the full default flow (`describe-review` → `judge` → `asks` → `summary`). Only set it when a project rule asks to customize the steps. Available step ids:

--- a/packages/agent/src/autopilot-judge.ts
+++ b/packages/agent/src/autopilot-judge.ts
@@ -22,6 +22,11 @@ export interface JudgeCandidate {
   prLocalId: string;
   title: string;
   description?: string;
+  /** 源 / 目标分支名（背景输入，助判分支合并 / 回合并）。 */
+  sourceBranch?: string;
+  targetBranch?: string;
+  /** 调用方据元数据判出的「纯分支合并」信号（见 classifyBranchMerge）；true 时强烈倾向 skip。 */
+  branchMerge?: boolean;
 }
 
 export interface JudgeDecision {
@@ -63,10 +68,13 @@ export async function judgeAutopilotBatch(
     .join('\n');
 
   const list = input.candidates
-    .map(
-      (c, i) =>
-        `${String(i + 1)}. [id:${c.prLocalId}] ${c.title}\n${(c.description ?? '').trim().slice(0, DESC_CLAMP)}`,
-    )
+    .map((c, i) => {
+      const branch =
+        c.sourceBranch && c.targetBranch
+          ? `\nbranches: ${c.sourceBranch} -> ${c.targetBranch}${c.branchMerge ? '  [detected branch merge — prefer skip]' : ''}`
+          : '';
+      return `${String(i + 1)}. [id:${c.prLocalId}] ${c.title}${branch}\n${(c.description ?? '').trim().slice(0, DESC_CLAMP)}`;
+    })
     .join('\n\n');
 
   const user = [
@@ -98,7 +106,12 @@ export async function judgeAutopilotBatch(
 
   // 解析缺失的候选默认评审，保证每个候选都有决策。
   const decisions = input.candidates.map(
-    (c) => byId.get(c.prLocalId) ?? { prLocalId: c.prLocalId, review: true, reason: 'default (unparsed)' },
+    (c) =>
+      byId.get(c.prLocalId) ?? {
+        prLocalId: c.prLocalId,
+        review: true,
+        reason: 'default (unparsed)',
+      },
   );
   return { decisions, usage: r.usage };
 }

--- a/packages/agent/src/branch-merge.ts
+++ b/packages/agent/src/branch-merge.ts
@@ -1,0 +1,47 @@
+/**
+ * 「纯分支合并」判定（AutoPilot 第一步 judge 的背景输入，见 docs/arch/06-agent.md）：分支合并 / 回合并
+ * 把已评审过的分支改动同步到另一分支，无原创工作，自动预评审无意义。判定**只用元数据**，分两级：
+ * - (c) 分支约定：源分支是长期 / 集成分支（main / develop / release/* 等）→ 把它合进别处即回合并 / 同步。
+ *   纯元数据、零成本、零网络。
+ * - (b) 提交结构（(c) 拿不准时）：PR 提交**全为 merge commit**（无原创非 merge 提交）→ 纯合并。需调用方
+ *   先经 commits API 拉取提交（远端元数据，不碰本地 git）后传入。
+ *
+ * 个人仓库 / fork 贡献 PR 的源分支通常是 feature 分支、不命中 (c)，且含原创提交、不命中 (b)，故天然不误判。
+ */
+
+const MAINLINE_EXACT = new Set(['main', 'master', 'develop', 'dev', 'trunk']);
+const MAINLINE_PREFIX = ['release/', 'hotfix/'];
+
+/** 源分支是否为长期 / 集成分支（其改动通常已在自身 PR 评审过）。 */
+export function isMainlineBranch(branch: string): boolean {
+  const b = branch.trim().toLowerCase();
+  return MAINLINE_EXACT.has(b) || MAINLINE_PREFIX.some((p) => b.startsWith(p));
+}
+
+export interface BranchMergeInput {
+  sourceBranch: string;
+  targetBranch: string;
+  /** PR 提交（可选）；(c) 拿不准时由调用方拉取后传入做 (b) 判定。 */
+  commits?: ReadonlyArray<{ parents: string[] }>;
+}
+
+export interface BranchMergeVerdict {
+  isBranchMerge: boolean;
+  /** 判定依据：分支约定 (c) / 提交结构 (b) / 无法判断（未提供 commits 且不命中 (c)）。 */
+  basis: 'branch-convention' | 'commits' | 'inconclusive';
+}
+
+/**
+ * 判定一个 PR 是否「纯分支合并」。(c) 优先（零成本）；不命中且给了 commits 才走 (b)；都不命中 → inconclusive
+ * （调用方据此决定是否拉 commits 再判一次，或交给 LLM judge）。
+ */
+export function classifyBranchMerge(input: BranchMergeInput): BranchMergeVerdict {
+  if (isMainlineBranch(input.sourceBranch)) {
+    return { isBranchMerge: true, basis: 'branch-convention' };
+  }
+  if (input.commits) {
+    const allMerges = input.commits.length > 0 && input.commits.every((c) => c.parents.length > 1);
+    return { isBranchMerge: allMerges, basis: 'commits' };
+  }
+  return { isBranchMerge: false, basis: 'inconclusive' };
+}

--- a/packages/agent/src/constants.ts
+++ b/packages/agent/src/constants.ts
@@ -36,20 +36,8 @@ export const AGENT_RULES_SUBDIR = 'rules';
 /** 全空上下文文件集：空 agentDir / 读失败时的失败安全回退（Agent 退化为原生）。 */
 export const EMPTY_FILES: AgentContextFiles = { soul: '', agents: '', memory: '', user: '' };
 
-// ── 工具目录与红线（见 docs/arch/06-agent.md「工具修改红线」）──
-/** 只读 / 分析类工具：始终可用。 */
-export const READ_TOOLS = [
-  { name: '/describe', summary: 'Generate the PR description.' },
-  { name: '/review', summary: 'Generate review findings.' },
-  { name: '/ask', summary: 'Ask a free-form question about the PR.' },
-] as const;
-
-/** 修改类工具：对远端有副作用，默认禁止；`grant` 是授权它所需的 grants 项。 */
-export const MUTATING_TOOLS = [
-  { name: '/approve', summary: 'Approve the PR.', grant: 'approve' },
-  { name: '/needswork', summary: 'Request changes on the PR.', grant: 'needs_work' },
-  { name: '/publish', summary: 'Publish review comments to the remote.', grant: 'publish_comment' },
-] as const;
+// 工具清单（读 / 改 / grant）已收口到 @meebox/shared 的统一注册表 tool-registry（TOOLS）；
+// 工具目录由 buildToolCatalog 从中派生，见 tool-catalog.ts。
 
 // ── 工具并发错开（见 stagger.ts）──
 /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,4 @@
-export { AGENT_FILES, AGENT_RULES_SUBDIR, READ_TOOLS, MUTATING_TOOLS } from './constants.js';
+export { AGENT_FILES, AGENT_RULES_SUBDIR } from './constants.js';
 export {
   resolveAgentPaths,
   loadAgentContext,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,11 +11,7 @@ export { appendAgentNotes } from './memory.js';
 export type { MemoryNote, WritableAgentFile } from './memory.js';
 export type { AgentContext, AgentContextFiles, LoadAgentContextOptions } from './types.js';
 export { assembleSystemContext } from './prompts.js';
-export type {
-  AssembleInput,
-  AssemblePrMeta,
-  AssembleSessionSnapshot,
-} from './prompts.js';
+export type { AssembleInput, AssemblePrMeta, AssembleSessionSnapshot } from './prompts.js';
 export { runReviewMicroflow } from './orchestrator.js';
 export { DEFAULT_REVIEW_PLAN, isValidReviewPlan } from './steps/review/index.js';
 export type { ReviewPlan, ReviewStepKind } from './steps/review/index.js';
@@ -29,6 +25,8 @@ export type {
   PlanningToolResult,
 } from './planner.js';
 export { buildToolCatalog, assertToolAllowed } from './tool-catalog.js';
+export { classifyBranchMerge, isMainlineBranch } from './branch-merge.js';
+export type { BranchMergeInput, BranchMergeVerdict } from './branch-merge.js';
 export { judgeAutopilotBatch } from './autopilot-judge.js';
 export type {
   AutopilotJudgeInput,

--- a/packages/agent/src/tool-catalog.ts
+++ b/packages/agent/src/tool-catalog.ts
@@ -1,31 +1,25 @@
-import type { ToolCatalogEntry } from '@meebox/shared';
-import { MUTATING_TOOLS, READ_TOOLS } from './constants.js';
+import { TOOLS, type ToolCatalogEntry } from '@meebox/shared';
 
 /**
  * 工具目录与修改红线（见 docs/arch/06-agent.md「工具修改红线」）。读 / 分析类工具 Agent 始终可自主调用；
  * 修改类（对远端有副作用）**默认禁止**，仅在 `grants` 显式授权时放行——以**禁用态**注入目录（Agent 知其
  * 存在但不可调用），并由 `assertToolAllowed` 在分发入口**运行时硬校验**：即便 LLM 越权产出修改类调用也被拒。
- * 工具清单常量（READ_TOOLS / MUTATING_TOOLS）见 constants.ts。
+ * 工具清单（读 / 改 / grant）来自 @meebox/shared 的统一注册表 `TOOLS`（tool-registry）。
  */
 
 /**
- * 构建工具目录：读类 enabled=true；修改类仅在 grants 含其授权项时 enabled，否则禁用态。
+ * 构建工具目录：读类 enabled=true；修改类仅在 grants 含其授权项时 enabled，否则禁用态。从注册表派生。
  */
 export function buildToolCatalog(grants: ReadonlyArray<string> = []): ToolCatalogEntry[] {
   const granted = new Set(grants);
-  return [
-    ...READ_TOOLS.map(
-      (t): ToolCatalogEntry => ({ name: t.name, summary: t.summary, mutating: false, enabled: true }),
-    ),
-    ...MUTATING_TOOLS.map(
-      (t): ToolCatalogEntry => ({
-        name: t.name,
-        summary: t.summary,
-        mutating: true,
-        enabled: granted.has(t.grant),
-      }),
-    ),
-  ];
+  return TOOLS.map(
+    (t): ToolCatalogEntry => ({
+      name: t.command,
+      summary: t.summary,
+      mutating: t.kind === 'mutating',
+      enabled: t.kind === 'mutating' ? granted.has(t.grant) : true,
+    }),
+  );
 }
 
 /**

--- a/packages/agent/tests/branch-merge.test.ts
+++ b/packages/agent/tests/branch-merge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { classifyBranchMerge, isMainlineBranch } from '../src/branch-merge.js';
+
+describe('isMainlineBranch', () => {
+  it('recognizes long-lived / integration branches', () => {
+    for (const b of [
+      'main',
+      'master',
+      'develop',
+      'dev',
+      'trunk',
+      'release/1.2',
+      'hotfix/x',
+      'MAIN',
+    ]) {
+      expect(isMainlineBranch(b)).toBe(true);
+    }
+  });
+  it('treats feature / topic branches as non-mainline', () => {
+    for (const b of ['feature/x', 'fix/bug', 'chore/deps', 'jdoe/wip']) {
+      expect(isMainlineBranch(b)).toBe(false);
+    }
+  });
+});
+
+describe('classifyBranchMerge', () => {
+  it('(c) flags by branch convention when the source is a mainline branch', () => {
+    expect(classifyBranchMerge({ sourceBranch: 'main', targetBranch: 'feature/x' })).toEqual({
+      isBranchMerge: true,
+      basis: 'branch-convention',
+    });
+  });
+
+  it('is inconclusive for a feature source with no commits provided', () => {
+    expect(classifyBranchMerge({ sourceBranch: 'feature/x', targetBranch: 'main' })).toEqual({
+      isBranchMerge: false,
+      basis: 'inconclusive',
+    });
+  });
+
+  it('(b) flags by commits when every commit is a merge', () => {
+    const commits = [{ parents: ['a', 'b'] }, { parents: ['c', 'd'] }];
+    expect(
+      classifyBranchMerge({ sourceBranch: 'feature/x', targetBranch: 'main', commits }),
+    ).toEqual({
+      isBranchMerge: true,
+      basis: 'commits',
+    });
+  });
+
+  it('(b) does not flag when there is an original (non-merge) commit', () => {
+    const commits = [{ parents: ['a', 'b'] }, { parents: ['c'] }];
+    expect(
+      classifyBranchMerge({ sourceBranch: 'feature/x', targetBranch: 'main', commits }),
+    ).toEqual({
+      isBranchMerge: false,
+      basis: 'commits',
+    });
+  });
+
+  it('(b) does not flag an empty commit list', () => {
+    expect(
+      classifyBranchMerge({ sourceBranch: 'feature/x', targetBranch: 'main', commits: [] }),
+    ).toEqual({ isBranchMerge: false, basis: 'commits' });
+  });
+});

--- a/packages/agent/tests/tool-catalog.test.ts
+++ b/packages/agent/tests/tool-catalog.test.ts
@@ -5,7 +5,18 @@ describe('buildToolCatalog', () => {
   it('enables read tools and disables mutating tools by default', () => {
     const cat = buildToolCatalog();
     expect(cat.find((e) => e.name === '/review')).toMatchObject({ mutating: false, enabled: true });
-    expect(cat.find((e) => e.name === '/approve')).toMatchObject({ mutating: true, enabled: false });
+    expect(cat.find((e) => e.name === '/approve')).toMatchObject({
+      mutating: true,
+      enabled: false,
+    });
+  });
+
+  it('includes /improve as an enabled read tool (derived from the registry, no longer an orphan)', () => {
+    const cat = buildToolCatalog();
+    expect(cat.find((e) => e.name === '/improve')).toMatchObject({
+      mutating: false,
+      enabled: true,
+    });
   });
 
   it('enables a mutating tool only when its grant is present', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export * from './platform.js';
 export * from './poller-contract.js';
 export * from './pr-agent-status.js';
 export * from './sync-progress.js';
+export * from './tool-registry.js';

--- a/packages/shared/src/poller-contract.ts
+++ b/packages/shared/src/poller-contract.ts
@@ -1,5 +1,6 @@
 import type { PlatformKind, PrDiscoveryFilter, PullRequest } from './platform.js';
 import type { PrAgentStrategy } from './pr-agent-status.js';
+import type { ReviewRunTool } from './tool-registry.js';
 
 /**
  * 本地 review 判定。和 Bitbucket reviewer.status 一一对应，UI 由它驱动两个 toggle 按钮：
@@ -11,20 +12,9 @@ import type { PrAgentStrategy } from './pr-agent-status.js';
  */
 export type LocalPrStatus = 'pending' | 'approved' | 'needs_work';
 
-/**
- * pr-agent 跑的工具枚举：
- * - describe / review：生成 PR 描述 / 代码评审，输出落到工作树的 markdown 文件
- * - ask：自然语言追问，输出走 stdout (没有专属 output 文件)，request 必带 question
- * - improve：逐行代码改进建议；pr-agent local provider 不实现
- *   `publish_code_suggestions`，所以走 `publish_comment` 把汇总 markdown 写到
- *   `review.md` (跟 review / ask 共用)。每条建议形态：
- *     <details><summary>file<br>[start-end]:</summary>...```diff\nold\nnew\n```...</details>
- *   parseReviewOutput 对 tool='improve' 走专门解析路径，把每条 details 拆成
- *   带 anchor (path / startLine / endLine) 的 code-feedback finding。
- *
- * 后续 /reflect 等接进来时往这里加值
- */
-export type ReviewRunTool = 'describe' | 'review' | 'ask' | 'improve';
+// 工具枚举 ReviewRunTool 见统一注册表 tool-registry（新增工具改那里）。注：improve 的 pr-agent local
+// provider 不实现 `publish_code_suggestions`，输出走 review.md（与 review / ask 共用）；parseReviewOutput
+// 对 tool='improve' 走专门解析路径，把每条 <details> 建议拆成带 anchor 的 code-feedback finding。
 
 export type ReviewRunStatus = 'running' | 'succeeded' | 'failed' | 'cancelled';
 
@@ -59,20 +49,20 @@ export type FindingCategory = 'description' | 'general' | 'code-feedback';
  * 是否隐藏 / 后续做特化卡片。
  */
 export type PrDocSectionKey =
-  | 'title'             // 建议的 PR 标题
-  | 'pr-type'           // 类型标签 (Bug fix / Enhancement / Tests / ...)
-  | 'summary'           // /review 顶部总结
-  | 'description'       // 主描述段
-  | 'diagram'           // 架构图（changes_diagram，mermaid）
-  | 'assessment'        // 思路建议（注入字段：替代方案 + 倾向性建议，对齐 Qodo High-Level Assessment）
-  | 'walkthrough'       // 文件级走查
-  | 'relevant-tests'    // 相关测试
-  | 'security'          // 安全发现
-  | 'code-feedback'     // /review 单条 finding (带 file:line anchor)
-  | 'code-suggestion'   // /improve 单条改进建议 (带 file:line anchor + existing/improved diff)
-  | 'effort'            // 评估工作量 1-5
-  | 'score'             // 质量分
-  | 'general';          // 兜底，未识别
+  | 'title' // 建议的 PR 标题
+  | 'pr-type' // 类型标签 (Bug fix / Enhancement / Tests / ...)
+  | 'summary' // /review 顶部总结
+  | 'description' // 主描述段
+  | 'diagram' // 架构图（changes_diagram，mermaid）
+  | 'assessment' // 思路建议（注入字段：替代方案 + 倾向性建议，对齐 Qodo High-Level Assessment）
+  | 'walkthrough' // 文件级走查
+  | 'relevant-tests' // 相关测试
+  | 'security' // 安全发现
+  | 'code-feedback' // /review 单条 finding (带 file:line anchor)
+  | 'code-suggestion' // /improve 单条改进建议 (带 file:line anchor + existing/improved diff)
+  | 'effort' // 评估工作量 1-5
+  | 'score' // 质量分
+  | 'general'; // 兜底，未识别
 
 export interface FindingAnchor {
   path: string;

--- a/packages/shared/src/tool-registry.ts
+++ b/packages/shared/src/tool-registry.ts
@@ -1,0 +1,87 @@
+/**
+ * 统一工具注册表（唯一真相源，见 docs/arch/06-agent.md「工具修改红线」）。新增 / 调整工具只改这里，
+ * 下列派生物自动跟随：
+ * - `ReviewRunTool`：pr-agent 运行队列工具 id（`isRun`）。
+ * - agent 工具目录 `buildToolCatalog`：按 `kind` 标读 / 改、按 `grant` 放行修改类（红线策略在 agent 层）。
+ * - 规划红线允许集：`READ_RUN_TOOL_IDS`。
+ */
+
+/** 工具读 / 改分类。read 始终可用；mutating 对远端有副作用、默认禁止，仅 grant 放行。 */
+export type ToolKind = 'read' | 'mutating';
+
+export interface ToolSpec {
+  /** 规范 id（无斜杠），如 `describe`。 */
+  id: string;
+  /** 展示 / 调用名（带斜杠），如 `/describe`。 */
+  command: string;
+  /** 一句话说明（注入工具目录提示词；面向 LLM，英语）。 */
+  summary: string;
+  kind: ToolKind;
+  /** 修改类放行所需的 grant 键；读类省略。 */
+  grant?: string;
+  /** 是否为 pr-agent 运行队列工具（经 run-queue 产出 ReviewRun）。 */
+  isRun: boolean;
+}
+
+export const TOOLS = [
+  {
+    id: 'describe',
+    command: '/describe',
+    summary: 'Generate the PR description.',
+    kind: 'read',
+    isRun: true,
+  },
+  {
+    id: 'review',
+    command: '/review',
+    summary: 'Generate review findings.',
+    kind: 'read',
+    isRun: true,
+  },
+  {
+    id: 'ask',
+    command: '/ask',
+    summary: 'Ask a free-form question about the PR.',
+    kind: 'read',
+    isRun: true,
+  },
+  {
+    id: 'improve',
+    command: '/improve',
+    summary: 'Generate code improvement suggestions.',
+    kind: 'read',
+    isRun: true,
+  },
+  {
+    id: 'approve',
+    command: '/approve',
+    summary: 'Approve the PR.',
+    kind: 'mutating',
+    grant: 'approve',
+    isRun: false,
+  },
+  {
+    id: 'needswork',
+    command: '/needswork',
+    summary: 'Request changes on the PR.',
+    kind: 'mutating',
+    grant: 'needs_work',
+    isRun: false,
+  },
+  {
+    id: 'publish',
+    command: '/publish',
+    summary: 'Publish review comments to the remote.',
+    kind: 'mutating',
+    grant: 'publish_comment',
+    isRun: false,
+  },
+] as const satisfies readonly ToolSpec[];
+
+/** pr-agent 运行队列工具 id（注册表中 `isRun` 的项）。 */
+export type ReviewRunTool = Extract<(typeof TOOLS)[number], { isRun: true }>['id'];
+
+/** 读类运行工具 id 集合：规划（ReAct）红线只放行这些工具自主调用，校验用。 */
+export const READ_RUN_TOOL_IDS: ReadonlySet<string> = new Set(
+  TOOLS.filter((t) => t.isRun && t.kind === 'read').map((t) => t.id),
+);


### PR DESCRIPTION
## 概述

两块 agent 改进（2 commits）：① autopilot 第一步 judge 增加「纯分支合并」背景输入 + 决策日志；② 工具层收口为单一注册表。

## 1. autopilot 分支合并判定（`d869e72`）

第一步 judge(`judgeAutopilotBatch`)本就在 describe/review 之前,但它只拿 title+desc、判不出分支合并。补元数据背景信号:
- **[branch-merge.ts](packages/agent/src/branch-merge.ts) `classifyBranchMerge`**:(c) 源分支是长期/集成分支(`main`/`develop`/`release/*` 等)→ 回合并/同步,零成本;(c) 拿不准且给了 commits → (b) 提交**全为 merge commit**(无原创提交)→ 纯合并。fork/个人仓库贡献 PR 天然不误判。
- **autopilot.ts**:每候选先 (c),inconclusive 再调一次 commits API 走 (b)(并行,失败按非合并处理),把分支名 + branchMerge 信号喂给 judge。
- **judge prompt**:标注 `branches: a -> b [detected branch merge]`,指引 detected branch merge → skip。
- **决策日志**:每条 judge 决策(review/skip + reason + plan + branchMerge)记日志,解决「看不到 judge 在跑」的观感问题。

review 后的 `JudgeStep`(定追问)是第二阶段,未动。

## 2. 工具层统一注册表（`5673de9`）

工具清单原散在三处(`ReviewRunTool` 联合 / agent `READ_TOOLS`·`MUTATING_TOOLS` / planning 本地 read 集),`/improve` 在词汇表却不在目录(孤儿)。收口为单一真相源:
- shared 新增 **[tool-registry.ts](packages/shared/src/tool-registry.ts) `TOOLS`**(id/command/summary/kind/grant/isRun)。`ReviewRunTool` 由 isRun 派生;`READ_RUN_TOOL_IDS` 供规划红线。
- agent `buildToolCatalog` 从 `TOOLS` 按 kind/grant 派生(删常量);planning 红线用 `READ_RUN_TOOL_IDS`。
- **红线策略一字未改**(`assertToolAllowed`/默认禁改/grant 放行)。
- **`/improve` 脱孤儿**:进注册表(read+isRun+enabled)→ 自动进目录、自由规划 agent 可调度;评审微流程固定步骤不受影响。
- → 加工具只改注册表一处。

## 验证

每 commit：shared/agent/desktop typecheck/lint、agent 62/62（含分支合并 7 项 + /improve）、desktop build 全绿。docs/arch/06-agent.md 同步更新两处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)