### PR TITLE
feat(poller): 退场 PR 数据独立归档冷存储、复活搬回与孤儿清扫

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 本项目所有重要变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### ♻️ 变更
+
+- 退场（已合并 / 关闭 / 不再需你评审）的 PR 数据迁出活跃目录、独立归档存放，归档保留与到期自动清理策略保持不变。
+
 ## [0.7.0] - 2026-06-27
 
 > 本版重点：
@@ -311,6 +317,7 @@
 
 许可证：[Apache-2.0](LICENSE)。打包内含第三方组件（pr-agent、Electron 等），各按其许可证分发，见 [NOTICE](NOTICE)。
 
+[Unreleased]: https://github.com/huhamhire/code-meeseeks/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.4.0...v0.5.0

--- a/apps/desktop/src/main/bootstrap/poller.ts
+++ b/apps/desktop/src/main/bootstrap/poller.ts
@@ -13,16 +13,19 @@ import { broadcast } from '../services/broadcast.js';
 export function createPoller(deps: {
   bootstrap: BootstrapResult;
   stateStore: JsonFileStateStore;
+  /** 归档 PR 冷存储（`archived/` 根，与 state/ 平级）；退场 PR 整树搬入此处。 */
+  archiveStore: JsonFileStateStore;
   logger: Logger;
   /** poll tick 顺带的副作用（清理消失 PR 的 agent 操作 / 版本检测 / AutoPilot 准入），由 index 绑定。 */
   onTickExtras: () => void;
   /** 延迟取 repoMirror（它在 poller 之后才建好）。 */
   getRepoMirror: () => RepoMirrorManager;
 }): Poller {
-  const { bootstrap, stateStore, logger } = deps;
+  const { bootstrap, stateStore, archiveStore, logger } = deps;
   return new Poller({
     connections: [],
     stateStore,
+    archiveStore,
     intervalSeconds: bootstrap.config.poller.interval_seconds,
     logger: logger.child({ scope: 'poller' }),
     onTick: (info) => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,7 +5,7 @@ import { ensureWorkspace, type BootstrapResult } from '@meebox/config';
 import { scaffoldAgentDir } from '@meebox/agent';
 import { editorThemeNativeSource, resolveLanguage } from '@meebox/shared';
 import { createLogger } from '@meebox/logger';
-import type { Poller } from '@meebox/poller';
+import { sweepOrphanedArchivedPrs, type Poller } from '@meebox/poller';
 import type { RepoMirrorManager } from '@meebox/repo-mirror';
 import { JsonFileStateStore } from '@meebox/state-store';
 import {
@@ -43,6 +43,8 @@ class App {
   private bootstrap!: BootstrapResult;
   private logger!: Logger;
   private stateStore!: JsonFileStateStore;
+  /** 归档 PR 冷存储（`archived/` 根，与 state/ 平级）；退场 PR 整树搬入、按 grace 期清理。 */
+  private archiveStore!: JsonFileStateStore;
   private poller!: Poller;
   private repoMirror!: RepoMirrorManager;
   private prAgent!: PrAgentRuntime;
@@ -67,6 +69,17 @@ class App {
       await this.stateStore
         .sweepStaleTmpFiles()
         .catch((err: unknown) => this.logger.warn({ err }, 'state-store: tmp sweep failed'));
+      // 归档冷存储同样清扫上次会话残留的原子写 tmp（搬迁中途退出可能留下孤儿）。
+      await this.archiveStore
+        .sweepStaleTmpFiles()
+        .catch((err: unknown) => this.logger.warn({ err }, 'archive-store: tmp sweep failed'));
+      // 归档孤儿清扫：统一索引丢失 / 重建后，归档数据失去索引条目、按索引遍历的硬清够不到 → 永久孤儿。
+      // 启动期（任何写入之前）按「索引无条目 + 目录 mtime 超 grace」无索引兜底回收（见 docs/arch/03）。
+      await sweepOrphanedArchivedPrs({
+        stateStore: this.stateStore,
+        archiveStore: this.archiveStore,
+        logger: this.logger,
+      }).catch((err: unknown) => this.logger.warn({ err }, 'archive housekeeping: orphan sweep failed'));
       await this.initConnectionsAndIpc();
       await this.initWindow();
       await this.startPolling();
@@ -126,6 +139,7 @@ class App {
     // 版本更新器：由 poller tick 顺带调 runIfDue（至多每小时一次，复用 poller 周期、不另起定时器）。
     this.updater = new Updater(this.bootstrap, this.logger);
     this.stateStore = new JsonFileStateStore(this.bootstrap.paths.stateDir, this.logger);
+    this.archiveStore = new JsonFileStateStore(this.bootstrap.paths.archivedDir, this.logger);
   }
 
   /**
@@ -145,6 +159,7 @@ class App {
     this.poller = createPoller({
       bootstrap: this.bootstrap,
       stateStore: this.stateStore,
+      archiveStore: this.archiveStore,
       logger: this.logger,
       onTickExtras: () => {
         // 本轮已被移除 / purge 的 PR：终止其上仍在执行的 agent 操作（先于 AutoPilot，避免给已消失的 PR 起新评审）。

--- a/docs/arch/03-state-storage.md
+++ b/docs/arch/03-state-storage.md
@@ -18,21 +18,33 @@
 - **PR localId = hash**：`sha1("<platform>|<connectionId>|<group>|<repo>|<remoteId>").slice(0,12)`。
   理由：Bitbucket PR id 是 per-repo 递增的，同连接不同 repo 会撞号；hash 唯一且路径友好（无 `:`/`/`，跨平台免 sanitize）；
   多平台共用同一 identity。
-- **per-PR 目录布局**：
+- **per-PR 目录布局**（活跃 PR 落 `state/prs/`，退场 PR 整树搬到平级的 `archived/prs/` 冷存储）：
   ```
-  state/prs/
-  ├── index.json              # hash → PrIndexEntry（lookup + 退场判定的单一来源）
-  └── <hash>/
-      ├── meta.json           # 完整 PR 元数据 StoredPullRequest（自带 platform 字段）
-      ├── comments.json       # 评论快照 + cache key
-      ├── read-state.json     # 用户已读水位（未读标记派生用，仅 markRead 写）
-      └── runs/<runId>.json   # 评审会话（跟 PR 同寿命）
+  ~/.code-meeseeks/
+  ├── state/prs/
+  │   ├── index.json          # hash → PrIndexEntry（lookup + 退场判定的单一来源；含活跃 + 归档全部条目）
+  │   └── <hash>/             # 仅活跃（在场）PR
+  │       ├── meta.json       # 完整 PR 元数据 StoredPullRequest（自带 platform 字段）
+  │       ├── comments.json   # 评论快照 + cache key
+  │       ├── read-state.json # 用户已读水位（未读标记派生用，仅 markRead 写）
+  │       └── runs/<runId>.json # 评审会话（跟 PR 同寿命）
+  └── archived/prs/<hash>/    # 退场（软删）PR 的同形冷存储；grace 期满整树清掉
   ```
-  另有 `connections.json` / `watched-repos.json` / `posted-comments.json`（横向幂等记录，与 PR 目录解耦）。
+  - **活跃 / 归档物理分离**：`state/` 与 `archived/` 是两个平级的 `StateStore` 根。活跃存储只装在场 PR；
+    PR 退场时其 `prs/<hash>/` 整树经 `relocateTree(state → archived)` 搬入冷存储，复活时反向搬回。
+    交互 / IPC 层只读活跃存储（`listStoredPullRequests` 天然不含归档），归档仅供生命周期清理。
+  - **索引仍单点**：`index.json` 只在活跃存储维护，是「哪些 hash 存在 + archivedAt」的唯一真相，覆盖活跃 + 归档全部条目；
+    数据所在根由 `archivedAt` 是否为空隐含决定（空=活跃存储 / 非空=归档存储）。
+  - 另有 `connections.json` / `watched-repos.json` / `posted-comments.json`（横向幂等记录，与 PR 目录解耦）。
 - **评论缓存按 PR `updatedAt` 失效**：`comments.json` 存写入时的 `pr_updated_at`；与当前 PR meta 的 `updatedAt`
   不一致即 stale → 重拉。Bitbucket 任何 PR 变更都跳 `updatedAt`，是足够保险的 cache key。
-- **软删 + 1 周 grace**：PR 从远端 reviewer 列表消失（merged/declined/不再是 reviewer）→ 标 `archivedAt`，
-  不立即删盘；窗口内 UI 隐藏但数据保留、远端复现自动复活；过期下轮 poll 整目录清掉。便于事后回看。
+- **软删 + 1 周 grace + 冷存储搬迁**：PR 从远端 reviewer 列表消失（merged/declined/不再是 reviewer）→ 把整树搬入
+  `archived/` 冷存储、再标 `archivedAt`（搬迁先于索引落盘，崩溃可幂等重来），不立即删盘；窗口内 UI 隐藏但数据保留，
+  远端复现时整树搬回活跃存储、自动复活；grace 期满下轮 poll 从**归档 + 活跃两端**整目录清掉（两端清以兜旧布局 /
+  异常 split-brain 残留）。便于事后回看。
+- **对账（最终一致）**：每轮 poll 遍历 archived 条目时，未到 grace 的若数据仍滞留活跃存储 → 整树搬入归档存储
+  （`relocateTree(state → archived)`，已就位者源缺失即 no-op）。覆盖升级前旧布局的存量、异常 split-brain 残留、
+  中断的搬迁，使「凡 archived 必在 archived/」自动收敛——无需迁移脚本。对账只搬数据、不改索引，不破「全失败 poll 零索引写」不变式。
 - **未读标记**：`listStoredPullRequests` 派生 `StoredPullRequest.unread`（不持久化）。规则：**从未打开过**（无 read-state）即
   未读——覆盖新分配 / 请求评审的新到达，以及清空目录 / 全新安装后涌入的 PR；**打开过之后**则看源 head 又变（新 commit）或已读
   时间后有「@我 / 回复我」评论（`index.lastMentionAt > read-state.lastReadAt`）。两类状态**分文件、分写者**以避开竞态：**已读水位**
@@ -48,10 +60,16 @@
 - **启动清扫孤儿 tmp**：原子写「tmp → rename」中，进程在两步之间被强杀 / 退出（如关窗瞬间的 in-flight 异步写）会留下 `*.tmp`
   孤儿、跨会话累积。`sweepStaleTmpFiles` 在启动早期、任何写入之前删掉全部 `*.tmp`——单写者前提下此刻无 in-flight 写，凡 tmp 皆为
   上次会话孤儿，可放心删；**绝不在运行期清扫**，以免误删并发写 / rename 重试正在用的 tmp（冲突场景不误删多余文件）。
+- **启动清扫归档孤儿**：按索引遍历的硬清够不到「索引丢失 / 重建后失去条目」的归档数据（poll 只从远端补回活跃 PR），
+  会在 `archived/prs/` 永久滞留。`sweepOrphanedArchivedPrs`（启动期、写入前）以无索引方式兜底：walk `archived/prs/*`，
+  对「统一索引无对应条目 **且** 目录 mtime 超 grace」的整树删掉（mtime 作 archivedAt 的代理）。双重保守避免误删暂时
+  不在索引里的目录；机制为 `JsonFileStateStore.sweepOrphanDirs`。**正常清理仍走统一索引的到期硬清，此处仅补索引丢失的缺口。**
 
 ## 数据 / 接口契约
 
 - `StateStore`：`read<T>(key)` / `write<T>(key,data)` / `delete(key)` / `deleteDir(prefix)` / `list(prefix)`。
+- `relocateTree(from, to, prefix)`：跨 store 整树搬迁（list→read→write→deleteDir），用于活跃⇄归档存储间搬 PR 子树。
+  目标先清空（源为权威）、源末删（幂等 / 崩溃可重来）、源缺失即 no-op；不破 `StateStore` 抽象、无需暴露文件系统根。
 - `PrIndexEntry`：`identity`(PrIdentity) / `updatedAt` / `discoveredAt` / `lastSeenAt` / `archivedAt|null` /
   mention 游标 `lastMentionAt?`。
 - `PrReadStateFile`（`read-state.json`）：`lastReadHeadSha` / `lastReadAt`（用户已读水位）。

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -28,6 +28,7 @@ export function buildAppPaths(reposDirRaw: string): AppPaths {
     appDir,
     configFile: path.join(appDir, 'config.yaml'),
     stateDir: path.join(appDir, 'state'),
+    archivedDir: path.join(appDir, 'archived'),
     logsDir: path.join(appDir, 'logs'),
     agentDir: path.join(appDir, 'agent'),
     cacheDir: path.join(appDir, 'cache'),

--- a/packages/poller/src/archive-housekeeping.ts
+++ b/packages/poller/src/archive-housekeeping.ts
@@ -1,0 +1,41 @@
+import type { Logger } from 'pino';
+import type { JsonFileStateStore, StateStore } from '@meebox/state-store';
+import { PURGE_GRACE_MS, readPrIndex } from './pr-state.js';
+
+/**
+ * Startup housekeeping for the `archived/` cold store: drop archived PR trees the unified index
+ * no longer references **and** that are older than the purge grace.
+ *
+ * Why: the per-poll hard-purge iterates index entries, so when the unified index is lost / externally
+ * rebuilt, archived data loses its catalog entry and can never be reached by purge — a permanent
+ * orphan (poll only re-adds *active* PRs from remote, never archived ones). This index-less fallback
+ * walks the archive store directly; `sweepOrphanDirs` uses each tree's filesystem mtime as a proxy for
+ * `archivedAt` (lost with the index entry). Conservative on two axes — absent from index AND aged past
+ * grace — so a healthy index sweeps nothing and a momentarily index-less tree is never nuked.
+ *
+ * Run only at startup, before any write (single-writer): no in-flight relocate can be mistaken for an orphan.
+ *
+ * @returns number of orphan trees removed.
+ */
+export async function sweepOrphanedArchivedPrs(opts: {
+  /** active store — read the unified index from here to learn which hashes are still catalogued */
+  stateStore: StateStore;
+  /** archive cold store (concrete: needs `sweepOrphanDirs` filesystem access) */
+  archiveStore: JsonFileStateStore;
+  /** injectable clock for tests; defaults to wall clock */
+  now?: () => Date;
+  logger?: Logger;
+}): Promise<number> {
+  const index = await readPrIndex(opts.stateStore);
+  // keep every hash the index still knows (active or archived) — only truly orphaned trees fall through
+  const keep = new Set(index ? Object.keys(index.prs) : []);
+  const nowMs = (opts.now?.() ?? new Date()).getTime();
+  const removed = await opts.archiveStore.sweepOrphanDirs('prs', keep, PURGE_GRACE_MS, nowMs);
+  if (removed > 0) {
+    opts.logger?.info(
+      { removed },
+      'archive housekeeping: swept orphaned PR trees (no index entry, aged past grace)',
+    );
+  }
+  return removed;
+}

--- a/packages/poller/src/index.ts
+++ b/packages/poller/src/index.ts
@@ -2,6 +2,7 @@ export * from './types.js';
 export * from './poller.js';
 export * from './pr-hash-id.js';
 export * from './pr-state.js';
+export * from './archive-housekeeping.js';
 export * from './comments-cache.js';
 export * from './unread.js';
 export * from './diff-base-cache.js';

--- a/packages/poller/src/poller.ts
+++ b/packages/poller/src/poller.ts
@@ -8,7 +8,7 @@ import type {
   ReviewerStatus,
 } from '@meebox/shared';
 import type { PlatformAdapter } from '@meebox/platform-core';
-import type { StateStore } from '@meebox/state-store';
+import { relocateTree, type StateStore } from '@meebox/state-store';
 import { prHashId } from './pr-hash-id.js';
 import { latestCommentToMeAt } from './unread.js';
 import {
@@ -36,7 +36,13 @@ export interface PollerConnection {
 
 export interface PollerOptions {
   connections: ReadonlyArray<PollerConnection>;
+  /** 活跃 PR 存储（`state/` 根）：索引 + 在场 PR 的 meta / 评论 / runs 等。 */
   stateStore: StateStore;
+  /**
+   * 归档 PR 冷存储（`archived/` 根，与 state/ 平级）。PR 退场（软删）时其 `prs/<hash>/` 整树从
+   * stateStore 搬入此处、复活时搬回；硬清按同一 grace 策略从此处删除。索引仍只在 stateStore 维护。
+   */
+  archiveStore: StateStore;
   intervalSeconds: number;
   logger: Logger;
   /** 用于测试注入；默认 Date.now() */
@@ -118,6 +124,8 @@ export class Poller {
     let dirty = false;
     for (const [localId, entry] of Object.entries(prs)) {
       if (!active.has(entry.identity.connectionId) && !entry.archivedAt) {
+        // 整树搬入归档冷存储后再标 archivedAt（搬迁先于索引落盘，崩溃可幂等重来）。
+        await relocateTree(this.opts.stateStore, this.opts.archiveStore, prDirKey(localId));
         prs[localId] = { ...entry, archivedAt: now };
         dirty = true;
       }
@@ -295,6 +303,12 @@ export class Poller {
             localStatus = prevMeta?.pr.localStatus ?? 'pending';
           }
 
+          // 复活：上一轮处于归档态（数据已搬入 archived/）→ 先把整树搬回活跃存储，再写 meta，
+          // 让 runs / 评论 / 已读水位等历史与新 meta 同处活跃目录（搬回先于 writePrMeta，避免 split）。
+          if (prev?.archivedAt) {
+            await relocateTree(this.opts.archiveStore, this.opts.stateStore, prDirKey(localId));
+          }
+
           // 完整 PR 元数据落到 per-PR meta.json。platform 字段让 meta 自描述
           await writePrMeta(this.opts.stateStore, localId, {
             ...pr,
@@ -356,6 +370,8 @@ export class Poller {
           !seen.has(localId) &&
           !entry.archivedAt
         ) {
+          // 整树搬入归档冷存储后再标 archivedAt（搬迁先于索引落盘，崩溃可幂等重来）。
+          await relocateTree(this.opts.stateStore, this.opts.archiveStore, prDirKey(localId));
           indexByLocalId.set(localId, { ...entry, archivedAt: now });
           removed++;
           dirty = true;
@@ -365,12 +381,26 @@ export class Poller {
 
     // 硬清：archived 超过 grace 期 (默认 1 周) → rm -r 整个 PR 目录 + 索引删除
     let purged = 0;
+    let reconciled = 0;
     for (const [localId, entry] of [...indexByLocalId.entries()]) {
-      if (entry.archivedAt && nowMs - Date.parse(entry.archivedAt) > PURGE_GRACE_MS) {
+      if (!entry.archivedAt) continue;
+      if (nowMs - Date.parse(entry.archivedAt) > PURGE_GRACE_MS) {
+        // 硬清：grace 期满 → 两端整目录清（archiveStore 主存 + stateStore 兜旧布局 / split-brain 残留）。
+        await this.opts.archiveStore.deleteDir(prDirKey(localId));
         await this.opts.stateStore.deleteDir(prDirKey(localId));
         indexByLocalId.delete(localId);
         purged++;
         dirty = true;
+      } else {
+        // 对账（最终一致）：凡 archived 条目其数据都应在 archiveStore。把仍滞留活跃存储的整树搬入归档——
+        // 涵盖旧布局存量、异常 split-brain 残留、中断的搬迁。已就位者源缺失即 no-op、近零成本。
+        // 仅搬数据、不改索引（archivedAt 不变），故不置 dirty——保持「全失败 poll 零索引写」不变式。
+        const moved = await relocateTree(
+          this.opts.stateStore,
+          this.opts.archiveStore,
+          prDirKey(localId),
+        );
+        if (moved > 0) reconciled++;
       }
     }
 
@@ -386,7 +416,7 @@ export class Poller {
 
     const result: PollResult = { fetched, changed, added, removed, errors };
     this._lastPollAt = now;
-    this.opts.logger.info({ ...result, purged, dirty }, 'poll complete');
+    this.opts.logger.info({ ...result, purged, reconciled, dirty }, 'poll complete');
     // 通知调用方有哪些 repo 需要 sync mirror。空集合不调，避免无谓 noop
     if (changedReposByKey.size > 0) {
       this.opts.onPrsChanged?.(Array.from(changedReposByKey.values()));

--- a/packages/poller/tests/archive-housekeeping.test.ts
+++ b/packages/poller/tests/archive-housekeeping.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { JsonFileStateStore } from '@meebox/state-store';
+import { sweepOrphanedArchivedPrs } from '../src/archive-housekeeping.js';
+import { PR_INDEX_KEY, type PrIndexFile } from '../src/pr-state.js';
+
+const GRACE = 7 * 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-06-10T00:00:00.000Z');
+
+let tmpDir: string;
+let store: JsonFileStateStore; // active (state/)
+let archiveStore: JsonFileStateStore; // archived/
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-archive-hk-'));
+  store = new JsonFileStateStore(path.join(tmpDir, 'state'));
+  archiveStore = new JsonFileStateStore(path.join(tmpDir, 'archived'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// 把归档目录 mtime 回拨到超期
+const backdateArchive = async (hash: string, ageMs: number): Promise<void> => {
+  const t = new Date(NOW.getTime() - ageMs);
+  await fs.utimes(path.join(tmpDir, 'archived', 'prs', hash), t, t);
+};
+
+const seedIndex = async (hashes: string[]): Promise<void> => {
+  const prs: PrIndexFile['prs'] = {};
+  for (const h of hashes) {
+    prs[h] = {
+      identity: {
+        platform: 'bitbucket-server',
+        connectionId: 'bb1',
+        group: 'P',
+        repo: 'r',
+        remoteId: h,
+        url: 'https://example/x',
+      },
+      updatedAt: NOW.toISOString(),
+      discoveredAt: NOW.toISOString(),
+      lastSeenAt: NOW.toISOString(),
+      archivedAt: NOW.toISOString(),
+    };
+  }
+  await store.write<PrIndexFile>(PR_INDEX_KEY, { schema_version: 1, prs });
+};
+
+describe('sweepOrphanedArchivedPrs', () => {
+  it('删除「索引无条目 + 超 grace」的归档孤儿，保留仍被索引登记的', async () => {
+    await archiveStore.write('prs/known/meta', { v: 1 });
+    await archiveStore.write('prs/orphan/meta', { v: 1 });
+    await backdateArchive('known', GRACE + 60_000);
+    await backdateArchive('orphan', GRACE + 60_000);
+    await seedIndex(['known']); // 只有 known 在索引里
+
+    const removed = await sweepOrphanedArchivedPrs({ stateStore: store, archiveStore, now: () => NOW });
+    expect(removed).toBe(1);
+    expect(await archiveStore.read('prs/known/meta')).not.toBeNull();
+    expect(await archiveStore.read('prs/orphan/meta')).toBeNull();
+  });
+
+  it('索引整个丢失时也只清超 grace 的孤儿、不动仍年轻的', async () => {
+    await archiveStore.write('prs/old/meta', { v: 1 });
+    await archiveStore.write('prs/recent/meta', { v: 1 });
+    await backdateArchive('old', GRACE + 60_000);
+    await backdateArchive('recent', GRACE - 60_000);
+    // 不写索引（模拟索引丢失）→ keep 为空
+
+    const removed = await sweepOrphanedArchivedPrs({ stateStore: store, archiveStore, now: () => NOW });
+    expect(removed).toBe(1);
+    expect(await archiveStore.read('prs/old/meta')).toBeNull(); // 超期 → 清
+    expect(await archiveStore.read('prs/recent/meta')).not.toBeNull(); // 年轻 → 保留（保守）
+  });
+});

--- a/packages/poller/tests/poller.test.ts
+++ b/packages/poller/tests/poller.test.ts
@@ -145,10 +145,13 @@ function makePr(id: string, updatedAt: string, title = `PR ${id}`): PullRequest 
 
 let tmpDir: string;
 let store: JsonFileStateStore;
+// 归档冷存储：与 store 物理分离（store 根 = tmpDir，archived 根 = tmpDir/archived）。
+let archiveStore: JsonFileStateStore;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-poller-test-'));
   store = new JsonFileStateStore(tmpDir);
+  archiveStore = new JsonFileStateStore(path.join(tmpDir, 'archived'));
 });
 
 afterEach(async () => {
@@ -162,6 +165,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
       now: () => fixedNow,
@@ -197,6 +201,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
       now: () => now,
@@ -219,6 +224,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -241,6 +247,7 @@ describe('Poller.tick', () => {
         { connectionId: 'bad', adapter: broken },
       ],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -312,6 +319,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter: slow }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -333,6 +341,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -356,6 +365,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -386,6 +396,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -409,6 +420,7 @@ describe('Poller.tick', () => {
         { connectionId: 'broken', adapter: broken },
       ],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -436,6 +448,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -456,6 +469,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -471,6 +485,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -486,6 +501,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -512,6 +528,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -536,6 +553,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -553,11 +571,13 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
     await poller.tick();
     expect(await listStoredPullRequests(store)).toHaveLength(2);
+    const goneHash = (await listStoredPullRequests(store)).find((p) => p.remoteId === '2')!.localId;
 
     // PR #2 关单 → soft archive (archivedAt set in index)，list 自动过滤掉
     adapter.setPrs([makePr('1', '2026-05-28T01:00:00.000Z')]);
@@ -566,10 +586,12 @@ describe('Poller.tick', () => {
     expect(visible).toHaveLength(1);
     expect(visible[0]!.remoteId).toBe('1');
 
-    // 但 meta.json + 索引条目仍在 (待 grace 期满才硬删)
+    // 索引条目仍在 (待 grace 期满才硬删)；数据已从活跃存储搬入归档冷存储
     const index = await store.read<PrIndexFile>(PR_INDEX_KEY);
     const archivedEntries = Object.values(index!.prs).filter((e) => e.archivedAt);
     expect(archivedEntries).toHaveLength(1);
+    expect(await store.read(`prs/${goneHash}/meta`)).toBeNull(); // 活跃存储已搬空
+    expect(await archiveStore.read(`prs/${goneHash}/meta`)).not.toBeNull(); // 落到归档存储
   });
 
   it('archived PR re-appearing on remote becomes active again', async () => {
@@ -577,20 +599,25 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
     await poller.tick();
+    const hash = (await listStoredPullRequests(store))[0]!.localId;
 
-    // 远端关单 → soft archive
+    // 远端关单 → soft archive：数据搬入归档存储
     adapter.setPrs([]);
     await poller.tick();
     expect(await listStoredPullRequests(store)).toHaveLength(0);
+    expect(await archiveStore.read(`prs/${hash}/meta`)).not.toBeNull();
 
-    // 复活：远端又出现 (例如 reviewer 被重新加回) → archivedAt 清零
+    // 复活：远端又出现 (例如 reviewer 被重新加回) → archivedAt 清零、整树搬回活跃存储
     adapter.setPrs([makePr('1', '2026-05-28T01:00:00.000Z')]);
     await poller.tick();
     expect(await listStoredPullRequests(store)).toHaveLength(1);
+    expect(await store.read(`prs/${hash}/meta`)).not.toBeNull(); // 搬回活跃存储
+    expect(await archiveStore.read(`prs/${hash}/meta`)).toBeNull(); // 归档存储已腾空
   });
 
   it('外部删除 prs/index.json: 下一轮 poll 自动重建', async () => {
@@ -598,6 +625,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -618,6 +646,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -641,6 +670,7 @@ describe('Poller.tick', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
       now: () => now,
@@ -648,17 +678,49 @@ describe('Poller.tick', () => {
     await poller.tick();
     const hash = (await listStoredPullRequests(store))[0]!.localId;
 
-    // T+0: 关单 → soft archive
+    // T+0: 关单 → soft archive：数据搬入归档存储（仍在 grace 期内保留）
     adapter.setPrs([]);
     await poller.tick();
-    expect(await store.read(`prs/${hash}/meta`)).not.toBeNull();
+    expect(await archiveStore.read(`prs/${hash}/meta`)).not.toBeNull();
 
-    // T+8 天: 超过 1 周 grace → 硬清掉整目录
+    // T+8 天: 超过 1 周 grace → 硬清掉整目录（归档存储 + 活跃存储两端都清）
     now = new Date('2026-06-09T00:00:00.000Z');
     await poller.tick();
+    expect(await archiveStore.read(`prs/${hash}/meta`)).toBeNull();
     expect(await store.read(`prs/${hash}/meta`)).toBeNull();
     const index = await store.read<PrIndexFile>(PR_INDEX_KEY);
     expect(Object.keys(index!.prs)).toHaveLength(0);
+  });
+
+  it('对账：把滞留活跃存储的归档数据搬入归档存储（旧布局 / split-brain 最终一致）', async () => {
+    const adapter = new FakeAdapter([makePr('1', '2026-05-28T01:00:00.000Z')]);
+    const now = new Date('2026-06-01T00:00:00.000Z');
+    const poller = new Poller({
+      connections: [{ connectionId: 'bb1', adapter }],
+      stateStore: store,
+      archiveStore,
+      intervalSeconds: 60,
+      logger: noopLogger,
+      now: () => now,
+    });
+    await poller.tick();
+    const hash = (await listStoredPullRequests(store))[0]!.localId;
+
+    // 模拟旧布局存量：手工把索引条目标 archived，但数据**仍留在活跃存储**（未搬迁）
+    const index = await store.read<PrIndexFile>(PR_INDEX_KEY);
+    index!.prs[hash]!.archivedAt = now.toISOString();
+    await store.write(PR_INDEX_KEY, index!);
+    expect(await store.read(`prs/${hash}/meta`)).not.toBeNull();
+    expect(await archiveStore.read(`prs/${hash}/meta`)).toBeNull();
+
+    // 远端仍无该 PR → 下一轮 poll 的对账步（未到 grace、不清）把整树搬入归档存储
+    adapter.setPrs([]);
+    await poller.tick();
+    expect(await store.read(`prs/${hash}/meta`)).toBeNull(); // 搬出活跃存储
+    expect(await archiveStore.read(`prs/${hash}/meta`)).not.toBeNull(); // 落到归档存储
+    // 仍在索引、仍 archived（对账只搬数据、不动索引）
+    const after = await store.read<PrIndexFile>(PR_INDEX_KEY);
+    expect(after!.prs[hash]!.archivedAt).toBe(now.toISOString());
   });
 });
 
@@ -668,6 +730,7 @@ describe('setLocalStatus', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -683,6 +746,7 @@ describe('setLocalStatus', () => {
     const poller = new Poller({
       connections: [{ connectionId: 'bb1', adapter }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
     });
@@ -708,6 +772,7 @@ describe('Poller.archiveConnectionsExcept', () => {
         { connectionId: 'bb2', adapter: a2 },
       ],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
       now: () => now,
@@ -723,12 +788,19 @@ describe('Poller.archiveConnectionsExcept', () => {
     const bb2 = entries.find((e) => e.identity.connectionId === 'bb2')!;
     expect(bb1.archivedAt).toBeNull(); // 活动连接不动
     expect(bb2.archivedAt).toBe(now.toISOString()); // 非活动连接被归档
+    // bb1 数据留在活跃存储；bb2 数据搬入归档存储
+    const bb1Hash = Object.entries(index!.prs).find(([, e]) => e === bb1)![0];
+    const bb2Hash = Object.entries(index!.prs).find(([, e]) => e === bb2)![0];
+    expect(await store.read(`prs/${bb1Hash}/meta`)).not.toBeNull();
+    expect(await store.read(`prs/${bb2Hash}/meta`)).toBeNull();
+    expect(await archiveStore.read(`prs/${bb2Hash}/meta`)).not.toBeNull();
 
     // 幂等：再调一次不改已归档的时间戳
     const later = new Date('2026-06-02T00:00:00.000Z');
     const poller2 = new Poller({
       connections: [{ connectionId: 'bb1', adapter: a1 }],
       stateStore: store,
+      archiveStore,
       intervalSeconds: 60,
       logger: noopLogger,
       now: () => later,

--- a/packages/shared/src/app-info.ts
+++ b/packages/shared/src/app-info.ts
@@ -5,6 +5,8 @@ export interface AppPaths {
   configFile: string;
   /** state/ subdir */
   stateDir: string;
+  /** archived/ subdir — cold store for retired PRs (sibling of state/); archived PR trees relocate here and follow the same purge lifecycle */
+  archivedDir: string;
   /** logs/ subdir */
   logsDir: string;
   /** agent/ subdir — 默认 Agent 目录位置（SOUL/AGENTS/MEMORY/USER + rules/） */

--- a/packages/state-store/src/index.ts
+++ b/packages/state-store/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export * from './json-file-state-store.js';
+export * from './relocate.js';

--- a/packages/state-store/src/json-file-state-store.ts
+++ b/packages/state-store/src/json-file-state-store.ts
@@ -124,6 +124,53 @@ export class JsonFileStateStore implements StateStore {
     return removed;
   }
 
+  /**
+   * 清扫 `<prefix>/<child>/` 下的孤儿子目录：`child` 不在 `keep` 集**且**目录 mtime 早于 `nowMs - olderThanMs`
+   * 的整树删掉。用于启动期回收归档冷存储里的孤儿——统一索引丢失 / 被重建后，归档条目失去目录索引，
+   * 按索引遍历的硬清够不到它（见 docs/arch/03）。无索引可依，故以目录 mtime 作 archivedAt 的代理（索引一并丢了）。
+   *
+   * **双重保守**：必须同时「不在 keep」+「mtime 超期」才删——避免误删一个只是暂时不在索引里的目录（如中断的搬迁）。
+   * **仅启动期、任何写入之前调用**才安全（单写者前提下此刻无 in-flight 搬迁会被误判为孤儿）。子目录直接子级遍历、
+   * 不递归判定；非目录项跳过。best-effort：单个失败仅记日志、不抛。返回删除的孤儿目录数。
+   */
+  async sweepOrphanDirs(
+    prefix: string,
+    keep: ReadonlySet<string>,
+    olderThanMs: number,
+    nowMs: number,
+  ): Promise<number> {
+    const root = this.subpathInside(prefix);
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(root, { withFileTypes: true });
+    } catch {
+      return 0; // prefix 目录不存在 / 不可读
+    }
+    let removed = 0;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || keep.has(entry.name)) continue;
+      const dir = path.join(root, entry.name);
+      let mtimeMs: number;
+      try {
+        mtimeMs = (await fs.stat(dir)).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (nowMs - mtimeMs <= olderThanMs) continue; // 太新：暂不动（保守）
+      try {
+        await fs.rm(dir, { recursive: true, force: true });
+        removed++;
+        this.logger?.info(
+          { dir: `${prefix}/${entry.name}`, ageMs: nowMs - mtimeMs },
+          'state-store: swept orphaned dir (no index entry, aged past grace)',
+        );
+      } catch (e) {
+        this.logger?.warn({ err: e, dir }, 'state-store: failed to sweep orphaned dir');
+      }
+    }
+    return removed;
+  }
+
   async delete(key: string): Promise<void> {
     const filePath = this.keyToPath(key);
     try {

--- a/packages/state-store/src/relocate.ts
+++ b/packages/state-store/src/relocate.ts
@@ -1,0 +1,44 @@
+import type { StateStore } from './types.js';
+
+/**
+ * Move an entire key subtree from one store to another (e.g. an archived PR's
+ * `prs/<hash>/` directory out of the active `state/` store and into the sibling
+ * `archived/` store). Works across stores rooted at different directories, which a
+ * single-store rename cannot — it copies via the `StateStore` abstraction
+ * (`list` → `read` → `write`) and then drops the source subtree, so it never needs
+ * to expose either store's filesystem root.
+ *
+ * Semantics:
+ * - **Source authoritative**: the destination subtree is cleared first, so the source
+ *   fully replaces whatever (stale / partial) data the destination held.
+ * - **Idempotent / crash-tolerant**: keys are enumerated up front and the source is
+ *   deleted only after every value is written. A crash mid-relocate leaves the source
+ *   intact (the move simply re-runs next time); the index that flips active⇄archived is
+ *   persisted only after the relocate, so an interrupted move re-derives cleanly.
+ * - **Missing source → no-op** (returns 0): already relocated, or never existed.
+ *
+ * Only `.json` values are carried (the only thing `StateStore.list` yields); every PR
+ * subtree file is JSON, so this loses nothing. Not atomic and re-serializes each file —
+ * fine because relocation is rare (archive / restore transitions) and PR subtrees are small.
+ *
+ * @returns the number of keys relocated.
+ */
+export async function relocateTree(
+  from: StateStore,
+  to: StateStore,
+  prefix: string,
+): Promise<number> {
+  // Enumerate before any mutation: the source is only deleted at the very end.
+  const keys: string[] = [];
+  for await (const key of from.list(prefix)) keys.push(key);
+  if (keys.length === 0) return 0;
+
+  // Source replaces destination wholesale — clear any stale/partial remnant first.
+  await to.deleteDir(prefix);
+  for (const key of keys) {
+    const data = await from.read<unknown>(key);
+    if (data !== null) await to.write(key, data);
+  }
+  await from.deleteDir(prefix);
+  return keys.length;
+}

--- a/packages/state-store/tests/json-file-state-store.test.ts
+++ b/packages/state-store/tests/json-file-state-store.test.ts
@@ -130,4 +130,41 @@ describe('JsonFileStateStore', () => {
     await expect(store.read(outside)).rejects.toThrow(/path traversal/);
     await expect(store.write(outside, { v: 1 })).rejects.toThrow(/path traversal/);
   });
+
+  describe('sweepOrphanDirs', () => {
+    const GRACE = 7 * 24 * 60 * 60 * 1000;
+    const NOW = Date.parse('2026-06-10T00:00:00.000Z');
+    // 把某个 <prefix>/<child> 目录的 mtime 回拨到 N 毫秒之前
+    const backdateDir = async (rel: string, ageMs: number): Promise<void> => {
+      const t = new Date(NOW - ageMs);
+      await fs.utimes(path.join(tmpDir, rel), t, t);
+    };
+
+    it('删「不在 keep + mtime 超 grace」的孤儿，保留 keep 内 / 仍年轻的目录', async () => {
+      await store.write('prs/orphan/meta', { v: 1 }); // 不在 keep、且回拨到超期 → 删
+      await store.write('prs/known/meta', { v: 1 }); // 在 keep → 留
+      await store.write('prs/young/meta', { v: 1 }); // 不在 keep 但还年轻 → 留
+      await backdateDir('prs/orphan', GRACE + 60_000);
+      await backdateDir('prs/known', GRACE + 60_000);
+      await backdateDir('prs/young', GRACE - 60_000);
+
+      const removed = await store.sweepOrphanDirs('prs', new Set(['known']), GRACE, NOW);
+      expect(removed).toBe(1);
+      expect(await store.read('prs/orphan/meta')).toBeNull();
+      expect(await store.read('prs/known/meta')).toEqual({ v: 1 });
+      expect(await store.read('prs/young/meta')).toEqual({ v: 1 });
+    });
+
+    it('prefix 目录不存在 → 返回 0、不抛', async () => {
+      expect(await store.sweepOrphanDirs('archived/prs', new Set(), GRACE, NOW)).toBe(0);
+    });
+
+    it('跳过非目录项（如散落的 .json 文件）', async () => {
+      await store.write('prs/index', { schema_version: 1 }); // prs/index.json 是文件，非目录
+      await backdateDir('prs', GRACE + 60_000);
+      const removed = await store.sweepOrphanDirs('prs', new Set(), GRACE, NOW);
+      expect(removed).toBe(0);
+      expect(await store.read('prs/index')).not.toBeNull();
+    });
+  });
 });

--- a/packages/state-store/tests/relocate.test.ts
+++ b/packages/state-store/tests/relocate.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { JsonFileStateStore } from '../src/json-file-state-store.js';
+import { relocateTree } from '../src/relocate.js';
+
+let rootDir: string;
+let from: JsonFileStateStore;
+let to: JsonFileStateStore;
+
+beforeEach(async () => {
+  rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-relocate-test-'));
+  // Two stores rooted at sibling dirs (mirrors state/ vs archived/).
+  from = new JsonFileStateStore(path.join(rootDir, 'state'));
+  to = new JsonFileStateStore(path.join(rootDir, 'archived'));
+});
+
+afterEach(async () => {
+  await fs.rm(rootDir, { recursive: true, force: true });
+});
+
+describe('relocateTree', () => {
+  it('moves a whole subtree to the destination store and drops the source', async () => {
+    await from.write('prs/abc/meta', { v: 1 });
+    await from.write('prs/abc/runs/r1', { ok: true });
+    await from.write('prs/abc/runs/r2', { ok: false });
+    // sibling subtree must stay put
+    await from.write('prs/other/meta', { keep: true });
+
+    const moved = await relocateTree(from, to, 'prs/abc');
+    expect(moved).toBe(3);
+
+    // destination now holds the data
+    expect(await to.read('prs/abc/meta')).toEqual({ v: 1 });
+    expect(await to.read('prs/abc/runs/r1')).toEqual({ ok: true });
+    expect(await to.read('prs/abc/runs/r2')).toEqual({ ok: false });
+
+    // source subtree gone, unrelated sibling untouched
+    expect(await from.read('prs/abc/meta')).toBeNull();
+    await expect(fs.access(path.join(rootDir, 'state', 'prs', 'abc'))).rejects.toThrow();
+    expect(await from.read('prs/other/meta')).toEqual({ keep: true });
+  });
+
+  it('is a no-op when the source subtree is missing', async () => {
+    const moved = await relocateTree(from, to, 'prs/ghost');
+    expect(moved).toBe(0);
+    expect(await to.read('prs/ghost/meta')).toBeNull();
+  });
+
+  it('replaces stale data already present at the destination', async () => {
+    await to.write('prs/abc/meta', { stale: true });
+    await to.write('prs/abc/runs/old', { dropMe: true });
+    await from.write('prs/abc/meta', { fresh: true });
+
+    await relocateTree(from, to, 'prs/abc');
+
+    expect(await to.read('prs/abc/meta')).toEqual({ fresh: true });
+    // stale key not present in source must be cleared (destination replaced wholesale)
+    expect(await to.read('prs/abc/runs/old')).toBeNull();
+  });
+
+  it('round-trips back (archive → active) preserving values', async () => {
+    await from.write('prs/abc/meta', { phase: 'active' });
+    await relocateTree(from, to, 'prs/abc');
+    const back = await relocateTree(to, from, 'prs/abc');
+    expect(back).toBe(1);
+    expect(await from.read('prs/abc/meta')).toEqual({ phase: 'active' });
+    expect(await to.read('prs/abc/meta')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景

PR / 状态存储改良：把退场（已合并 / 关闭 / 不再需你评审）的 PR 数据从活跃目录迁出，独立归档存放，活跃存储只装在场 PR。归档保留与到期自动清理策略保持不变。

## 改动

- **活跃 / 归档物理分离**：新增 `archived/` 冷存储（`~/.code-meeseeks/archived/`，与 `state/` 平级），退场 PR 的 `prs/<hash>/` 整树搬入；交互 / IPC 层只读活跃存储，`listStoredPullRequests` 天然不含归档。
- **跨 store 搬迁 `relocateTree`**：走 `list/read/write/deleteDir` 接口，目标先清（源为权威）、源末删（幂等可重来），不破 `StateStore` 抽象、无需暴露文件系统根。
- **生命周期**：软删搬出 / 复活搬回 / 到期两端硬清；其中 grace（7 天）内重开的 PR 历史（runs / 评论 / 草稿 / 已读水位 / 复评关闭关系 / AutoPilot 台账）**无损还原**回活跃目录。
- **对账（最终一致）**：每轮 poll 把滞留活跃存储的归档数据搬归位，覆盖旧布局存量、split-brain 残留、中断的搬迁。
- **启动期孤儿清扫**：统一索引丢失 / 重建后，归档数据失去索引条目、按索引遍历的硬清够不到 → 永久孤儿。`sweepOrphanedArchivedPrs` 以「无索引条目 + 目录 mtime 超 grace」无索引兜底回收。
- **索引仍单点**：`state/prs/index.json` 作为全量目录 + `archivedAt` 生命周期的唯一真相；数据所在根由 `archivedAt` 是否为空隐含决定。

设计 / 布局 / 生命周期文档见 [docs/arch/03](docs/arch/03-state-storage.md)。

## 验证

- lint ✓ / typecheck ✓ / build(desktop) ✓
- 测试：state-store 23、poller 114 全绿（含 relocate / sweepOrphanDirs / 复活搬回 / 对账 / 孤儿清扫新增用例）
- 既有 `repo-mirror` 6 个 `Not a git repository` 沙箱用例失败为环境问题，与本改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)