### PR TITLE
fix(ask): 复评取代建议改为可直接发布的评论本身

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 ### Fixed
 
+- 复评 `/ask` 取代裁决的「改进建议」改为可直接发布的评论本身：此前 `<suggestions>` 常被写成「建议将原评论替换为…/请确认…」这类**关于评论的元讨论**（还出现「原评论」概念），无法被评审者直接采用。现提示词要求 `replace` 裁决下 `<suggestions>` **只包含替代评论本身**——以标准 review 评论的口吻直接针对代码、按问题 → 影响 → 建议分段、可原样发布，不提「原评论 / 替换 / 请确认」等元信息；被取代的原评论仍按 `replace`/`drop` 裁决自动关闭。
 - CLI 模式 `/ask` 在「仓库自带 agent 指令文件被纳入版本管理」时整体失败：为防 CLI 子进程自动加载污染回答，`/ask` 会截断 worktree 内的 `CLAUDE.md` / `AGENTS.md` / `.cursor` 规则等；若这些文件被仓库跟踪，截断即让工作区变「脏」，触发 pr-agent `LocalGitProvider._prepare_repo` 的「repository is not in a clean state」守卫 → 取 git provider 阶段就崩、不写 `review.md`、`/ask` 失败（无此类跟踪文件的仓库不受影响）。修复：shim 覆写 `_prepare_repo` 去掉脏检查、仅保留「目标分支存在」校验——diff 取自分支提交（与工作区脏无关），该守卫对这套一次性受控 worktree 是误报。
 - 失败 / 取消的任务不再做结构化采集：`/ask`（及其它工具）run 失败（含 exit 0 但 LLM 调用失败）或被取消时，此前仍会把部分 / 报错输出解析成 finding 卡，易产出无意义的结构化元素。现失败 / 取消路径**不解析 findings**，只保留原始输出（stdout/stderr）供展示；复评 `/ask` 失败时也不触发自动关闭 / 建议提升。
 - `/ask` 的结构化分段 / 引用上下文 / 复评裁决指令此前对模型无效：pr-agent 的 `pr_questions` 提示词模板**不渲染 `extra_instructions`**（与 `/describe`、`/review`、`/improve` 不同），我们经 `PR_QUESTIONS__EXTRA_INSTRUCTIONS` 注入的这些指令对 `/ask` 是死字段、被静默丢弃，导致结构化输出 / 复评取代评论的代码定位时有时无。现 `/ask` 的这些指令改为拼进「问题」本身（user turn，唯一真正到达模型的文本，与语言后缀同路）；问题回显（含字面 `<summary>` / `<verdict>` 示例标签）按 pr-agent 固定的 `### **Answer:**` 表头整段切除，避免污染结构化解析。

--- a/packages/pr-agent-bridge/src/prompts.ts
+++ b/packages/pr-agent-bridge/src/prompts.ts
@@ -139,28 +139,33 @@ function structuredAskDirective(tool: ReviewRunTool): string {
 
 /**
  * /ask 复评模式指令：本次 /ask 是对一条既有评审评论（正文随 referencedContext 给出）的复评时注入。
- * 在结构化三段基础上，要求模型额外给出 `<verdict>` 裁决——replace（取代：给改进后的评论，写进
- * `<suggestions>`）/ keep（原评论成立）/ drop（原评论不成立、无需评论）。驱动结果卡的采纳 / 关闭动作。
+ * 在结构化三段基础上，要求模型额外给出 `<verdict>` 裁决——replace（取代：<suggestions> 写一条可直接发布的
+ * 替代评论本身）/ keep（原评论成立）/ drop（原评论不成立、无需评论）。驱动结果卡的采纳 / 关闭动作。
  */
 function referencedAskDirective(tool: ReviewRunTool, hasReferencedFinding: boolean): string {
   if (tool !== 'ask' || !hasReferencedFinding) return '';
   return [
     'RE-EVALUATION MODE: You are re-evaluating an EXISTING review comment (its text is',
-    'provided in the referenced selection). Decide whether that comment should stand, be',
-    'replaced, or be dropped, and end your answer with EXACTLY ONE verdict tag on its own',
-    'line:',
+    'provided in the referenced selection). Decide whether it should stand, be replaced, or be',
+    'dropped, and end your answer with EXACTLY ONE verdict tag on its own line:',
     '',
-    '  <verdict>replace</verdict>  — the original comment is wrong / weak / outdated; your',
-    '    improved comment should REPLACE it. Put the proposed replacement comment text in',
-    '    the <suggestions> section.',
-    '  <verdict>keep</verdict>     — the original comment is valid and should stand as-is.',
-    '  <verdict>drop</verdict>     — the original comment is not warranted (false positive /',
-    '    non-issue); no comment is needed.',
+    '  <verdict>replace</verdict>  — the original is wrong / weak / outdated; you will provide a',
+    '    better comment to take its place.',
+    '  <verdict>keep</verdict>     — the original is valid and should stand as-is.',
+    '  <verdict>drop</verdict>     — the original is not warranted (false positive / non-issue);',
+    '    no comment is needed.',
     '',
-    'Keep <summary> to your conclusion, put the reasoning in <analysis>, and (for replace)',
-    'the proposed replacement comment in <suggestions>, ending it with the',
-    '[file: <path>, lines: <start>-<end>] marker for the referenced code location so the',
-    'replacement stays pinned to the same place as the original comment.',
+    'Put your conclusion in <summary> and the reasoning (why replace / keep / drop) in <analysis>.',
+    '',
+    'For <verdict>replace</verdict>, the <suggestions> section MUST contain ONLY the replacement',
+    'review comment ITSELF — written as a STANDALONE code-review comment the reviewer can post',
+    'AS-IS, in the same voice and structure as a normal review finding: address the code directly;',
+    'separate problem → impact → suggested fix with blank lines into a few short paragraphs; be',
+    'concise. Do NOT write about the original comment, do NOT say "replace…" / "the original',
+    'comment" / "please confirm", and do NOT add meta-commentary or a checklist of questions —',
+    'write the comment, not a discussion about it. End it with a single',
+    '[file: <path>, lines: <start>-<end>] marker for the referenced code location so it stays',
+    'pinned to the same place.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## 问题

复评 `/ask` 取代（`replace`）裁决的「改进建议」此前常被写成「建议将原评论替换为…/请确认…」这类**关于评论的元讨论**，还冒出「原评论」概念——无法被评审者直接采用，不符合「取代 = 给一条可发布的新评论」的预期。

## 修复

收紧 `referencedAskDirective`（仅 `/ask` 复评模式注入）：

- `replace` 裁决下 `<suggestions>` **只包含替代评论本身**——以标准 review 评论口吻直接针对代码、按**问题 → 影响 → 建议**分段、简洁、可原样发布；末尾带 `[file:…, lines:…]` 锚到被引用位置。
- 明确禁止「建议将原评论替换为…」「请确认…」「the original comment」等元信息与问题清单，以及「原评论」概念——写评论，不是讨论评论。
- `<summary>` / `<analysis>` 仍承载结论与裁决理由。

被取代的原评论仍按 `replace`/`drop` 裁决由 run-executor 自动建立 closure 关闭（既有逻辑，本 PR 不改）。

## 影响 / 验证

纯提示词改动（`@meebox/pr-agent-bridge`），无需 `prepare:pragent`。`lint` / `typecheck` / `test` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)