### PR TITLE
fix(ci): 修复 CLI release 打包 windows/mac 校验和步骤挂掉

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,11 @@ jobs:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
+      # 显式声明 node：版本号取自 apps/desktop/package.json（`node -p` 读取），不依赖 runner 隐式自带 node。
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: 交叉编译 meebox CLI
         shell: bash
         working-directory: cli
@@ -183,19 +188,20 @@ jobs:
         run: |
           VERSION="$(node -p "require('$GITHUB_WORKSPACE/apps/desktop/package.json').version")"  # 与 app 同源
           BIN="meebox${{ matrix.ext }}"
-          ARCHIVE="meebox-cli-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          ARCHIVE="meebox-cli-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}"
           # Bundle LICENSE + README + SKILL.md so the archive is a drop-in agent skill
           # directory (unzip into a skills dir → SKILL.md beside the binary it drives).
           cp ../../LICENSE ../README.md ../SKILL.md .
           FILES=("${BIN}" LICENSE README.md SKILL.md)
           if [ "${{ matrix.archive }}" = "zip" ]; then
-            zip -q "${ARCHIVE}.zip" "${FILES[@]}"
+            zip -q "${ARCHIVE}" "${FILES[@]}"
           else
-            tar -czf "${ARCHIVE}.tar.gz" "${FILES[@]}"
+            tar -czf "${ARCHIVE}" "${FILES[@]}"
           fi
-          for f in "${ARCHIVE}".zip "${ARCHIVE}".tar.gz; do
-            [ -e "$f" ] && sha256sum "$f" > "$f.sha256"
-          done
+          # 只对本 matrix 实际产出的那个压缩包做校验和。此前遍历 .zip/.tar.gz 两种扩展名：zip 变体
+          # （windows/mac）最后一轮 `[ -e X.tar.gz ]` 为假、返回 1，恰是步骤末命令 → 整步以 1 退出而挂；
+          # linux（.tar.gz 末轮命中）才幸免。直接对已知文件名求 sha256，去掉这个脆弱循环。
+          sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
 
       - name: 上传到 Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## 问题

`v0.9.0-alpha.1` 的 Release workflow 里,CLI 的「打包压缩包 + 校验和」步骤在 **windows 和 mac 变体挂掉**(exit 1),linux 通过。

## 根因(与 node 无关)

步骤末尾对校验和的处理是遍历两种扩展名:

```bash
for f in "${ARCHIVE}".zip "${ARCHIVE}".tar.gz; do
  [ -e "$f" ] && sha256sum "$f" > "$f.sha256"
done
```

- **zip 变体(windows/mac)**:最后一轮测 `X.tar.gz` 不存在 → `[ -e ]` 返回 1 → `&&` 短路、该复合命令退出 1 → 它恰是**步骤的最后一条命令** → 整步以 exit 1 结束 → **失败**。
- **tar.gz 变体(linux)**:最后一轮 `X.tar.gz` 命中 → sha256sum 成功 → exit 0 → 通过。

正是「windows/mac 挂、linux 过」的分裂。截图里只有 `Process completed with exit code 1`、无命令报错,也印证是 `[ -e ]` 静默返回 1(而非 node/zip 缺失)。node 是在的——上一步交叉编译用了同样的 `node -p` 且通过。

## 修复

- 把扩展名并入 `ARCHIVE`,**只对本 matrix 实际产出的那一个压缩包**求 sha256,去掉脆弱的双扩展名循环。
- 顺带**显式声明 `actions/setup-node`**:版本号取自 `apps/desktop/package.json`(经 `node -p` 读取),此前赖 runner 隐式自带 node;显式声明更稳、也自证依赖。

## 再发布说明

Actions 从 tag ref 读取 workflow,故此修复需**重打 tag** 才对 `0.9.0-alpha.1` 生效(合并后删除并重推 `v0.9.0-alpha.1`,或改发 `-alpha.2`)。
