### PR TITLE
fix(review): m-6998252172 修正合并目标分支后的 diff 计算

### DIFF
--- a/apps/desktop/src/main/services/pr-service.ts
+++ b/apps/desktop/src/main/services/pr-service.ts
@@ -1,5 +1,10 @@
 import type { BootstrapResult } from '@meebox/config';
-import { listStoredPullRequests, readDiffBaseCache, writeDiffBaseCache } from '@meebox/poller';
+import {
+  isDiffBaseCacheReusable,
+  listStoredPullRequests,
+  readDiffBaseCache,
+  writeDiffBaseCache,
+} from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
 import type { PlatformAdapter, StoredPullRequest } from '@meebox/shared';
 import type { JsonFileStateStore } from '@meebox/state-store';
@@ -92,8 +97,11 @@ export class PrService {
    * - 内容（Monaco 左栏）锚到 merge-base → 编辑器即真三点，目标漂移不再把别的 PR 改动倒挂进来；
    * - 行锚点（评论 / finding）有了固定参照，目标漂移不致错位。
    *
-   * 失效重算：固化 base 不再是当前 head 的祖先（源分支被 rebase）→ 重算。head 正常 push（仅前进）
-   * 不失效。算不出（缺对象 / 无共同祖先）→ 兜底退回 targetRef.sha 且**不固化**，下次再试。
+   * 失效重算：
+   * - 固化 base 不再是当前 head 的祖先（源分支被 rebase）；
+   * - 当前 target 已经成为 head 的祖先，说明源分支把目标分支 merge 进来了，旧分叉点会把 merge
+   *   带来的目标分支内容也算进 PR diff。
+   * 算不出（缺对象 / 无共同祖先）→ 兜底退回 targetRef.sha 且**不固化**，下次再试。
    *
    * 前置：mirror 已含 head + targetRef.sha（diff 入口已 ensureMirrorReadyForPr / syncMirror）。
    */
@@ -101,7 +109,16 @@ export class PrService {
     const id = this.repoIdentityFor(pr);
     const head = pr.sourceRef.sha;
     const cached = await readDiffBaseCache(this.deps.stateStore, pr.localId);
-    if (cached?.base_sha && (await this.deps.repoMirror.isAncestor(id, cached.base_sha, head))) {
+    if (
+      cached?.base_sha &&
+      (await isDiffBaseCacheReusable({
+        cachedBaseSha: cached.base_sha,
+        targetSha: pr.targetRef.sha,
+        headSha: head,
+        isAncestor: (ancestor, descendant) =>
+          this.deps.repoMirror.isAncestor(id, ancestor, descendant),
+      }))
+    ) {
       return cached.base_sha;
     }
     const mb = await this.deps.repoMirror.mergeBase(id, pr.targetRef.sha, head);

--- a/packages/poller/src/diff-base-cache.ts
+++ b/packages/poller/src/diff-base-cache.ts
@@ -10,8 +10,9 @@ import type { StateStore } from '@meebox/state-store';
  *   的改动会以「倒挂/撤回」形式串进来。固化 merge-base 后，内容 / 列表 / 计数 / blame / pr-agent
  *   一律以它为 base，编辑器即真三点、对目标漂移稳定，评论 / finding 行锚点也有了固定参照。
  *
- * **失效**：`head`（`sourceRef.sha`）被 rebase 致固化 base 不再是其祖先时重算（见
- * `resolveDiffBaseSha`）；源分支正常 push（head 仅前进）不失效，base 仍锚在分叉点。
+ * **失效**：`head`（`sourceRef.sha`）被 rebase 致固化 base 不再是其祖先时重算；源分支把
+ * 当前目标分支 merge 进来时也重算，避免旧分叉点把 merge 带来的目标分支改动算进 PR diff。
+ * 源分支正常 push（head 仅前进）不失效，base 仍锚在分叉点。
  *
  * 它是**本地派生缓存**、非平台元数据，独立成文件，poller 重写 meta.json 时不触碰。
  */
@@ -23,6 +24,22 @@ export interface DiffBaseCacheFile {
   head_sha: string;
   /** 计算完成的 ISO 时间 */
   computed_at: string;
+}
+
+export interface DiffBaseCacheReuseInput {
+  cachedBaseSha: string;
+  targetSha: string;
+  headSha: string;
+  isAncestor: (ancestor: string, descendant: string) => Promise<boolean>;
+}
+
+export async function isDiffBaseCacheReusable(input: DiffBaseCacheReuseInput): Promise<boolean> {
+  const { cachedBaseSha, targetSha, headSha, isAncestor } = input;
+  if (!(await isAncestor(cachedBaseSha, headSha))) return false;
+  // 源分支 merge 目标分支后，target 会成为 head 的祖先；继续用旧分叉点会把这次 merge
+  // 带入的目标分支改动也算进 PR diff，必须重算到新的 merge-base（通常就是 target）。
+  if (targetSha !== cachedBaseSha && (await isAncestor(targetSha, headSha))) return false;
+  return true;
 }
 
 export function diffBaseCacheKey(localId: string): string {

--- a/packages/poller/tests/diff-base-cache.test.ts
+++ b/packages/poller/tests/diff-base-cache.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isDiffBaseCacheReusable } from '../src/diff-base-cache.js';
+
+describe('isDiffBaseCacheReusable', () => {
+  it('目标分支已被 merge 到源分支时失效旧 base', async () => {
+    const ancestors = new Set(['old-base..head', 'target..head', 'old-base..target']);
+
+    const reusable = await isDiffBaseCacheReusable({
+      cachedBaseSha: 'old-base',
+      targetSha: 'target',
+      headSha: 'head',
+      isAncestor: async (ancestor, descendant) => ancestors.has(`${ancestor}..${descendant}`),
+    });
+
+    expect(reusable).toBe(false);
+  });
+
+  it('目标分支前移但尚未进入源分支时复用旧 base', async () => {
+    const ancestors = new Set(['old-base..head', 'old-base..target']);
+
+    const reusable = await isDiffBaseCacheReusable({
+      cachedBaseSha: 'old-base',
+      targetSha: 'target',
+      headSha: 'head',
+      isAncestor: async (ancestor, descendant) => ancestors.has(`${ancestor}..${descendant}`),
+    });
+
+    expect(reusable).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #106

## 变更内容

修复源分支 merge 目标分支后，变更页 diff 混入目标分支已有改动的问题。

本次调整：

- 在复用本地 diff-base 缓存前，判断当前目标分支 `targetSha` 是否已经成为源分支 `headSha` 的祖先。
- 如果源分支已经 merge 当前目标分支，则失效旧 diff-base 缓存并重新计算 merge-base。
- 保留目标分支仅前移、但尚未进入源分支时复用旧 diff-base 的行为，避免目标分支漂移影响 PR diff。
- 补充 `isDiffBaseCacheReusable` 的回归测试。

## 背景

当前会固化 PR 的 diff base，用于稳定目标分支前移时的 diff 结果。

这个策略对“目标分支前移但尚未进入源分支”的场景是正确的；但当源分支 merge 了目标分支后，如果继续复用旧分叉点，`base...head` 会把 merge 带入的目标分支内容也算入当前 PR diff，导致变更文件列表和 diff 内容包含无关改动。

## 验证

已本地执行：

```bash
npm run lint && npm run typecheck && npm run test && npm run build