### PR TITLE
refactor(desktop): App.tsx 组合根化，抽离 useGlobalShortcuts / usePrNavigation

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import type { PrDiscoveryFilter, StoredPullRequest } from '@meebox/shared';
 import { invoke, subscribe } from './api';
 import { formatBackendError } from './errors';
-import { chatRunStore } from './stores/chat-run-store';
 import { ChatPane } from './components/features/chat';
 import { MainPane } from './components/layout/MainPane';
 import { PrPanel, PrEmpty, usePullRequests } from './components/features/pr';
@@ -24,6 +23,7 @@ import { usePanelLayout } from './hooks/usePanelLayout';
 import { useUpdateNotice } from './hooks/useUpdateNotice';
 import { useAppStores } from './hooks/useAppStores';
 import { useExternalLinkGuard } from './hooks/useExternalLinkGuard';
+import { useGlobalShortcuts } from './hooks/useGlobalShortcuts';
 import { useGlobalTheme, useEditorAppearanceSync } from './hooks/useTheme';
 
 export default function App() {
@@ -220,64 +220,15 @@ export default function App() {
   // 已关闭范围的「可参与」判定：合并 / 仍开放的 PR 可补充评论 + AI 评审；decline 仅浏览。活跃范围恒可参与。
   const canEngage = !archived || (selectedPr ? selectedPr.state !== 'declined' : false);
 
-  // 选中 PR 的 ref：供 F5 快捷键在稳定监听里读最新值，免得每次切 PR 重订阅。
-  const selectedIdRef = useRef(selectedId);
-  selectedIdRef.current = selectedId;
-  // 不可参与（decline / 无选中）时 F5 自动评审等写操作一律忽略；ref 供稳定监听读实时值。
-  const canEngageRef = useRef(canEngage);
-  canEngageRef.current = canEngage;
-
-  // 布局快捷键（窗口级，VS Code 风）：Ctrl/Cmd+B 切 PR 列表（左侧栏）、Ctrl/Cmd+J 切对话面板（右侧）、
-  // F5 运行自动评审、DevTools。仅单修饰键的 B/J 排除 Shift/Alt（避开 Cmd+Shift+P）；preventDefault 压过默认。
-  useEffect(() => {
-    const isMac = boot?.info.platform === 'darwin';
-    const onKey = (e: KeyboardEvent): void => {
-      const k = e.key.toLowerCase();
-      // F5：对当前选中 PR 运行自动评审（与命令面板同逻辑：有选中 PR、且未在跑才触发——重入保护）
-      if (k === 'f5') {
-        const id = selectedIdRef.current;
-        if (id && canEngageRef.current && !chatRunStore.getSnapshot().agentPrs.includes(id)) {
-          e.preventDefault();
-          void invoke('agent:run', { localId: id });
-        }
-        return;
-      }
-      // DevTools：mac ⌥⌘I / 其余 Ctrl+Shift+I（带 Shift/Alt，与下面单修饰键的 B/J 区分）
-      if (k === 'i') {
-        const devtools = isMac
-          ? e.metaKey && e.altKey && !e.shiftKey && !e.ctrlKey
-          : e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey;
-        if (devtools) {
-          e.preventDefault();
-          void invoke('app:openDevTools', undefined);
-        }
-        return;
-      }
-      // 查看已关闭（history）：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）
-      if (k === 'h') {
-        const wantArchived = isMac
-          ? e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey
-          : e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
-        if (wantArchived) {
-          e.preventDefault();
-          viewArchived();
-        }
-        return;
-      }
-      // 单修饰键布局开关：Ctrl/Cmd+B（PR 列表）、Ctrl/Cmd+J（对话面板）
-      const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-      if (!mod || e.shiftKey || e.altKey) return;
-      if (k === 'b') {
-        e.preventDefault();
-        setSidebarCollapsed((c) => !c);
-      } else if (k === 'j') {
-        e.preventDefault();
-        setChatCollapsed((c) => !c);
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [boot?.info.platform, setSidebarCollapsed, setChatCollapsed, viewArchived]);
+  // 窗口级全局快捷键（F5 自动评审 / DevTools / 查看已关闭 / Ctrl-Cmd+B·J 布局开关）——领域逻辑归 useGlobalShortcuts。
+  useGlobalShortcuts({
+    platform: boot?.info.platform,
+    selectedId,
+    canEngage,
+    viewArchived,
+    setSidebarCollapsed,
+    setChatCollapsed,
+  });
 
   if (fatalError) {
     return (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,8 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { PrDiscoveryFilter, StoredPullRequest } from '@meebox/shared';
-import { invoke, subscribe } from './api';
-import { formatBackendError } from './errors';
+import { invoke } from './api';
 import { ChatPane } from './components/features/chat';
 import { MainPane } from './components/layout/MainPane';
 import { PrPanel, PrEmpty, usePullRequests } from './components/features/pr';
@@ -24,6 +22,7 @@ import { useUpdateNotice } from './hooks/useUpdateNotice';
 import { useAppStores } from './hooks/useAppStores';
 import { useExternalLinkGuard } from './hooks/useExternalLinkGuard';
 import { useGlobalShortcuts } from './hooks/useGlobalShortcuts';
+import { usePrNavigation } from './hooks/usePrNavigation';
 import { useGlobalTheme, useEditorAppearanceSync } from './hooks/useTheme';
 
 export default function App() {
@@ -80,131 +79,33 @@ export default function App() {
     setSettingsCategory(category);
     setShowSettings(true);
   }, []);
-  /**
-   * M4 跨组件跳转：ChatPane finding card 点"编辑" / PublishReviewModal anchor 点击 → 这里 set →
-   * PrPanel 切到 Diff tab + 透传给 DiffView 做 scroll/highlight/(可选)open edit zone，消费完清空。
-   */
-  const [pendingDiffNav, setPendingDiffNav] = useState<{
-    runId?: string;
-    findingId?: string;
-    anchor: { path: string; startLine: number; endLine: number };
-  } | null>(null);
-  // 通知点击 summary 评论 → 请求 PrPanel 切到「活动」对话标签（inline 评论走 pendingDiffNav）。
-  const [pendingTab, setPendingTab] = useState<'activity' | null>(null);
-  // GitHub 发现分类（运行时筛选，不持久化）；仅活动连接支持时在 PR 列表展示。
-  const [discoveryFilter, setDiscoveryFilter] = useState<PrDiscoveryFilter>('review-requested');
   // PR 状态筛选（待处理 / 全部 / 冲突 / 可合并等）：提升到 App 以便命令面板亦可驱动、折叠侧栏不丢选择。
   const [statusFilter, setStatusFilter] = useState<FilterKey>('pending');
-  // PR 列表范围：进行中（活跃）/ 已关闭（归档冷存储，懒加载、只读）。命令面板「查看已关闭」亦可驱动。
-  const [scope, setScope] = useState<'active' | 'archived'>('active');
-  const [archivedPrs, setArchivedPrs] = useState<StoredPullRequest[]>([]);
-  // 归档冷存储拉取中：列表区据此显示 loading（归档规模大、可能慢；PaneLoading 自带 150ms 延迟，快路径不闪）。
-  const [archivedLoading, setArchivedLoading] = useState(false);
-  // 进入「已关闭」范围时懒加载归档冷存储（每次进入重取，纳入此后新归档的 PR）；离开不清，便于来回切。
-  useEffect(() => {
-    if (scope !== 'archived') return;
-    let cancelled = false;
-    setArchivedLoading(true);
-    void invoke('prs:listArchived', undefined)
-      .then((list) => {
-        if (!cancelled) setArchivedPrs(list);
-      })
-      .finally(() => {
-        if (!cancelled) setArchivedLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [scope]);
+  // PR 导航 / 范围领域（发现分类 / 活跃·归档切换 / 归档懒加载 / 按 URL 打开 / 定位跳转 / 通知点击导航 +
+  // 跨组件 Diff·Tab 跳转意图）——领域逻辑归 usePrNavigation；选中态 / 已读仍由 usePullRequests 拥有。
+  const {
+    scope,
+    discoveryFilter,
+    displayedPrs,
+    selectedPr,
+    archivedLoading,
+    selectDiscovery,
+    viewActive,
+    viewArchived,
+    openPrByUrl,
+    jumpToPr,
+    pendingDiffNav,
+    setPendingDiffNav,
+    pendingTab,
+    setPendingTab,
+  } = usePrNavigation({ prs, selectedId, setSelectedId, markRead, notifyError });
   // macOS dock 角标：活跃 PR「@我 / 回复我」待回应总数 → 主进程落到 dock 图标（系统行为，逻辑见 useDockBadge）。
   useDockBadge({
     prs,
     platform: boot?.info.platform,
     notifications: boot?.config.notifications,
   });
-  // 选发现分类（侧栏 tab / 命令面板）即回到「进行中」范围；「查看已关闭」切到归档范围。
-  const selectDiscovery = useCallback((f: PrDiscoveryFilter) => {
-    setScope('active');
-    setDiscoveryFilter(f);
-  }, []);
-  const viewActive = useCallback(() => setScope('active'), []);
-  const viewArchived = useCallback(() => setScope('archived'), []);
-  // 当前发现分类的 ref：供 openPrByUrl 在稳定回调里读最新值，免得把 discoveryFilter 进依赖、频繁重建命令。
-  const discoveryFilterRef = useRef(discoveryFilter);
-  discoveryFilterRef.current = discoveryFilter;
-  // 按 URL 打开当前平台 PR（命令面板「打开 URL」）：定位本地或拉取存档后切到对应范围并选中；失败弹 toast。
-  const openPrByUrl = useCallback(
-    async (url: string) => {
-      try {
-        const res = await invoke('prs:openByUrl', { url });
-        setScope(res.location);
-        if (res.location === 'archived') {
-          // 归档范围（已存在归档 / 新拉取存档）需重载列表纳入目标 PR。
-          setArchivedPrs(await invoke('prs:listArchived', undefined));
-        } else if (
-          // 活跃 PR：若当前发现分类不含它，落到包含它的分类，确保侧栏能展示并高亮（否则只剩详情显示、列表无选中）。
-          res.discoveryFilters.length > 0 &&
-          !res.discoveryFilters.includes(discoveryFilterRef.current)
-        ) {
-          setDiscoveryFilter(res.discoveryFilters[0]!);
-        }
-        setSelectedId(res.localId);
-        if (res.location === 'active') void markRead(res.localId);
-      } catch (e) {
-        notifyError(formatBackendError(e).title);
-      }
-    },
-    [setSelectedId, markRead, notifyError],
-  );
-
-  // 活跃 PR 列表 ref：供通知点击在稳定订阅里读最新值，免得把 prs 进依赖、频繁重订阅。
-  const prsRef = useRef(prs);
-  prsRef.current = prs;
-  // 状态栏运行指示点击 → 定位该 agent 任务所属 PR 并打开会话。任务运行期间该 PR 可能已被 poll 归档（任务不取消、
-  // 仍在跑），故活跃列表里找不到时视为已归档：切归档范围 + 重载归档列表（覆盖「本 tick 刚归档、缓存未含」与
-  // 「已在归档范围、setScope 同值不触发懒加载」两种情况）再选中。活跃命中则切活跃范围 + 必要时切到含它的发现分类
-  // （确保侧栏展示并高亮）+ 标已读。
-  const jumpToPr = useCallback(
-    async (localId: string) => {
-      const active = prsRef.current.find((p) => p.localId === localId);
-      if (active) {
-        setScope('active');
-        if (
-          active.discoveryFilters.length > 0 &&
-          !active.discoveryFilters.includes(discoveryFilterRef.current)
-        ) {
-          setDiscoveryFilter(active.discoveryFilters[0]!);
-        }
-        setSelectedId(localId);
-        void markRead(localId);
-        return;
-      }
-      setScope('archived');
-      setArchivedPrs(await invoke('prs:listArchived', undefined));
-      setSelectedId(localId);
-    },
-    [markRead, setSelectedId],
-  );
-  // 系统通知点击 → 导航：复用 jumpToPr 选中目标（活跃命中切活跃范围 + 必要时切到含它的发现分类 + 标已读；
-  // 否则视为已归档 → 切归档范围、加载归档列表后选中），再按类型定位——inline 评论跳 Diff 行，summary 评论
-  // （mention / reply）开「活动」标签，new_pr 仅选中。此前仅在活跃列表查找、找不到即忽略，会漏掉已归档 PR 的
-  // 通知（如运行中任务的 PR 本 tick 刚被归档）；改走 jumpToPr 与状态栏跳转同一套活跃 / 归档定位逻辑。
-  useEffect(() => {
-    return subscribe('notification:activate', ({ localId, kind, anchor }) => {
-      void jumpToPr(localId);
-      if (anchor) {
-        setPendingDiffNav({ anchor: { path: anchor.path, startLine: anchor.line, endLine: anchor.line } });
-      } else if (kind === 'mention' || kind === 'reply') {
-        setPendingTab('activity');
-      }
-    });
-  }, [jumpToPr]);
-
-  // 列表 / 详情数据源随范围切换：已关闭范围用归档列表，其余用活跃列表。选中 PR 从当前展示列表解析——
-  // 切到归档范围时若原选中是活跃 PR 则解析不到、详情区回落空态，选归档项后再展示其详情。
   const archived = scope === 'archived';
-  const displayedPrs = archived ? archivedPrs : prs;
-  const selectedPr = displayedPrs.find((p) => p.localId === selectedId) ?? null;
   // 状态栏「待审 PR」计数：仅计**需我评审且本人尚未评审**的 PR（discovery=review-requested 且 localStatus=pending）。
   // 不能简单数 localStatus==='pending'——「我创建的」等分类的 PR 本人非评审人、localStatus 恒为 pending，会把计数撑大。
   // 无发现分类的平台（单一「待我评审」发现）discoveryFilters 为空，视作 review-requested。

--- a/apps/desktop/src/renderer/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import { invoke } from '../api';
+import { chatRunStore } from '../stores/chat-run-store';
+
+/**
+ * 窗口级全局快捷键（VS Code 风），统一在此挂一个 `keydown` 监听：
+ * - **F5**：对当前选中 PR 运行自动评审（与命令面板同逻辑：有选中 PR、可参与、且未在跑才触发——重入保护）。
+ * - **DevTools**：mac ⌥⌘I / 其余 Ctrl+Shift+I（带 Shift/Alt，与下面单修饰键的 B/J 区分）。
+ * - **查看已关闭**：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）。
+ * - **布局开关**：Ctrl/Cmd+B 切 PR 列表（左侧栏）、Ctrl/Cmd+J 切对话面板（右侧）；单修饰键，排除 Shift/Alt
+ *   （避开 Cmd+Shift+P 命令面板）。
+ *
+ * `selectedId` / `canEngage` 经 ref 读实时值，使监听只随 platform 与几个稳定回调重建、不随选中 PR 频繁重订阅。
+ */
+export function useGlobalShortcuts({
+  platform,
+  selectedId,
+  canEngage,
+  viewArchived,
+  setSidebarCollapsed,
+  setChatCollapsed,
+}: {
+  platform: string | undefined;
+  selectedId: string | null;
+  canEngage: boolean;
+  viewArchived: () => void;
+  setSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
+  setChatCollapsed: Dispatch<SetStateAction<boolean>>;
+}): void {
+  // 选中 PR / 可参与态的 ref：供稳定监听读实时值，免得每次切 PR 重订阅。
+  const selectedIdRef = useRef(selectedId);
+  selectedIdRef.current = selectedId;
+  const canEngageRef = useRef(canEngage);
+  canEngageRef.current = canEngage;
+
+  useEffect(() => {
+    const isMac = platform === 'darwin';
+    const onKey = (e: KeyboardEvent): void => {
+      const k = e.key.toLowerCase();
+      // F5：对当前选中 PR 运行自动评审（有选中 PR、可参与、且未在跑才触发——重入保护）
+      if (k === 'f5') {
+        const id = selectedIdRef.current;
+        if (id && canEngageRef.current && !chatRunStore.getSnapshot().agentPrs.includes(id)) {
+          e.preventDefault();
+          void invoke('agent:run', { localId: id });
+        }
+        return;
+      }
+      // DevTools：mac ⌥⌘I / 其余 Ctrl+Shift+I（带 Shift/Alt，与下面单修饰键的 B/J 区分）
+      if (k === 'i') {
+        const devtools = isMac
+          ? e.metaKey && e.altKey && !e.shiftKey && !e.ctrlKey
+          : e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey;
+        if (devtools) {
+          e.preventDefault();
+          void invoke('app:openDevTools', undefined);
+        }
+        return;
+      }
+      // 查看已关闭（history）：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）
+      if (k === 'h') {
+        const wantArchived = isMac
+          ? e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey
+          : e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
+        if (wantArchived) {
+          e.preventDefault();
+          viewArchived();
+        }
+        return;
+      }
+      // 单修饰键布局开关：Ctrl/Cmd+B（PR 列表）、Ctrl/Cmd+J（对话面板）
+      const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+      if (!mod || e.shiftKey || e.altKey) return;
+      if (k === 'b') {
+        e.preventDefault();
+        setSidebarCollapsed((c) => !c);
+      } else if (k === 'j') {
+        e.preventDefault();
+        setChatCollapsed((c) => !c);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [platform, viewArchived, setSidebarCollapsed, setChatCollapsed]);
+}

--- a/apps/desktop/src/renderer/src/hooks/usePrNavigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/usePrNavigation.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import type { PrDiscoveryFilter, StoredPullRequest } from '@meebox/shared';
+import { invoke, subscribe } from '../api';
+import { formatBackendError } from '../errors';
+
+/**
+ * 跨组件跳转意图（M4）：ChatPane finding card 点「编辑」/ PublishReviewModal anchor 点击 / 通知点击 inline
+ * 评论 → 这里 set → PrPanel 切到 Diff tab + 透传给 DiffView 做 scroll/highlight/(可选)open edit zone，消费完清空。
+ */
+export interface PendingDiffNav {
+  runId?: string;
+  findingId?: string;
+  anchor: { path: string; startLine: number; endLine: number };
+}
+
+export interface PrNavigation {
+  /** 列表范围：进行中（活跃）/ 已关闭（归档冷存储，懒加载、只读）。 */
+  scope: 'active' | 'archived';
+  /** GitHub 发现分类（运行时筛选，不持久化）；仅活动连接支持时在 PR 列表展示。 */
+  discoveryFilter: PrDiscoveryFilter;
+  /** 当前展示列表（归档范围用归档列表，其余用活跃列表）。 */
+  displayedPrs: StoredPullRequest[];
+  /** 当前展示列表里解析出的选中 PR（解析不到回 null）。 */
+  selectedPr: StoredPullRequest | null;
+  /** 归档冷存储拉取中（列表区据此显示 loading）。 */
+  archivedLoading: boolean;
+  /** 选发现分类（侧栏 tab / 命令面板）→ 回到「进行中」范围并切分类。 */
+  selectDiscovery: (f: PrDiscoveryFilter) => void;
+  /** 切到「进行中」范围。 */
+  viewActive: () => void;
+  /** 切到「已关闭」范围（触发懒加载）。 */
+  viewArchived: () => void;
+  /** 按 URL 打开当前平台 PR（命令面板「打开 URL」）：定位本地或拉取存档后切到对应范围并选中；失败弹 toast。 */
+  openPrByUrl: (url: string) => Promise<void>;
+  /** 定位并选中某 PR（活跃命中切活跃 + 必要时切分类 + 标已读；否则视为已归档 → 切归档范围、加载归档列表后选中）。 */
+  jumpToPr: (localId: string) => Promise<void>;
+  pendingDiffNav: PendingDiffNav | null;
+  setPendingDiffNav: Dispatch<SetStateAction<PendingDiffNav | null>>;
+  pendingTab: 'activity' | null;
+  setPendingTab: Dispatch<SetStateAction<'activity' | null>>;
+}
+
+/**
+ * PR 导航 / 范围领域：在 {@link usePullRequests} 的列表 + 选中之上，统管发现分类、活跃 / 归档范围切换、
+ * 归档冷存储懒加载、按 URL 打开、定位跳转（活跃 / 归档统一逻辑），并消费系统通知点击的导航意图
+ * （`notification:activate` → jumpToPr + inline 评论跳 Diff 行 / summary 评论开「活动」标签）。
+ *
+ * 选中态 / 已读由 usePullRequests 拥有（经入参传入）；本 hook 只负责「去哪儿、看哪个范围」。
+ */
+export function usePrNavigation({
+  prs,
+  selectedId,
+  setSelectedId,
+  markRead,
+  notifyError,
+}: {
+  prs: StoredPullRequest[];
+  selectedId: string | null;
+  setSelectedId: (id: string | null) => void;
+  markRead: (localId: string) => Promise<void> | void;
+  notifyError: (text: string) => void;
+}): PrNavigation {
+  const [discoveryFilter, setDiscoveryFilter] = useState<PrDiscoveryFilter>('review-requested');
+  const [scope, setScope] = useState<'active' | 'archived'>('active');
+  const [archivedPrs, setArchivedPrs] = useState<StoredPullRequest[]>([]);
+  // 归档冷存储拉取中：列表区据此显示 loading（归档规模大、可能慢；PaneLoading 自带 150ms 延迟，快路径不闪）。
+  const [archivedLoading, setArchivedLoading] = useState(false);
+  const [pendingDiffNav, setPendingDiffNav] = useState<PendingDiffNav | null>(null);
+  // 通知点击 summary 评论 → 请求 PrPanel 切到「活动」对话标签（inline 评论走 pendingDiffNav）。
+  const [pendingTab, setPendingTab] = useState<'activity' | null>(null);
+
+  // 进入「已关闭」范围时懒加载归档冷存储（每次进入重取，纳入此后新归档的 PR）；离开不清，便于来回切。
+  useEffect(() => {
+    if (scope !== 'archived') return;
+    let cancelled = false;
+    setArchivedLoading(true);
+    void invoke('prs:listArchived', undefined)
+      .then((list) => {
+        if (!cancelled) setArchivedPrs(list);
+      })
+      .finally(() => {
+        if (!cancelled) setArchivedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scope]);
+
+  // 选发现分类（侧栏 tab / 命令面板）即回到「进行中」范围；「查看已关闭」切到归档范围。
+  const selectDiscovery = useCallback((f: PrDiscoveryFilter) => {
+    setScope('active');
+    setDiscoveryFilter(f);
+  }, []);
+  const viewActive = useCallback(() => setScope('active'), []);
+  const viewArchived = useCallback(() => setScope('archived'), []);
+
+  // 当前发现分类的 ref：供 openPrByUrl / jumpToPr 在稳定回调里读最新值，免得把 discoveryFilter 进依赖、频繁重建。
+  const discoveryFilterRef = useRef(discoveryFilter);
+  discoveryFilterRef.current = discoveryFilter;
+
+  const openPrByUrl = useCallback(
+    async (url: string) => {
+      try {
+        const res = await invoke('prs:openByUrl', { url });
+        setScope(res.location);
+        if (res.location === 'archived') {
+          // 归档范围（已存在归档 / 新拉取存档）需重载列表纳入目标 PR。
+          setArchivedPrs(await invoke('prs:listArchived', undefined));
+        } else if (
+          // 活跃 PR：若当前发现分类不含它，落到包含它的分类，确保侧栏能展示并高亮（否则只剩详情显示、列表无选中）。
+          res.discoveryFilters.length > 0 &&
+          !res.discoveryFilters.includes(discoveryFilterRef.current)
+        ) {
+          setDiscoveryFilter(res.discoveryFilters[0]!);
+        }
+        setSelectedId(res.localId);
+        if (res.location === 'active') void markRead(res.localId);
+      } catch (e) {
+        notifyError(formatBackendError(e).title);
+      }
+    },
+    [setSelectedId, markRead, notifyError],
+  );
+
+  // 活跃 PR 列表 ref：供通知点击 / 状态栏跳转在稳定回调里读最新值，免得把 prs 进依赖、频繁重建。
+  const prsRef = useRef(prs);
+  prsRef.current = prs;
+  // 状态栏运行指示 / 通知点击 → 定位 PR。任务运行期间该 PR 可能已被 poll 归档（任务不取消、仍在跑），故活跃列表
+  // 里找不到时视为已归档：切归档范围 + 重载归档列表（覆盖「本 tick 刚归档、缓存未含」与「已在归档范围、setScope
+  // 同值不触发懒加载」两种情况）再选中。活跃命中则切活跃范围 + 必要时切到含它的发现分类（确保侧栏展示并高亮）+ 标已读。
+  const jumpToPr = useCallback(
+    async (localId: string) => {
+      const active = prsRef.current.find((p) => p.localId === localId);
+      if (active) {
+        setScope('active');
+        if (
+          active.discoveryFilters.length > 0 &&
+          !active.discoveryFilters.includes(discoveryFilterRef.current)
+        ) {
+          setDiscoveryFilter(active.discoveryFilters[0]!);
+        }
+        setSelectedId(localId);
+        void markRead(localId);
+        return;
+      }
+      setScope('archived');
+      setArchivedPrs(await invoke('prs:listArchived', undefined));
+      setSelectedId(localId);
+    },
+    [markRead, setSelectedId],
+  );
+
+  // 系统通知点击 → 导航：复用 jumpToPr 选中目标，再按类型定位——inline 评论跳 Diff 行，summary 评论
+  // （mention / reply）开「活动」标签，new_pr 仅选中。与状态栏跳转走同一套活跃 / 归档定位逻辑。
+  useEffect(() => {
+    return subscribe('notification:activate', ({ localId, kind, anchor }) => {
+      void jumpToPr(localId);
+      if (anchor) {
+        setPendingDiffNav({ anchor: { path: anchor.path, startLine: anchor.line, endLine: anchor.line } });
+      } else if (kind === 'mention' || kind === 'reply') {
+        setPendingTab('activity');
+      }
+    });
+  }, [jumpToPr]);
+
+  // 列表 / 详情数据源随范围切换：已关闭范围用归档列表，其余用活跃列表。选中 PR 从当前展示列表解析——
+  // 切到归档范围时若原选中是活跃 PR 则解析不到、详情区回落空态，选归档项后再展示其详情。
+  const displayedPrs = scope === 'archived' ? archivedPrs : prs;
+  const selectedPr = displayedPrs.find((p) => p.localId === selectedId) ?? null;
+
+  return {
+    scope,
+    discoveryFilter,
+    displayedPrs,
+    selectedPr,
+    archivedLoading,
+    selectDiscovery,
+    viewActive,
+    viewArchived,
+    openPrByUrl,
+    jumpToPr,
+    pendingDiffNav,
+    setPendingDiffNav,
+    pendingTab,
+    setPendingTab,
+  };
+}

--- a/docs/arch/10-ui-interaction.md
+++ b/docs/arch/10-ui-interaction.md
@@ -39,6 +39,16 @@ pr-agent run 的实时状态、仓库同步、草稿都用**模块级 store**（
 启动时把主进程的事件流（run 进度 / 队列变化 / 同步进度 / 草稿变化）接入。这样切换 PR 时运行中的状态、
 实时 stdout、草稿列表不随组件卸载丢失。
 
+### 组件分层：App = 组合根，领域逻辑归 hooks
+
+`App.tsx` 是**组合根（composition root）**——只做三件事：调用各领域 hook、装配视图模型（廉价派生）、把数据与回调透传给 TitleBar / Sidebar / MainPane / ChatPane / StatusBar 等子组件。**不在 App 内堆领域逻辑**（状态机、effect、IPC 调用、ref 同步等），这些下沉到 `renderer/src/hooks/use*.ts` 各自的领域 hook：
+
+- `usePullRequests`（列表 / 选中 / 审批 / 合并 / 刷新 / 已读）、`useBootstrap`（启动 + 全局生命周期）、`usePrNavigation`（发现分类 / 活跃·归档范围 / 归档懒加载 / 按 URL 打开 / 定位跳转 / 通知点击导航 / 跨组件 Diff·Tab 跳转意图）、`useGlobalShortcuts`（窗口级快捷键）、`usePanelLayout`、`useDockBadge`、`useTheme`、`useToast`、`useUpdateNotice`、`useExternalLinkGuard`、`useAppStores`。
+- **判据**：一段逻辑若含自身的 state/effect/ref 同步、或可独立测试，就该是一个 hook；若只是「把 A 的输出接到 B 的入参」的装配与廉价派生（如按能力位过滤可见筛选项），留在组合根。
+- **避免反向臃肿**：相互依赖的状态（如 scope / selectedId / discoveryFilter）收在**同一个** hook，别拆成多个靠参数互穿 setter 的小 hook。hook 之间有依赖时按「数据源 → 派生」单向组合（如 `usePrNavigation` 组合在 `usePullRequests` 之上）。
+
+历史上 App 会随特性迭代「长回来」（通知、快捷键等细分领域内联堆积）——发现 App 又变臃肿时，按上述判据把成形的领域抽成 hook、回归组合根。
+
 ### 无边框窗口
 
 主窗口去掉系统原生标题栏（`titleBarStyle: 'hidden'`），由渲染层自绘一条 36px 标题栏（VS Code 风），
@@ -72,6 +82,7 @@ pr-agent run 的实时状态、仓库同步、草稿都用**模块级 store**（
 
 - **新交互一律走 IPC + 类型映射**：渲染层不直接碰 Node / 文件 / 网络。
 - **跨 PR 需存活的状态进模块级 store**，不要塞组件 useState（切 PR 即丢）。
+- **App.tsx 保持组合根**：新交互的领域逻辑下沉到 `hooks/use*.ts`，App 只装配（见「组件分层」）；发现 App 又变臃肿即按域抽 hook。
 - **安全基线**：`contextIsolation` 开、无 `nodeIntegration`、CSP；preload 只暴露白名单能力。
 - **二层模态**新增时记得 backdrop `stopPropagation`，否则会连带关掉外层。
 - **无边框标题栏高度**改动时，渲染层 `.app-titlebar` 与主进程 `titleBarOverlay.height` 两处须同步，否则 Windows 窗控与标题区错位；标题栏内新增交互元素记得标 `no-drag`。


### PR DESCRIPTION
## 背景

`App.tsx` 经多版本迭代又重新臃肿（474 行），内联堆积了通知、快捷键、PR 导航/范围等细分领域逻辑。按本仓库既有约定（领域逻辑下沉 `hooks/use*.ts`、App 退化为组合根）做进一步领域化拆分。

## 改动（零行为变更）

- **`useGlobalShortcuts`**：窗口级快捷键（F5 自动评审 / DevTools / 查看已关闭 / Ctrl-Cmd+B·J 布局开关）及配套 ref 收进 hook。
- **`usePrNavigation`**：发现分类、活跃·归档范围切换、归档冷存储懒加载、按 URL 打开、定位跳转（jumpToPr）、系统通知点击导航、跨组件 Diff/Tab 跳转意图（pendingDiffNav / pendingTab）—— 组合在 `usePullRequests`（列表 + 选中）之上。导航相关相互依赖的状态收在同一 hook，避免 setter 互穿。
- **文档**：[10-ui-interaction.md](docs/arch/10-ui-interaction.md) 新增「组件分层」小节，成文化「App=组合根、领域逻辑归 hooks」约定（含抽离判据与避免反向臃肿指引）。

刻意保留在组合根的：JSX 装配、廉价视图模型派生（`selectedConn` / `llmConfigured` / `effectiveDiscoveryFilter` / `visibleStatusFilters`）、`statusFilter` / `pendingReviewCount` 等简单状态。

## 成效

`App.tsx` **474 → 320 行**，回归纯组合根 + 视图模型装配。

## 验证

每步独立过 `lint`（zero-warnings）+ `typecheck` + `build`，全绿；无行为变更，无新增测试需求（纯结构重组）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)