### PR TITLE
chore(release): 准备 0.8.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 本项目所有重要变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-## [Unreleased]
+## [0.8.0-alpha.1] - 2026-06-30
+
+> 本版重点：
+>
+> - **消息通知**：系统通知（新 PR / 评论回复 / 被 @）+ macOS dock 角标 + 授权引导
+> - **评论体验优化**：emoji 反应、@ 提及补全、图片附件、表情代码渲染——评论 / 回复 / 行内 / 草稿一致
+> - **命令面板**：`Ctrl/Cmd+Shift+P` 归口常用操作
+> - **已关闭 PR 浏览与按 URL 打开**：查看历史 PR、补充评论 / 补跑评审
+> - **评审规则增强**：规则目录递归、多规则按 `Ruleset` 分段注入
+> - **2026 主题配色** 与 **PR 列表点名计数**
 
 ### ✨ 新增
 
@@ -359,7 +368,7 @@
 
 许可证：[Apache-2.0](LICENSE)。打包内含第三方组件（pr-agent、Electron 等），各按其许可证分发，见 [NOTICE](NOTICE)。
 
-[Unreleased]: https://github.com/huhamhire/code-meeseeks/compare/v0.7.0...HEAD
+[0.8.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.7.0...v0.8.0-alpha.1
 [0.7.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.4.0...v0.5.0

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meebox/desktop",
-  "version": "0.8.0-dev",
+  "version": "0.8.0-alpha.1",
   "private": true,
   "description": "meebox Electron desktop app",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/desktop": {
       "name": "@meebox/desktop",
-      "version": "0.8.0-dev",
+      "version": "0.8.0-alpha.1",
       "dependencies": {
         "@iconify-json/material-icon-theme": "^1.2.66",
         "@iconify/react": "^5.2.1",


### PR DESCRIPTION
## 发布预备：0.8.0-alpha.1

按发布流程在同一批改动里完成三步前置（随本 PR 经 `dev` → `master`，之后在 `master` 打 `v0.8.0-alpha.1` tag 触发 release）：

1. **版本号**：[apps/desktop/package.json](apps/desktop/package.json) `0.8.0-dev` → `0.8.0-alpha.1`；`npm install` 对齐 `package-lock.json`（仅一行版本号变更）。
2. **CHANGELOG**：`## [Unreleased]` 改名为 `## [0.8.0-alpha.1] - 2026-06-30`，补「本版重点」引言；底部补 `[0.8.0-alpha.1]: …/compare/v0.7.0...v0.8.0-alpha.1` 链接、移除 `[Unreleased]`（不另起空段）。
3. **校对**：该段已覆盖自 0.7.0 以来合入 dev 的用户向要点（消息通知、评论体验优化、命令面板、已关闭 PR 浏览 / 按 URL 打开、评审规则增强、2026 主题、点名计数等；纯重构 / 文档不计）。

预发布 tag（名含 `-`）由 release.yml 自动标 prerelease、不抢占 Latest。

## 验证

`lint` / `typecheck` / `test` / `build` 全绿（源码未变，多为缓存命中）。

> ⚠️ 合并到 dev 后还需 `dev` → `master`，并在 `master` 打 `v0.8.0-alpha.1` tag 才会触发出包；tag 名须与 package.json 版本一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)