### PR TITLE
fix(bitbucket): 修复附件上传 405 + PR 列表切换类型清空搜索框

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -108,6 +108,10 @@ export function Sidebar({
   };
 
   const [query, setQuery] = useState('');
+  // 切换 PR 类型（发现分类标签 / 进行中⇄已关闭范围）后清空搜索框，避免上一类型遗留的过滤条件连带到新类型。
+  useEffect(() => {
+    setQuery('');
+  }, [discoveryFilter, scope]);
   // 状态筛选改由 App 持有（受控）：命令面板的「分类筛选」亦可驱动；折叠侧栏也不丢选择。
   const filter = statusFilter;
   const setFilter = onStatusFilterChange;

--- a/packages/platform-bitbucket-server/src/client.ts
+++ b/packages/platform-bitbucket-server/src/client.ts
@@ -259,6 +259,10 @@ export class BitbucketClient implements PlatformTransport {
   /**
    * multipart/form-data POST（附件上传用）。不手动设 Content-Type（交给 fetch 按 FormData 加 boundary）；
    * 附件上传须带 `X-Atlassian-Token: no-check` 绕过 XSRF 校验（Atlassian 文件上传端点通用要求）。
+   *
+   * Accept 必须用通配（星/斜杠/星），**不能**显式写 `application/json`：附件 servlet（nginx 前置）对该
+   * 端点做内容协商，显式请求 `application/json` 会被判 405（`Allow: OPTIONS`）——尽管它本就以 JSON 应答。
+   * 响应仍按 JSON 解析。（curl 默认用通配 Accept 故能成功，曾掩盖此坑。）
    */
   async postForm<T>(path: string, form: FormData): Promise<T> {
     const url = buildUrl(this.baseUrl, path);
@@ -269,7 +273,7 @@ export class BitbucketClient implements PlatformTransport {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${this.token}`,
-          Accept: 'application/json',
+          Accept: '*/*',
           'X-Atlassian-Token': 'no-check',
         },
         body: form,


### PR DESCRIPTION
两个独立的小改动，合并为一个 PR。

## 🔧 修复：Bitbucket 图片附件上传 405

附件上传一直返回 `405 on POST /projects/{key}/repos/{slug}/attachments`。经对实例只读复现确认：端点路径、HTTP 方法、`X-Atlassian-Token: no-check`、字段名 `files` 均无误，**唯一触发点是请求头 `Accept`**。

附件 servlet（nginx 前置）对该端点做内容协商，客户端显式发 `Accept: application/json` 会被判 405（`Allow: OPTIONS`）——尽管它本就以 JSON 应答。`postForm` 此前硬编码 `Accept: application/json`，正是病根；curl 默认发通配 `Accept` 故能成功，长期掩盖了此坑。

改为发通配 `Accept`，响应仍按 JSON 解析。

## ✨ 改良：PR 列表切换类型后自动清空搜索框

切换发现分类标签（待我评审 / 我创建的 等）或进行中⇄已关闭范围时，自动清空搜索框，避免上一类型遗留的过滤条件连带到新类型。同一类型下的状态筛选（待处理 / 全部 / 冲突…）属细分，不受影响、保留搜索。

## 验证

`lint` / `typecheck` / `test` / `build` 均通过；附件修复已对真实 Bitbucket 实例复现并验证修复后返回 201。
