### PR TITLE
release: 0.9.0-alpha.1 重发（修复 CLI 打包 CI + 设置导航德语溢出）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,11 @@ jobs:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
 
+      # 显式声明 node：版本号取自 apps/desktop/package.json（`node -p` 读取），不依赖 runner 隐式自带 node。
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: 交叉编译 meebox CLI
         shell: bash
         working-directory: cli
@@ -183,19 +188,20 @@ jobs:
         run: |
           VERSION="$(node -p "require('$GITHUB_WORKSPACE/apps/desktop/package.json').version")"  # 与 app 同源
           BIN="meebox${{ matrix.ext }}"
-          ARCHIVE="meebox-cli-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          ARCHIVE="meebox-cli-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}"
           # Bundle LICENSE + README + SKILL.md so the archive is a drop-in agent skill
           # directory (unzip into a skills dir → SKILL.md beside the binary it drives).
           cp ../../LICENSE ../README.md ../SKILL.md .
           FILES=("${BIN}" LICENSE README.md SKILL.md)
           if [ "${{ matrix.archive }}" = "zip" ]; then
-            zip -q "${ARCHIVE}.zip" "${FILES[@]}"
+            zip -q "${ARCHIVE}" "${FILES[@]}"
           else
-            tar -czf "${ARCHIVE}.tar.gz" "${FILES[@]}"
+            tar -czf "${ARCHIVE}" "${FILES[@]}"
           fi
-          for f in "${ARCHIVE}".zip "${ARCHIVE}".tar.gz; do
-            [ -e "$f" ] && sha256sum "$f" > "$f.sha256"
-          done
+          # 只对本 matrix 实际产出的那个压缩包做校验和。此前遍历 .zip/.tar.gz 两种扩展名：zip 变体
+          # （windows/mac）最后一轮 `[ -e X.tar.gz ]` 为假、返回 1，恰是步骤末命令 → 整步以 1 退出而挂；
+          # linux（.tar.gz 末轮命中）才幸免。直接对已知文件名求 sha256，去掉这个脆弱循环。
+          sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
 
       - name: 上传到 Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/apps/desktop/src/renderer/src/i18n/index.ts
+++ b/apps/desktop/src/renderer/src/i18n/index.ts
@@ -66,6 +66,23 @@ export function persistLanguage(lang: string): void {
   }
 }
 
+/**
+ * 让 `<html lang>` 跟随当前 UI 语言（初始 + 每次切换）。index.html 静态写死 `zh-CN`、切语言时不更新，
+ * 会误导 CSS `hyphens:auto` 断词（用错语言的断词词典）、屏幕阅读器与字体选择。i18n 的 languageChanged
+ * 覆盖所有切换来源（启动 / 设置页 / 首启向导 / 命令面板），在此一处同步即可。
+ */
+function syncDocumentLang(lng: string): void {
+  try {
+    document.documentElement.lang = lng;
+  } catch {
+    // document 不可用（非常规宿主）时忽略：仅影响断词 / 可达性提示，不影响功能。
+  }
+}
+
+const initialLanguage = readInitialLanguage();
+syncDocumentLang(initialLanguage);
+i18n.on('languageChanged', syncDocumentLang);
+
 void i18n
   .use(
     // zh-CN 已静态打包，backend 只为其余语言按需拉取对应 chunk。
@@ -82,7 +99,7 @@ void i18n
     },
     partialBundledLanguages: true,
     // 初始语言取持久化值 / OS 偏好（默认按 OS 回落英语）：直接以用户语言启动。
-    lng: readInitialLanguage(),
+    lng: initialLanguage,
     // 兜底取 en-US（国际化标准：英文最通用）：任何 locale 缺 key 回退英文而非中文。
     // 各 locale 满覆盖，单层兜底足够；en-US 已静态打包，作 fallback 也不必再拉 chunk。
     fallbackLng: 'en-US',

--- a/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
+++ b/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
@@ -49,6 +49,15 @@
     color: $text-muted;
   }
 
+  // 标签允许换行 + 断词：德语等长复合词（如 Benachrichtigungen）在固定宽导航里一行放不下，
+  // 靠 hyphens 正确断词（依赖 <html lang>，见 i18n），overflow-wrap 兜底——绝不裁切。
+  span {
+    min-width: 0;
+    overflow-wrap: break-word;
+    hyphens: auto;
+    line-height: 1.25;
+  }
+
   &:hover {
     background: $bg-hover;
   }


### PR DESCRIPTION
## 0.9.0-alpha.1 重发 PR（dev → master）

首个 alpha 的 Release workflow 在 **CLI 打包步骤**挂掉(windows/mac 变体),产出残缺(GUI + linux CLI 已传,windows/mac CLI 压缩包缺失)。本 PR 把修复带到 master,以便**重打同名 tag `v0.9.0-alpha.1`** 触发完整发布。

版本号仍为 `0.9.0-alpha.1`(未变)、CHANGELOG 的 `[0.9.0-alpha.1]` 段已就位——无需再动版本/日志。

### 携带的修复

- **fix(ci):CLI 打包校验和步骤挂掉**(#176)。原因:步骤末尾遍历 `.zip`/`.tar.gz` 两种扩展名求 sha256,zip 变体(windows/mac)最后一轮 `[ -e X.tar.gz ]` 为假返回 1、恰为步骤末命令 → 整步 exit 1;linux 幸免。改为只对本 matrix 实际产出的压缩包求校验和,并显式声明 `setup-node`。
- **fix(settings):设置导航德语长标签溢出**(#175)。导航标签允许换行 + `hyphens` 断词;并让 `<html lang>` 跟随 UI 语言(修 index.html 静态写死 zh-CN)。

### 合并后

删除并重推 tag `v0.9.0-alpha.1`(覆盖同一 Release),重跑修复后的 workflow → 补齐 windows/mac CLI 压缩包。
