### PR TITLE
fix(repo-mirror): 镜像缺 PR head sha 时按平台精确 fetch PR 头引用自愈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 
 ### Fixed
 
+- 本地镜像缺 PR head sha 导致 diff / 评审失败且不自愈：源分支被删 / 强推（rebase / squash 常见）后，`refs/heads/*` 已看不到 PR 的 head sha，而 GitHub `refs/pull/<n>/head` / GitLab `refs/merge-requests/<n>/head` 默认不在 ref 广播里、通配 fetch 取不到 → `git diff base...head` 报 `Invalid symmetric difference`，此前只能手动删 bare 镜像目录重 clone（且删后对已删源分支仍救不回）。现 `ensureMirrorReadyForPr` 在常规 sync 后若 head sha 仍缺失，**按平台 + PR 号精确 fetch 该 PR 的头引用**（新增 `repoMirror.fetchRefspecs` + `pullRequestHeadRefspec`）把 head sha 钉回本地，自动恢复 diff / blame / pr-agent worktree（worktree 路径也改走同一 ensure 自愈）。Bitbucket 经既有通配 PR 引用本就覆盖。
+
 - Monaco 控制台噪音报错治理：只读 diff + 着色用不到的 typescript/javascript · json · css · html 语言服务从源头关闭（对各 `*Defaults` 传空 `ModeConfiguration`，不注册任何 provider），消除其向未注册 worker 发 RPC 抛出的 `Missing requestHandler or method: …`（`getNavigationTree` / `getSyntacticDiagnostics` 等整族）；着色走 tokenizer 不受影响。剩余 Monaco 上游已知竞态（`TextModel got disposed before DiffEditorWidget model got reset`）作为已知问题默认静默，需诊断时 `localStorage.setItem('meebox.monacoDebug','1')` 再刷新可看明细——仅命中白名单消息，其它异常照常抛出。
 - PR 头部与详情页的评审状态 chip（pending / approved / needs_work、reviewer 的 approved / needs work / pending）此前为写死英文，现按界面语言出国际化文案（新增 `prStatus` 文案集，四语言）。
 - 切换不同 PR 时 diff 文件树「左栏空白 → 文件树整体弹出」的抖动：DiffView 改为 stale-while-loading——引入 `loadedPrId` 标记当前已渲染内容所属 PR，切 PR 期间保留旧树 / 旧内容渲染、上盖加载遮罩（延迟 150ms，命中缓存的快切换直接换新），并门控 content / comments / blame 拉取（避免「新 localId + 旧选中文件」错拉），新文件列表 ready 后整体替换。

