### PR TITLE
fix(ci): release 改两阶段单点发布，根除并发 finalize 竞态

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@
 #   APPLE_API_KEY           App Store Connect API key .p8 的 base64（或路径）
 #   APPLE_API_KEY_ID / APPLE_API_ISSUER
 # 并在 electron-builder.yml mac 段加 hardenedRuntime / entitlements / notarize。
+#
+# 发布采用**两阶段**：gui / cli 各 matrix job 只构建并把产物上传为 workflow artifact；末置单个
+# release job 汇总下载 + 组装正文 + 一次性上传到 Release。此前各 job 各自调 softprops 直传，多个 job
+# 并发对同一 tag 创建 / finalize Release 会撞 `already_exists` 竞态——单点发布根除之。
 
 name: Release
 
@@ -107,40 +111,21 @@ jobs:
             fi
           done
 
-      # 组装 Release 正文：把 CHANGELOG 里对应版本的段落注入 RELEASE_NOTES 的占位，
-      # 让 Release 页直接看到本版变更，而不是只给一个链接。找不到对应段落则回退用原说明。
-      - name: 组装 Release 说明
+      # 安装包 + 校验和上传为 workflow artifact，交末置 release job 单点发布（不在此直传 Release）。
+      - name: 上传构建产物
         if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          # 抽取 `## [VERSION] ...` 到下一个 `## [` 之间的正文（index==1 做字面前缀匹配，避开正则元字符）
-          awk -v ver="## [$VERSION]" 'index($0,ver)==1{f=1;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > changelog-section.md
-          if [ -s changelog-section.md ]; then
-            awk 'FNR==NR{a[++n]=$0;next} /%%CHANGELOG_SECTION%%/{for(i=1;i<=n;i++)print a[i];next} {print}' \
-              changelog-section.md .github/RELEASE_NOTES.md > RELEASE_BODY.md
-          else
-            echo "::warning::CHANGELOG 未找到 [$VERSION] 段，Release 正文回退用 RELEASE_NOTES.md 原文"
-            sed 's/%%CHANGELOG_SECTION%%//' .github/RELEASE_NOTES.md > RELEASE_BODY.md
-          fi
-
-      - name: 上传到 Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: gui-${{ matrix.os }}
+          path: |
             ${{ matrix.artifacts }}
             ${{ matrix.artifacts }}.sha256
-          fail_on_unmatched_files: true
-          # alpha / 任何带 - 的预发布 tag（如 v0.1.0-alpha.1）→ 标为 prerelease，且不抢占 Latest
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          make_latest: ${{ !contains(github.ref_name, '-') }}
-          # 正文 = RELEASE_NOTES（安装 / 首次打开 / 校验和）+ 注入的本版 CHANGELOG 段
-          body_path: RELEASE_BODY.md
+          if-no-files-found: error
+          retention-days: 1
 
   # meebox CLI（cli/，独立 Go module）：纯 Go、无 CGO → 单 runner 交叉编译全平台。出四平台压缩包 +
