### PR TITLE
fix(chat): autopilot 思考阶段补显「思考中」指示

### DIFF
--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
@@ -13,6 +13,7 @@ import type {
   StoredPullRequest,
 } from '@meebox/shared';
 import { invoke } from '../../../../api';
+import { useChatRunStore } from '../../../../stores/chat-run-store';
 import { htmlInlineToMarkdown, stripFindingMarker } from '../utils/findings';
 
 interface UseChatActionsParams {
@@ -94,9 +95,16 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
   const { t } = useTranslation();
 
   // 记录**各 PR** 的起跑时刻（localId → since）。不同 PR 的 agent 任务可并发 / 排队，仅禁止对同一 PR 重复发起。
+  // 本地态只承载**用户手动发起**的乐观即时反馈（不等 main 广播回环）；AutoPilot 后台评审不经此处。
   const [runningPrs, setRunningPrs] = useState<Map<string, number>>(() => new Map());
+  // 编排 Agent 运行中的 PR 集合（含纯思考阶段）——来自 store 的 `agent:runningChanged`，手动与 AutoPilot
+  // 一并计入，是「是否在跑」的权威来源。
+  const { agentPrs } = useChatRunStore();
   // 仅「跑在当前 PR」才在本会话显示运行态 / 思考中；其它 PR 在跑不影响本会话发起（可并发 / 排队）。
-  const agentRunningHere = prLocalId !== undefined && runningPrs.has(prLocalId);
+  // 取「本地乐观态 ∪ store 权威态」：手动发起即时点亮（本地），AutoPilot 后台评审经 store 点亮——
+  // 否则后台评审的纯思考阶段（工具 run 跑完后的 judge / 总结）因 agentRunningHere=false 不显示「思考中」。
+  const agentRunningHere =
+    prLocalId !== undefined && (runningPrs.has(prLocalId) || agentPrs.includes(prLocalId));
 
   // 触发 /describe / /review / /ask。队列模型下 active 非空也允许提交，新 run 进
   // 队列，main 端先后串行执行。失败抛 banner；成功不需要手动 setRuns，session effect


### PR DESCRIPTION
## 问题

AutoPilot 后台评审时，工具调用阶段（/describe·/review run）完成后，judge / 总结的纯思考阶段**不显示「思考中」**实时指示；手动评审正常。

## 根因

`ThinkingLive`（实时「思考中」占位）由 `agentRunningHere` 控制，而它只从**本地 `runningPrs`** 取值——该 Map **仅由用户手动 `handleAgentReview` / `handleAgentAsk` 写入**。

- 手动评审：写本地 `runningPrs` → `agentRunningHere=true` → 思考阶段显示「思考中」。
- AutoPilot：后台 `markRunning` 经 `agent:runningChanged` 只进 **store 的 `agentPrs`**，从不写本地态 → 工具阶段（有 active run）结束后，judge / 总结阶段无 active run 且 `agentRunningHere=false` → 「思考中」不显示。

即「autopilot 专属」，病在前端运行态判定漏看了 store 里的权威集合。

> 已完成的 judge / 总结步骤行（「已思考 xx s / 判断…/ 综合…」）不受 `agentRunningHere` 约束，经时间线由持久化 + 广播的 step 正常渲染——缺的只是那段**实时占位**。

## 修复

`agentRunningHere` 改取「本地乐观态 ∪ store 权威态」：

```ts
const { agentPrs } = useChatRunStore();
const agentRunningHere =
  prLocalId !== undefined && (runningPrs.has(prLocalId) || agentPrs.includes(prLocalId));
```

- 本地 `runningPrs` 保留：手动发起**即时**点亮（不等 main 广播回环）；
- `agentPrs`（来自 `agent:runningChanged`，手动 + AutoPilot 一并计入）兜住后台评审。

手动路径行为不变；autopilot 的 judge / 总结阶段现与手动一致显示「思考中」。

## 验证

desktop typecheck / lint / build 全绿。手测：AutoPilot 评审某 PR，工具卡片跑完后进入 judge / 总结阶段 → 出现「思考中 xx s」占位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)