### PR TITLE
feat(agent): 评审计划新增 improve 步（规则可让 autopilot 增删工具）

### DIFF
--- a/apps/desktop/src/main/i18n/locales/de-DE.json
+++ b/apps/desktop/src/main/i18n/locales/de-DE.json
@@ -2,6 +2,7 @@
   "agent": {
     "steps": {
       "describeReview": "PR-Beschreibung und Review-Befunde erstellen",
+      "improve": "Code-Verbesserungsvorschläge erstellen",
       "judge": "Entscheiden, ob wichtige Probleme eine Rückfrage erfordern",
       "judgeNone": "Keine wichtigen Probleme — keine Rückfrage",
       "judgeSevere_one": "Wichtig — {{count}} Rückfrage",

--- a/apps/desktop/src/main/i18n/locales/en-US.json
+++ b/apps/desktop/src/main/i18n/locales/en-US.json
@@ -2,6 +2,7 @@
   "agent": {
     "steps": {
       "describeReview": "Generate the PR description and review findings",
+      "improve": "Generate code improvement suggestions",
       "judge": "Decide whether there are important issues needing follow-up",
       "judgeNone": "No important issues — no follow-up",
       "judgeSevere_one": "Important — {{count}} follow-up question",

--- a/apps/desktop/src/main/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/main/i18n/locales/ja-JP.json
@@ -2,6 +2,7 @@
   "agent": {
     "steps": {
       "describeReview": "PR の説明とコードレビュー指摘を生成",
+      "improve": "コード改善提案を生成",
       "judge": "追加質問が必要な重要な問題があるか判断",
       "judgeNone": "重要な問題なし、追加質問なし",
       "judgeSevere_other": "重要、追加質問 {{count}} 件",

--- a/apps/desktop/src/main/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/main/i18n/locales/zh-CN.json
@@ -2,6 +2,7 @@
   "agent": {
     "steps": {
       "describeReview": "生成 PR 描述与审查发现",
+      "improve": "生成代码改进建议",
       "judge": "判断是否存在需追问的重要问题",
       "judgeNone": "无重要问题，不追问",
       "judgeSevere_other": "重要，追问 {{count}} 个",

--- a/apps/desktop/src/main/services/agent/labels.ts
+++ b/apps/desktop/src/main/services/agent/labels.ts
@@ -11,6 +11,7 @@ import { t } from '../../i18n/index.js';
 export function buildStepLabels(): AgentStepLabels {
   return {
     describeReview: t('agent.steps.describeReview'),
+    improve: t('agent.steps.improve'),
     judge: t('agent.steps.judge'),
     judgeSevere: (n) => t('agent.steps.judgeSevere', { count: n }),
     judgeNone: t('agent.steps.judgeNone'),

--- a/apps/desktop/src/main/services/agent/review.ts
+++ b/apps/desktop/src/main/services/agent/review.ts
@@ -5,6 +5,7 @@ import type {
   AgentSession,
   AgentStep,
   ReviewRun,
+  ReviewRunTool,
   StoredPullRequest,
   TokenUsage,
   ToolCatalogEntry,
@@ -30,11 +31,7 @@ function reviewRunText(run: ReviewRun): string {
 export interface ReviewDeps {
   stateStore: StateStore;
   /** 入队一个 pr-agent run，resolve 完成的 ReviewRun（与用户手动 run 共用队列）。 */
-  enqueueRun: (
-    pr: StoredPullRequest,
-    tool: 'describe' | 'review' | 'ask',
-    question?: string,
-  ) => Promise<ReviewRun>;
+  enqueueRun: (pr: StoredPullRequest, tool: ReviewRunTool, question?: string) => Promise<ReviewRun>;
   /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
   chat: (input: { system: string; user: string }) => Promise<{ text: string; usage?: TokenUsage }>;
   agentContext: AgentContext;

--- a/docs/arch/06-agent.md
+++ b/docs/arch/06-agent.md
@@ -380,12 +380,14 @@ flowchart TD
 **步骤计划可经规则定制（plan）**：上述微流程是**默认序列**（`describe-review` → `judge` → `asks` →
 `summary`，由步骤注册表 `REVIEW_STEP_REGISTRY` 组装、`assembleReviewSteps` 装配），而非写死。批量判定时，
 规划 agent 可据 `AGENTS.md` 规则为单个 PR 给出**自定义计划**（一组有序步骤 id），从而**跳过 / 重排 /
-裁剪**步骤——例如规则「配置类 PR 只生成描述与 findings、跳过追问」即得 `["describe-review", "summary"]`。
-计划**省略或非法时回落默认全集**：合法性校验 `isValidReviewPlan`——步骤 id 须在注册表内，且含 `judge` /
-`summary` 时必须先含 `describe-review`（后两步读其产物）；判定层与微流程驱动处**双重守卫**，坏计划不致崩在
-步骤里。**仅 autopilot 走计划**：手动评审按钮不经判定层、恒跑默认全集，不受规则影响。「跳过整篇」仍用判定的
-`review:false`（计划用于「评审但裁剪步骤」，非整篇跳过）。后续若要让计划引入**新工具**（如 `/improve`），
-在 `REVIEW_STEP_REGISTRY` 登记对应步骤、并入步骤 id 词表并放开 `runTool` 工具类型即可，驱动与手动路径无需改动。
+增删**步骤。可用步骤 id：`describe-review`、`improve`（生成代码改进建议，独立、默认不含、规则要时纳入）、
+`judge`、`asks`、`summary`——例如「配置类 PR 只生成描述与 findings、跳过追问」得 `["describe-review",
+"summary"]`；「需改进建议」得 `["describe-review", "improve", "summary"]`。计划**省略或非法时回落默认全集**：
+合法性校验 `isValidReviewPlan`——步骤 id 须在注册表内，且含 `judge` / `summary` 时必须先含 `describe-review`
+（后两步读其产物）；判定层与微流程驱动处**双重守卫**，坏计划不致崩在步骤里。**仅 autopilot 走计划**：手动
+评审按钮不经判定层、恒跑默认全集，不受规则影响。「跳过整篇」仍用判定的 `review:false`（计划用于「评审但裁剪 /
+增删步骤」，非整篇跳过）。新增工具步 = 在 `REVIEW_STEP_REGISTRY` 登记 + 并入 `ReviewStepKind`（工具本身见
+统一注册表 `TOOLS`）。
 
 **不自动发布**：上述全部产物——草稿、追问回答、总结——**只落本地、进待确认状态**，
 进应用即见,**不自动写远端**（除非 §4 / §6 扩展显式授权）。决策权仍在评审者。
@@ -394,9 +396,9 @@ flowchart TD
 
 - **规划 agent（planner）**：只做「批量判定 + 派发」，预算极小（一次 judge pass + 分发），
   不自由展开。
-- **每个 PR 的 agent**：**不自由规划**，只执行 planner 派的微流程——默认模板，或规则定制的计划（计划
-  仅在**既有步骤内裁剪 / 重排**、不引入新工具，故只会**减步**不会加步）；模板内唯一可变处是 0..N 个条件性
-  追问。故步数上限**由模板形状推导**，不套用更宽的交互式 `agent.max_steps`：硬上限 ≈
+- **每个 PR 的 agent**：**不自由规划**，只执行 planner 派的微流程——默认模板，或规则定制的计划（计划在
+  注册表既有步骤内裁剪 / 重排 / 增删，最多纳入一个 `improve` 步，**不会自由展开**）；模板内另一可变处是
+  0..N 个条件性追问。故步数上限**由模板形状 + 计划推导**，不套用更宽的交互式 `agent.max_steps`：硬上限 ≈
   `2（describe + review）+ max_followup_asks + 1（summary）` + 少量判定开销，
   **唯一能推高它的可调量是 `max_followup_asks`**。另设结构化硬 backstop
   `agent.autopilot.max_steps`（默认按上式推导、运行期不超过它）兜底，防自循环把背景任务撑爆；

--- a/packages/agent/resources/prompts/autopilot-judge.md
+++ b/packages/agent/resources/prompts/autopilot-judge.md
@@ -8,6 +8,7 @@ For each PR return:
 - `reason`: a short reason.
 - `plan` (optional): a custom ordered list of review-step ids. OMIT it to run the full default flow (`describe-review` → `judge` → `asks` → `summary`). Only set it when a project rule asks to customize the steps. Available step ids:
   - `describe-review`: generate the PR description and the code-review findings (REQUIRED whenever `judge` or `summary` is included)
+  - `improve`: generate code improvement suggestions (independent; include it only when a rule asks for improvement suggestions)
   - `judge`: decide whether follow-up questions are needed
   - `asks`: ask the follow-up questions deemed necessary
   - `summary`: synthesize the review summary + recommendation

--- a/packages/agent/src/orchestrator.ts
+++ b/packages/agent/src/orchestrator.ts
@@ -1,5 +1,11 @@
 import type { Rule } from '@meebox/rules';
-import type { AgentRecommendation, AgentStep, TokenUsage, ToolCatalogEntry } from '@meebox/shared';
+import type {
+  AgentRecommendation,
+  AgentStep,
+  ReviewRunTool,
+  TokenUsage,
+  ToolCatalogEntry,
+} from '@meebox/shared';
 import { assembleSystemContext, type AssemblePrMeta } from './prompts.js';
 import { createStepRecorder } from './steps/context.js';
 import {
@@ -27,7 +33,7 @@ export interface ToolText {
 
 export interface ReviewOrchestratorDeps {
   /** 分发一个只读 pr-agent 工具，返回文本结果（描述 / findings / 回答）。 */
-  runTool(call: { tool: 'describe' | 'review' | 'ask'; question?: string }): Promise<ToolText>;
+  runTool(call: { tool: ReviewRunTool; question?: string }): Promise<ToolText>;
   /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。maxOutputTokens 可给轻量路由判读封顶输出。 */
   chat(input: { system: string; user: string; maxOutputTokens?: number }): Promise<ToolText>;
   /** 每产生一个编排步骤即回调（持久化 / 流式推送）。 */
@@ -83,6 +89,8 @@ export const DEFAULT_SUMMARY_SECTIONS: readonly [string, string, string] = [
 export interface AgentStepLabels {
   /** 微流程「生成 PR 描述与审查发现」步思考（describe + review 合并为一行；二者并行执行）。 */
   describeReview: string;
+  /** 微流程「生成代码改进建议」步思考（/improve；仅规则计划纳入时出现）。 */
+  improve: string;
   /** 微流程判读步思考。 */
   judge: string;
   /** 判读结果：存在严重问题、将追问 n 个。 */
@@ -99,6 +107,7 @@ export interface AgentStepLabels {
 /** 步骤文案默认值（en-US 兜底）；多语言由主进程 i18n 解析后经 input.labels 注入，未注入时回落本默认。 */
 export const DEFAULT_STEP_LABELS: AgentStepLabels = {
   describeReview: 'Generate the PR description and review findings',
+  improve: 'Generate code improvement suggestions',
   judge: 'Decide whether there are important issues needing follow-up',
   judgeSevere: (n) => `Important — ${String(n)} follow-up question${n === 1 ? '' : 's'}`,
   judgeNone: 'No important issues — no follow-up',
@@ -149,7 +158,10 @@ export async function runReviewMicroflow(
   return {
     steps: rec.steps,
     summary: ctx.bag.summary ?? '',
-    recommendation: ctx.bag.recommendation ?? { verdict: 'manual_review', reason: labels.parseFail },
+    recommendation: ctx.bag.recommendation ?? {
+      verdict: 'manual_review',
+      reason: labels.parseFail,
+    },
     tokenUsage: rec.usage,
   };
 }

--- a/packages/agent/src/steps/review/improve-step.ts
+++ b/packages/agent/src/steps/review/improve-step.ts
@@ -1,0 +1,18 @@
+import { Step } from '../context.js';
+import type { ReviewStepCtx } from './shared.js';
+
+/**
+ * 生成代码改进建议（只读 /improve）。先把本步思考流式出去（思考在前），再派发工具；建议以
+ * code-suggestion findings 经各自 run 卡片呈现（parseReviewOutput 对 tool='improve' 走专门解析），
+ * 故无需回填 bag。**默认计划不含本步**——仅当规则给出的计划纳入 `improve` 时才执行。
+ */
+export class ImproveStep extends Step<ReviewStepCtx> {
+  readonly name = 'improve';
+
+  async run(ctx: ReviewStepCtx): Promise<void> {
+    ctx.checkAbort();
+    await ctx.rec.record({ kind: 'plan', thought: ctx.labels.improve });
+    const result = await ctx.deps.runTool({ tool: 'improve' });
+    ctx.rec.track(result.usage);
+  }
+}

--- a/packages/agent/src/steps/review/index.ts
+++ b/packages/agent/src/steps/review/index.ts
@@ -1,6 +1,7 @@
 import type { Step } from '../context.js';
 import { AsksStep } from './asks-step.js';
 import { DescribeReviewStep } from './describe-review-step.js';
+import { ImproveStep } from './improve-step.js';
 import { JudgeStep } from './judge-step.js';
 import type { ReviewStepCtx } from './shared.js';
 import { SummaryStep } from './summary-step.js';
@@ -9,9 +10,9 @@ export type { ReviewBag, ReviewStepCtx } from './shared.js';
 
 /**
  * 评审微流程可用步骤的稳定标识（与各 step.name 对应）。一份评审计划即由这些 kind 有序组成。
- * 新增工具步（如 'improve'）= 在 REVIEW_STEP_REGISTRY 登记 + 在此并上 kind，驱动与默认计划无需改动。
+ * 新增工具步 = 在 REVIEW_STEP_REGISTRY 登记 + 在此并上 kind，驱动与默认计划无需改动。
  */
-export type ReviewStepKind = 'describe-review' | 'judge' | 'asks' | 'summary';
+export type ReviewStepKind = 'describe-review' | 'improve' | 'judge' | 'asks' | 'summary';
 
 /**
  * 评审微流程执行计划：一组**有序**步骤 kind。AutoPilot 后续可据用户 agent 上下文规则给出自定义计划
@@ -25,6 +26,7 @@ export interface ReviewPlan {
 /** 步骤注册表（kind → 无状态单例）。各 step 运行态全在 ctx，故单例可复用。 */
 export const REVIEW_STEP_REGISTRY: Record<ReviewStepKind, Step<ReviewStepCtx>> = {
   'describe-review': new DescribeReviewStep(),
+  improve: new ImproveStep(),
   judge: new JudgeStep(),
   asks: new AsksStep(),
   summary: new SummaryStep(),

--- a/packages/agent/tests/orchestrator.test.ts
+++ b/packages/agent/tests/orchestrator.test.ts
@@ -13,19 +13,21 @@ const pr = { title: 'Fix bug', targetBranch: 'main' };
 
 /** 可编排的 fake deps：runTool 按 tool 返回固定文本；chat 顺序返回排好的回复。 */
 function makeDeps(opts: {
-  toolText?: Partial<Record<'describe' | 'review' | 'ask', string>>;
+  toolText?: Partial<Record<'describe' | 'review' | 'ask' | 'improve', string>>;
   chatReplies: string[];
 }): { deps: ReviewOrchestratorDeps; toolCalls: Array<{ tool: string; question?: string }> } {
   const toolCalls: Array<{ tool: string; question?: string }> = [];
   let chatIdx = 0;
   const deps: ReviewOrchestratorDeps = {
-    runTool: vi.fn(async (call: { tool: 'describe' | 'review' | 'ask'; question?: string }) => {
-      toolCalls.push(call);
-      return {
-        text: opts.toolText?.[call.tool] ?? `${call.tool}-result`,
-        usage: { totalTokens: 10 },
-      };
-    }),
+    runTool: vi.fn(
+      async (call: { tool: 'describe' | 'review' | 'ask' | 'improve'; question?: string }) => {
+        toolCalls.push(call);
+        return {
+          text: opts.toolText?.[call.tool] ?? `${call.tool}-result`,
+          usage: { totalTokens: 10 },
+        };
+      },
+    ),
     chat: vi.fn(async () => {
       const text = opts.chatReplies[chatIdx++] ?? '{}';
       return { text, usage: { totalTokens: 5 } };
@@ -163,6 +165,20 @@ describe('runReviewMicroflow', () => {
     expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review']);
     expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'plan']);
     expect(r.summary).toBe('ok');
+  });
+
+  it('runs a plan that includes the improve step', async () => {
+    const { deps, toolCalls } = makeDeps({
+      chatReplies: ['{"summary": "ok", "recommendation": {"verdict": "approve", "reason": "r"}}'],
+    });
+    const r = await runReviewMicroflow(deps, {
+      context,
+      pr,
+      plan: { steps: ['describe-review', 'improve', 'summary'] },
+    });
+    // describe + review（并行）→ improve → summary（chat）。
+    expect(toolCalls.map((c) => c.tool)).toEqual(['describe', 'review', 'improve']);
+    expect(r.steps.map((s) => s.kind)).toEqual(['plan', 'plan', 'plan']);
   });
 
   it('falls back to the default plan when the plan is invalid (summary without describe-review)', async () => {


### PR DESCRIPTION
## 背景

判定 → plan 通道在 #100 已通：autopilot 第一步 judge 能据 AGENTS.md 规则产出 per-PR 步骤计划。但当时步骤词表只有 `describe-review / judge / asks / summary`，规则**只能裁剪 / 重排**既有步骤，**无法增删工具**。本 PR 补上 `improve` 步，让「规则驱动 plan」具备增删能力（衔接 #103 把 `/improve` 纳入统一工具注册表）。

## 改动

- **`ImproveStep`**（新）：派发只读 `/improve`，建议以 code-suggestion findings 经各自 run 卡片呈现（`parseReviewOutput` 对 improve 走专门解析），不回填 bag。
- `ReviewStepKind += 'improve'` + `REVIEW_STEP_REGISTRY` 登记；**默认计划不含 improve**（opt-in，仅规则计划纳入时执行）。
- orchestrator `runTool`、review.ts `enqueueRun` 放宽到 `ReviewRunTool`（支持 improve）；`AgentStepLabels`/`DEFAULT_STEP_LABELS` + improve；`buildStepLabels` + `agent.steps.improve`（四语言对等）。
- `autopilot-judge` prompt 列出 `improve` 为可选 step id。
- `isValidReviewPlan` 无需改（improve 无前置依赖）。

## 效果

规则示例（AGENTS.md）→ judge 产出 `["describe-review","improve","summary"]` → autopilot 实跑 describe+review+improve+总结。手动评审恒默认全集、不受影响；步数仍受 `agent.autopilot.max_steps` backstop 兜底（计划最多 +1 个 improve 步）。

## 验证

`nx test agent` 63/63（含 improve 计划测试）；shared/agent/desktop typecheck/lint、desktop build 全绿；docs/arch/06-agent.md 同步（可用 step id 列表 + 步数说明）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)