### PR TITLE
chore(github): 配置默认 PR 评审人与 issue 处理人

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# 代码所有者 / 默认评审人（Code owners / default reviewers）
+# 语法见 https://docs.github.com/articles/about-code-owners
+# 匹配规则后者覆盖前者；PR 触及对应路径时自动请求其所有者评审。
+
+# 默认：所有改动请求 @huhamhire 评审
+* @huhamhire

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: 缺陷报告（Bug report）
+description: 报告一个问题或异常行为
+labels: [bug]
+assignees:
+  - huhamhire
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 问题描述（What happened）
+      description: 发生了什么、预期是什么，以及复现步骤。
+      placeholder: 简要描述问题与复现步骤。
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: 版本（Version）
+      placeholder: 如 0.6.0-alpha.1
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: 操作系统（OS）
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 截图（Logs / screenshots）
+      description: 相关日志（`~/.code-meeseeks/`）或截图，便于定位。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# 关掉空白 issue，强制走下方模板——模板带 assignees，确保新 issue 默认有处理人。
+blank_issues_enabled: false
+contact_links:
+  - name: 使用文档（Documentation）
+    url: https://github.com/huhamhire/code-meeseeks/tree/master/docs/guide
+    about: 安装、代码平台 / LLM / 代理配置与使用说明，先看这里。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: 功能建议（Feature request）
+description: 提出新功能或改进建议
+labels: [enhancement]
+assignees:
+  - huhamhire
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 需求 / 痛点（Problem）
+      description: 你希望解决什么问题、当前有何不便。
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 期望方案（Proposed solution）
+      description: 期望的功能形态或交互；有备选方案也可一并说明。
+    validations:
+      required: false


### PR DESCRIPTION
为仓库设置默认评审人与 issue 处理人（均为维护者 @huhamhire，当前唯一具写权限的协作者）。

## 变更

- **`.github/CODEOWNERS`**：`* @huhamhire`——任何 PR 开启时自动请求 @huhamhire 评审（PR 作者本人不会被请求，主要对外部贡献者 PR 生效）。
- **`.github/ISSUE_TEMPLATE/`**：
  - `bug_report.yml`（labels: bug）、`feature_request.yml`（labels: enhancement），均 `assignees: huhamhire`。
  - `config.yml` 关闭空白 issue、强制走模板，确保新建 issue 默认有处理人；并加「使用文档」外链。

## 生效说明

- issue 模板从**默认分支（master）**读取——合并到 dev 后，需随下次发版汇入 master 才在新建 issue 界面生效。
- CODEOWNERS 对**以该分支为 base** 的 PR 生效：合并到 dev 后即对 targeting dev 的 PR 生效，对 targeting master 的 PR 待汇入 master 后生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)