### PR TITLE
fix(settings): 设置导航长标签换行断词，修复德语溢出

### DIFF
--- a/apps/desktop/src/renderer/src/i18n/index.ts
+++ b/apps/desktop/src/renderer/src/i18n/index.ts
@@ -66,6 +66,23 @@ export function persistLanguage(lang: string): void {
   }
 }
 
+/**
+ * 让 `<html lang>` 跟随当前 UI 语言（初始 + 每次切换）。index.html 静态写死 `zh-CN`、切语言时不更新，
+ * 会误导 CSS `hyphens:auto` 断词（用错语言的断词词典）、屏幕阅读器与字体选择。i18n 的 languageChanged
+ * 覆盖所有切换来源（启动 / 设置页 / 首启向导 / 命令面板），在此一处同步即可。
+ */
+function syncDocumentLang(lng: string): void {
+  try {
+    document.documentElement.lang = lng;
+  } catch {
+    // document 不可用（非常规宿主）时忽略：仅影响断词 / 可达性提示，不影响功能。
+  }
+}
+
+const initialLanguage = readInitialLanguage();
+syncDocumentLang(initialLanguage);
+i18n.on('languageChanged', syncDocumentLang);
+
 void i18n
   .use(
     // zh-CN 已静态打包，backend 只为其余语言按需拉取对应 chunk。
@@ -82,7 +99,7 @@ void i18n
     },
     partialBundledLanguages: true,
     // 初始语言取持久化值 / OS 偏好（默认按 OS 回落英语）：直接以用户语言启动。
-    lng: readInitialLanguage(),
+    lng: initialLanguage,
     // 兜底取 en-US（国际化标准：英文最通用）：任何 locale 缺 key 回退英文而非中文。
     // 各 locale 满覆盖，单层兜底足够；en-US 已静态打包，作 fallback 也不必再拉 chunk。
     fallbackLng: 'en-US',

--- a/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
+++ b/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
@@ -49,6 +49,15 @@
     color: $text-muted;
   }
 
+  // 标签允许换行 + 断词：德语等长复合词（如 Benachrichtigungen）在固定宽导航里一行放不下，
+  // 靠 hyphens 正确断词（依赖 <html lang>，见 i18n），overflow-wrap 兜底——绝不裁切。
+  span {
+    min-width: 0;
+    overflow-wrap: break-word;
+    hyphens: auto;
+    line-height: 1.25;
+  }
+
   &:hover {
     background: $bg-hover;
   }


### PR DESCRIPTION
## 问题

德语界面下,设置面板左导航的长标签 **Benachrichtigungen** 溢出被裁切(最后一个字母被切掉)。

固定宽导航 `flex: 0 0 168px`,文本可用宽度约 104px;德语该复合词 @14px 约需 ~135px。它是**单个不可断的词**,flex 子项无法收缩、单词又不能换行 → 溢出被裁。英文 "Notifications" 勉强不裁,故只有德语翻车。

## 改进(语言无关,不打宽度补丁)

- **导航标签允许换行 + 断词**:`.settings-nav-item span` 加 `min-width:0` + `hyphens:auto`(正确断词)+ `overflow-wrap:break-word`(兜底)+ 收紧 `line-height`。任何语言、任何长度都不再裁切。
- **修 `<html lang>` 跟随 UI 语言**:index.html 静态写死 `lang="zh-CN"`、切语言从不更新——`hyphens:auto` 会用错断词词典,并误导屏幕阅读器/字体选择。改为订阅 i18n `languageChanged` 一处同步 `document.documentElement.lang`,覆盖全部切换来源(启动/设置/向导/命令面板)+ 初始值。

德语下得到 "Benachrich‑/tigungen" 式正确两行断词。

## 文案说明

保留 "Benachrichtigungen" 不改短:它是德语通知的标准术语(分区标题本身即该词,改标签会术语不一致);且本改动已语言无关地根治排版,改文案只治德语一词、换语言即复发。

## 验证

desktop typecheck + lint 通过。