--- a/apps/desktop/src/main/services/pr-agent/run-executor.ts
+++ b/apps/desktop/src/main/services/pr-agent/run-executor.ts
@@ -266,7 +266,9 @@ export class RunExecutor {
   private async prepareWorkspace(pr: QueueItem['pr']) {
     const { repoMirror, pr: prService } = this.ctx;
     const repoId = prService.repoIdentityFor(pr);
-    await repoMirror.syncMirror(repoId);
+    // 走 ensureMirrorReadyForPr（而非裸 syncMirror）：与 UI diff 同源，且复用其自愈——源分支被删 / 强推后
+    // 按平台精确 fetch PR 头引用补齐 head sha，否则 materializeWorktree 建 meebox/head 会因对象缺失失败。
+    await prService.ensureMirrorReadyForPr(pr);
     // pr-agent 的 LOCAL__TARGET_BRANCH 用固定 merge-base，而非 targetRef.sha 漂移后混入别的 PR 的两点对比。
     const diffBase = await prService.resolveDiffBaseSha(pr);
     return repoMirror.materializeWorktree(repoId, pr.sourceRef.sha, diffBase);

--- a/apps/desktop/src/main/services/pr-service.ts
+++ b/apps/desktop/src/main/services/pr-service.ts
@@ -6,7 +6,11 @@ import {
   writeDiffBaseCache,
 } from '@meebox/poller';
 import type { RepoIdentity, RepoMirrorManager } from '@meebox/repo-mirror';
-import type { PlatformAdapter, StoredPullRequest } from '@meebox/shared';
+import {
+  pullRequestHeadRefspec,
+  type PlatformAdapter,
+  type StoredPullRequest,
+} from '@meebox/shared';
 import type { JsonFileStateStore } from '@meebox/state-store';
 import type { ConnectionRuntime } from '../adapters.js';
 import { broadcast } from './broadcast.js';
@@ -85,6 +89,13 @@ export class PrService {
       return { mirrorPath: this.deps.repoMirror.mirrorPath(id), freshClone: false };
     }
     const r = await this.deps.repoMirror.syncMirror(id);
+    // 自愈：源分支被删 / 强推后 head sha 不在 refs/heads，syncMirror（只抓 heads + Bitbucket 通配 PR 引用）
+    // 仍补不齐 → 按平台 + PR 号精确 fetch PR 头引用（GitHub refs/pull/<n>/head 等，通配取不到，必须精确）。
+    // 补齐后 diff base...head 才不报 "Invalid symmetric difference"。best-effort，仍缺则由下游 diff 抛可读错误。
+    if (!(await this.deps.repoMirror.hasCommit(id, pr.sourceRef.sha))) {
+      const refspec = pullRequestHeadRefspec(pr.platform, pr.remoteId);
+      if (refspec) await this.deps.repoMirror.fetchRefspecs(id, [refspec]);
+    }
     return { mirrorPath: r.mirrorPath, freshClone: r.freshClone };
   }
 

--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -141,6 +141,34 @@ export class RepoMirrorManager {
   }
 
   /**
+   * 按给定 refspec best-effort fetch 进 bare 镜像（典型用法：补一道平台 PR 头引用
+   * `refs/pull/<n>/head` 等，把被删 / 强推源分支的 PR head sha 钉回本地——`refs/heads/*` 已看不到它）。
+   * 镜像不存在 / fetch 失败均**不抛**（网络 / 远端拒绝 / 该 PR 引用不存在都可能），调用方随后自行复验
+   * hasCommit。空 refspec 直接返回。前置：调用方已 await 过 syncMirror，故与全局 sync 队列无并发。
+   */
+  async fetchRefspecs(repo: RepoIdentity, refspecs: string[]): Promise<void> {
+    if (refspecs.length === 0) return;
+    const mp = this.mirrorPath(repo);
+    try {
+      await fs.access(mp);
+    } catch {
+      return;
+    }
+    try {
+      await this.withProxyEnv(simpleGit({ baseDir: mp })).raw(['fetch', 'origin', ...refspecs]);
+    } catch (err) {
+      this.opts.logger?.debug(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          repo: this.repoKey(repo),
+          refspecs,
+        },
+        'fetchRefspecs failed (best-effort); sha may still be unreachable',
+      );
+    }
+  }
+
+  /**
    * 镜像是否「健康」：是有效 git 目录且 origin remote 已配置。clone/fetch 中途被打断会留下「HEAD 在、
    * 但 git 元数据残缺（常缺 origin remote）」的目录，仅判 HEAD 存在会误以为可 fetch → `git fetch origin`
    * 直接 fatal（`'origin' does not appear to be a git repository`）。用 `git config --get
@@ -167,11 +195,7 @@ export class RepoMirrorManager {
    * 任一 sha 不在本地镜像 (尚未 sync 到本 PR 范围) → 返回 null，调用方把它
    * 当 "暂时未知" 处理 (不显示角标 / 显示加载占位)。
    */