-  # 校验和，随桌面安装包挂到同一个 GitHub Release（不打进安装包，是独立可分发物）。仅 tag 触发上传；
-  # workflow_dispatch 仍构建做编译冒烟、不上传。本 job 不设 Release 正文（由 build job 注入），仅追加产物。
+  # 校验和，随桌面安装包挂到同一个 GitHub Release（不打进安装包，是独立可分发物）。同样只上传为 artifact，
+  # 由末置 release job 单点发布；workflow_dispatch 仍构建做编译冒烟、不上传（无 tag）。
   cli:
     name: CLI (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
@@ -203,12 +188,54 @@ jobs:
           # linux（.tar.gz 末轮命中）才幸免。直接对已知文件名求 sha256，去掉这个脆弱循环。
           sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
 
-      - name: 上传到 Release
+      # 压缩包 + 校验和上传为 workflow artifact（glob 仅取 meebox-cli-*，排除 dist 里的裸二进制与随包 LICENSE 等）。
+      - name: 上传构建产物
         if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cli/dist/meebox-cli-*
+          if-no-files-found: error
+          retention-days: 1
+
+  # 单点发布：等所有构建产物就绪后，一个 job 汇总下载 + 组装正文 + 一次性上传到 Release。避免多个
+  # matrix job 并发对同一 tag 创建 / finalize Release 触发 `already_exists` 竞态。仅 tag 触发。
+  release:
+    needs: [gui, cli]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # 取 CHANGELOG / RELEASE_NOTES（正文组装用）；无需 LFS
+
+      - name: 下载全部构建产物
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true # 各 job 的产物合并平铺到 dist/（文件名互不相同、无冲突）
+
+      # 组装 Release 正文：把 CHANGELOG 里对应版本的段落注入 RELEASE_NOTES 的占位，
+      # 让 Release 页直接看到本版变更，而不是只给一个链接。找不到对应段落则回退用原说明。
+      - name: 组装 Release 说明
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # 抽取 `## [VERSION] ...` 到下一个 `## [` 之间的正文（index==1 做字面前缀匹配，避开正则元字符）
+          awk -v ver="## [$VERSION]" 'index($0,ver)==1{f=1;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > changelog-section.md
+          if [ -s changelog-section.md ]; then
+            awk 'FNR==NR{a[++n]=$0;next} /%%CHANGELOG_SECTION%%/{for(i=1;i<=n;i++)print a[i];next} {print}' \
+              changelog-section.md .github/RELEASE_NOTES.md > RELEASE_BODY.md
+          else
+            echo "::warning::CHANGELOG 未找到 [$VERSION] 段，Release 正文回退用 RELEASE_NOTES.md 原文"
+            sed 's/%%CHANGELOG_SECTION%%//' .github/RELEASE_NOTES.md > RELEASE_BODY.md
+          fi
+
+      - name: 上传到 Release（单点）
         uses: softprops/action-gh-release@v2
         with:
-          # 本 matrix 项仅产出自身的压缩包 + .sha256（fresh runner）；不设 body_path 以免覆盖 build job 注入的正文
-          files: cli/dist/meebox-cli-*
+          files: dist/*
           fail_on_unmatched_files: true
+          # alpha / 任何带 - 的预发布 tag（如 v0.1.0-alpha.1）→ 标为 prerelease，且不抢占 Latest
           prerelease: ${{ contains(github.ref_name, '-') }}
           make_latest: ${{ !contains(github.ref_name, '-') }}
+          # 正文 = RELEASE_NOTES（安装 / 首次打开 / 校验和）+ 注入的本版 CHANGELOG 段
+          body_path: RELEASE_BODY.md


### PR DESCRIPTION
## 问题

Release workflow 里 gui / cli 各 matrix job **各自调 `softprops/action-gh-release` 直传同一个 Release**。多个 job 并发对同一 tag 创建 / finalize Release 时撞 GitHub 的:

```
error finalizing release: HttpError: Validation Failed: {"code":"already_exists","field":"tag_name"}
Too many retries.
```

`v0.9.0-alpha.1` 重发时 linux/amd64 CLI 即因此挂(其余 5 个 job 恰好错开)。此前首发只有 2 个 linux CLI job 走到上传、未撞上,竞态一直潜伏。

## 修复:两阶段单点发布

- **构建阶段**:gui / cli 各 job 只把安装包 / 压缩包 + `.sha256` 上传为 **workflow artifact**(`actions/upload-artifact`),不再直传 Release。
- **发布阶段**:末置单个 `release` job(`needs: [gui, cli]`,仅 tag 触发)汇总 `download-artifact`(merge 平铺)→ 组装 Release 正文(CHANGELOG 段注入,从 gui job 移入此处)→ **一次** `softprops` 上传全部产物 + 设 prerelease / make_latest / body。

单点上传 → 不存在多 job 并发 finalize,竞态根除。同时发布更**原子**:任一构建失败则不发布残缺 Release。

## 说明

- 已本地校验 YAML 解析与 job 结构(`release.needs=[gui,cli]`、单点上传步骤)。真正生效在**下次打 tag**——`0.9.0-alpha.1` 已发完,本 PR 面向后续版本(含 0.9.0 正式版),不需重打 alpha.1。
- 行为不变项:免费 ad-hoc mac 签名、CHANGELOG 注入、prerelease/Latest 判定、产物命名均保持一致。
