### PR TITLE
feat(desktop): 已关闭快捷键与命令面板默认项滚入视区

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -154,6 +154,17 @@ export default function App() {
         }
         return;
       }
+      // 查看已关闭（history）：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）
+      if (k === 'h') {
+        const wantArchived = isMac
+          ? e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey
+          : e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
+        if (wantArchived) {
+          e.preventDefault();
+          viewArchived();
+        }
+        return;
+      }
       // 单修饰键布局开关：Ctrl/Cmd+B（PR 列表）、Ctrl/Cmd+J（对话面板）
       const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
       if (!mod || e.shiftKey || e.altKey) return;
@@ -167,7 +178,7 @@ export default function App() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [boot?.info.platform, setSidebarCollapsed, setChatCollapsed]);
+  }, [boot?.info.platform, setSidebarCollapsed, setChatCollapsed, viewArchived]);
 
   if (fatalError) {
     return (

--- a/apps/desktop/src/renderer/src/components/features/command-palette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/CommandPalette.tsx
@@ -100,6 +100,7 @@ export function CommandPalette({
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const activeItemRef = useRef<HTMLButtonElement>(null);
   const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // 固定英文翻译器（en-US 静态打包、恒可用）：非英语界面作次行 + 恒按英文检索
@@ -226,6 +227,11 @@ export function CommandPalette({
     setActiveIndex((i) => Math.min(Math.max(0, i), Math.max(0, items.length - 1)));
   }, [items.length]);
 
+  // 高亮项滚入可视区：打开时默认选中的是 MRU 项（可能在列表中段），需自动滚到；方向键导航同理。
+  useEffect(() => {
+    if (open) activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [open, activeIndex, items.length]);
+
   // 全局快捷键：mac Cmd+Shift+P / 其余 Ctrl+Shift+P 打开
   useEffect(() => {
     const isMac = platform === 'darwin';
@@ -295,6 +301,7 @@ export function CommandPalette({
               return (
                 <button
                   key={it.id}
+                  ref={i === activeIndex ? activeItemRef : undefined}
                   type="button"
                   role="option"
                   aria-selected={i === activeIndex}

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/pr.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/pr.ts
@@ -37,13 +37,15 @@ export function buildPrCommands(ctx: CommandContext): RootCommand[] {
     });
   }
 
-  // 查看已关闭：切到归档（已关闭）范围浏览
+  // 查看已关闭：切到归档（已关闭）范围浏览。快捷键取 H（history）；mac 用 ⌘⇧H 避开系统「隐藏应用」(⌘H)，
+  // 其余平台 Ctrl+H（浏览器历史惯例）。见 App 窗口级快捷键。
   out.push({
     id: 'view-archived',
     category,
     categoryEn,
     title: t('commandPalette.cmdViewArchived'),
     titleEn: tEn('commandPalette.cmdViewArchived'),
+    shortcut: formatChord(ctx.platform, 'H', ctx.platform === 'darwin' ? { shift: true } : undefined),
     run: () => ctx.viewArchived(),
   });
 

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -799,7 +799,7 @@
     "discoveryAssigned": "Assigned",
     "discoveryCreated": "Created",
     "discoveryMentioned": "Mentioned",
-    "discoveryReviewRequested": "Review requested",
+    "discoveryReviewRequested": "Review Requested",
     "discoveryTablistAria": "PR discovery scope",
     "empty": "No matching PRs",
     "filterAll": "All",


### PR DESCRIPTION
延续 #138 的几处小优化。

## 改动

- **「查看已关闭」快捷键**（history 助记）：macOS `⌘⇧H`（避开系统保留的「隐藏应用」`⌘H`）/ 其余平台 `Ctrl+H`（浏览器历史惯例）；窗口级监听 + 命令面板展示对应键位。
- **命令面板默认项滚入视区**：打开时默认选中的是最近用过（MRU）的命令，可能位于列表中段——此前不会自动滚动到它；现打开即滚入可视区，方向键导航同理（`block: 'nearest'`，不抖动）。
- **英文文案**：`Review requested` → `Review Requested`，与其他发现分类标题大小写一致。

## 验证
lint / typecheck / build 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)