-  async countCommits(
-    repo: RepoIdentity,
-    baseSha: string,
-    headSha: string,
-  ): Promise<number | null> {
+  async countCommits(repo: RepoIdentity, baseSha: string, headSha: string): Promise<number | null> {
     if (!baseSha || !headSha) return null;
     const [hasBase, hasHead] = await Promise.all([
       this.hasCommit(repo, baseSha),
@@ -306,13 +330,7 @@ export class RepoMirrorManager {
     const BASE_BRANCH = 'meebox/base';
 
     const mirrorPath = this.mirrorPath(repo);
-    const wtRoot = path.join(
-      this.opts.reposDir,
-      repo.host,
-      repo.projectKey,
-      repo.repoSlug,
-      'wt',
-    );
+    const wtRoot = path.join(this.opts.reposDir, repo.host, repo.projectKey, repo.repoSlug, 'wt');
     await fs.mkdir(wtRoot, { recursive: true });
     const nonce = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     const wtPath = path.join(wtRoot, `${headSha.slice(0, 12)}-${nonce}`);
@@ -402,13 +420,7 @@ export class RepoMirrorManager {
     // git 可能短暂报 'Invalid symmetric difference' / 'bad revision'。简单重试
     // 两次，间隔 200ms / 400ms 后通常就稳了。失败再向上抛由 renderer 走 banner。
     const out = await retryTransientGit(
-      () =>
-        simpleGit(mirrorPath).raw([
-          'diff',
-          '-z',
-          '--name-status',
-          `${baseSha}...${headSha}`,
-        ]),
+      () => simpleGit(mirrorPath).raw(['diff', '-z', '--name-status', `${baseSha}...${headSha}`]),
       this.opts.logger,
       { op: 'listChangedFiles', repo: this.repoKey(repo), baseSha, headSha },
     );
@@ -420,11 +432,7 @@ export class RepoMirrorManager {
    * 文件不在该 commit (新增/删除场景) 返回空 content。
    * 简单 null-byte 启发判定二进制（前 8000 字符）。
    */
-  async getFileContent(
-    repo: RepoIdentity,
-    sha: string,
-    filePath: string,
-  ): Promise<FileContent> {
+  async getFileContent(repo: RepoIdentity, sha: string, filePath: string): Promise<FileContent> {
     const mirrorPath = this.mirrorPath(repo);
     let content: string;
     try {
@@ -488,13 +496,7 @@ export class RepoMirrorManager {
   async getBlame(repo: RepoIdentity, sha: string, filePath: string): Promise<BlameLine[]> {
     const mirrorPath = this.mirrorPath(repo);
     try {
-      const out = await simpleGit(mirrorPath).raw([
-        'blame',
-        '--porcelain',
-        sha,
-        '--',
-        filePath,
-      ]);
+      const out = await simpleGit(mirrorPath).raw(['blame', '--porcelain', sha, '--', filePath]);
       return parseBlamePorcelain(out);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -505,10 +507,7 @@ export class RepoMirrorManager {
         );
         return [];
       }
-      this.opts.logger?.warn(
-        { err, repo: this.repoKey(repo), sha, filePath },
-        'git blame failed',
-      );
+      this.opts.logger?.warn({ err, repo: this.repoKey(repo), sha, filePath }, 'git blame failed');
       throw err;
     }
   }
@@ -641,7 +640,6 @@ export class RepoMirrorManager {
     }
     return total;
   }
-
 }
 
 /**
@@ -827,9 +825,7 @@ export function parseBlamePorcelain(raw: string): BlameLine[] {
       commit: sha,
       author: meta.author,
       authorEmail: meta.authorEmail,
-      authorDate: meta.authorTime
-        ? new Date(meta.authorTime * 1000).toISOString()
-        : '',
+      authorDate: meta.authorTime ? new Date(meta.authorTime * 1000).toISOString() : '',
       summary: meta.summary,
     });
   }

--- a/packages/repo-mirror/tests/pull-ref.test.ts
+++ b/packages/repo-mirror/tests/pull-ref.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { pullRequestHeadRefspec } from '@meebox/shared';
+
+describe('pullRequestHeadRefspec', () => {
+  it('按平台构造 PR 头引用 refspec（精确编号，非通配）', () => {
+    expect(pullRequestHeadRefspec('github', '108')).toBe('+refs/pull/108/head:refs/pull/108/head');
+    expect(pullRequestHeadRefspec('gitlab', '42')).toBe(
+      '+refs/merge-requests/42/head:refs/merge-requests/42/head',
+    );
+    expect(pullRequestHeadRefspec('bitbucket-server', '7')).toBe(
+      '+refs/pull-requests/7/from:refs/pull-requests/7/from',
+    );
+  });
+
+  it('remoteId 非纯数字 → null（不构造可疑 ref）', () => {
+    expect(pullRequestHeadRefspec('github', '')).toBeNull();
+    expect(pullRequestHeadRefspec('github', 'abc')).toBeNull();
+    expect(pullRequestHeadRefspec('github', '1; rm -rf')).toBeNull();
+    expect(pullRequestHeadRefspec('github', '12/head')).toBeNull();
+  });
+
+  it('两端空白容错（trim 后纯数字）', () => {
+    expect(pullRequestHeadRefspec('github', ' 9 ')).toBe('+refs/pull/9/head:refs/pull/9/head');
+  });
+});

--- a/packages/shared/src/platform.ts
+++ b/packages/shared/src/platform.ts
@@ -1,6 +1,28 @@
 // 顺序即各处平台展示准绳：GitHub → Bitbucket → GitLab，新平台追加末尾（见 PlatformIcon.PLATFORM_META）。
 export type PlatformKind = 'github' | 'bitbucket-server' | 'gitlab';
 
+/**
+ * 各平台「PR 头」的 git 引用 refspec（fetch 进本地镜像，把 PR 源 sha 钉牢）。源分支被删 / 强推后，
+ * `refs/heads/*` 已看不到 head sha，但平台保留了 PR 专属引用——据此 fetch 才能让 `git diff base...head`
+ * 不报 "Invalid symmetric difference"。
+ *
+ * **必须按 PR 号精确取**：GitHub 的 pull 引用 / GitLab 的 merge-requests 引用默认不在 ref 广播里，
+ * 通配 fetch 匹配不到（Bitbucket 的 pull-requests 引用会广播、通配可取，二者不同）；按确切编号 fetch
+ * 平台才返回。remoteId 非纯数字（异常）→ 返回 null（不构造可疑 ref）。
+ */
+export function pullRequestHeadRefspec(platform: PlatformKind, remoteId: string): string | null {
+  const n = remoteId.trim();
+  if (!/^\d+$/.test(n)) return null;
+  switch (platform) {
+    case 'github':
+      return `+refs/pull/${n}/head:refs/pull/${n}/head`;
+    case 'gitlab':
+      return `+refs/merge-requests/${n}/head:refs/merge-requests/${n}/head`;
+    case 'bitbucket-server':
+      return `+refs/pull-requests/${n}/from:refs/pull-requests/${n}/from`;
+  }
+}
+
 export interface RepoRef {
   /** Bitbucket: project key; GitHub: org/user; GitLab: namespace */
   projectKey: string;
@@ -382,11 +404,7 @@ export interface PlatformAdapter {
    * 需要 ping() 已经跑过、cachedUser 已经落地，否则无法构造端点 (Bitbucket 需要 userSlug)。
    * 失败抛 PlatformError 子类；调用方决定是否回滚本地状态。
    */
-  setPullRequestReviewStatus(
-    repo: RepoRef,
-    prId: string,
-    status: ReviewerStatus,
-  ): Promise<void>;
+  setPullRequestReviewStatus(repo: RepoRef, prId: string, status: ReviewerStatus): Promise<void>;
 
   /**
    * 合并 PR 到目标分支。仅应在 mergeStatus.canMerge=true 时调用（上层据此控制
@@ -456,12 +474,7 @@ export interface PlatformAdapter {
    *
    * 跨平台契约：返回 void，调用方在删除成功后应清空缓存 + 广播 comments:changed
    */
-  deleteComment(
-    repo: RepoRef,
-    prId: string,
-    commentId: string,
-    version: number,
-  ): Promise<void>;
+  deleteComment(repo: RepoRef, prId: string, commentId: string, version: number): Promise<void>;
 
   /**
    * 编辑 PR 上的一条评论 (改 body 文本)。


### PR DESCRIPTION
## 问题

打开 PR 拉变更文件 / blame / pr-agent 评审时报 `GitError: fatal: Invalid symmetric difference expression <head>...<base>`，本地镜像「没找到 PR 引用的 commit」，且**不自愈**——只能手动删 bare 镜像目录重 clone（对已删源分支甚至重 clone 也救不回）。

## 根因

`git diff base...head` 要求两端 sha 都在本地 bare 镜像。`ensureMirrorReadyForPr` 缺 sha 时走 `syncMirror`，但其 fetch 只抓 `+refs/heads/*` + Bitbucket 通配 `+refs/pull-requests/*/from`。当 PR **源分支被删 / 强推**（rebase / squash 极常见）时：
- `refs/heads/*` 已无该 head sha；
- GitHub `refs/pull/<n>/head`、GitLab `refs/merge-requests/<n>/head` **默认不在 ref 广播里 → 通配 fetch 匹配不到**（与 Bitbucket 的 pull-requests 引用会广播不同），never fetched；
- `ensureMirrorReadyForPr` 同步后**不复验** head 是否到位 → diff 直接失败。现有自愈只覆盖「损坏镜像」，不覆盖「可取但没取的 PR commit」。

（日志佐证：`repo=api.github.com/...` 即 GitHub；`retryTransientGit` 把永久缺失的 head 误当瞬态重试两次后失败。）

## 修复

- `pullRequestHeadRefspec(platform, remoteId)`（shared）：按平台 + PR 号构造**精确** refspec（GitHub `refs/pull/<n>/head`、GitLab `refs/merge-requests/<n>/head`、Bitbucket `refs/pull-requests/<n>/from`）——GitHub/GitLab 通配取不到，必须精确编号。`remoteId` 非纯数字 → null（不构造可疑 ref）。
- `repoMirror.fetchRefspecs(repo, refspecs)`：best-effort 把 refspec fetch 进 bare 镜像（失败不抛）。
- `ensureMirrorReadyForPr`：常规 sync 后若 head sha **仍缺失** → 精确 fetch 该 PR 头引用补齐，恢复 diff / blame；仍缺才由下游抛可读错误。
- `run-executor.prepareWorkspace` 改走 `ensureMirrorReadyForPr`，pr-agent worktree 同享自愈（materialize 经 `--local` 共享对象，head 对象在 bare 即可建 `meebox/head`）。

一处 ensure 修复，diff / blame / pr-agent worktree 全覆盖。

## 与 #107 的关系

#107（已合并）修的是 **diff-base 缓存失效**（源分支 merge 目标分支后重算 base），与本 bug **正交**：本 bug 是 head sha 在镜像里缺失。两者不冲突、互补（本修复保证 head 可达 → #107 的 isAncestor/mergeBase 才能算对）。已 rebase 到含 #107 的 dev，无冲突。

## 验证

- 新增 `repo-mirror/tests/pull-ref.test.ts`（refspec 构造 + 非数字兜底，通过）。
- typecheck/lint（shared/repo-mirror/desktop）+ build desktop 全绿。
- `repo-mirror-manager.test.ts` 既有 5 个真实 git 集成测试在本机/沙箱失败 — 已对 dev 基线复验为**既有失败**，与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)