### PR TITLE
release: 0.9.0 正式版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@
 #   APPLE_API_KEY           App Store Connect API key .p8 的 base64（或路径）
 #   APPLE_API_KEY_ID / APPLE_API_ISSUER
 # 并在 electron-builder.yml mac 段加 hardenedRuntime / entitlements / notarize。
+#
+# 发布采用**两阶段**：gui / cli 各 matrix job 只构建并把产物上传为 workflow artifact；末置单个
+# release job 汇总下载 + 组装正文 + 一次性上传到 Release。此前各 job 各自调 softprops 直传，多个 job
+# 并发对同一 tag 创建 / finalize Release 会撞 `already_exists` 竞态——单点发布根除之。
 
 name: Release
 
@@ -107,40 +111,21 @@ jobs:
             fi
           done
 
-      # 组装 Release 正文：把 CHANGELOG 里对应版本的段落注入 RELEASE_NOTES 的占位，
-      # 让 Release 页直接看到本版变更，而不是只给一个链接。找不到对应段落则回退用原说明。
-      - name: 组装 Release 说明
+      # 安装包 + 校验和上传为 workflow artifact，交末置 release job 单点发布（不在此直传 Release）。
+      - name: 上传构建产物
         if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          # 抽取 `## [VERSION] ...` 到下一个 `## [` 之间的正文（index==1 做字面前缀匹配，避开正则元字符）
-          awk -v ver="## [$VERSION]" 'index($0,ver)==1{f=1;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > changelog-section.md
-          if [ -s changelog-section.md ]; then
-            awk 'FNR==NR{a[++n]=$0;next} /%%CHANGELOG_SECTION%%/{for(i=1;i<=n;i++)print a[i];next} {print}' \
-              changelog-section.md .github/RELEASE_NOTES.md > RELEASE_BODY.md
-          else
-            echo "::warning::CHANGELOG 未找到 [$VERSION] 段，Release 正文回退用 RELEASE_NOTES.md 原文"
-            sed 's/%%CHANGELOG_SECTION%%//' .github/RELEASE_NOTES.md > RELEASE_BODY.md
-          fi
-
-      - name: 上传到 Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: gui-${{ matrix.os }}
+          path: |
             ${{ matrix.artifacts }}
             ${{ matrix.artifacts }}.sha256
-          fail_on_unmatched_files: true
-          # alpha / 任何带 - 的预发布 tag（如 v0.1.0-alpha.1）→ 标为 prerelease，且不抢占 Latest
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          make_latest: ${{ !contains(github.ref_name, '-') }}
-          # 正文 = RELEASE_NOTES（安装 / 首次打开 / 校验和）+ 注入的本版 CHANGELOG 段
-          body_path: RELEASE_BODY.md
+          if-no-files-found: error
+          retention-days: 1
 
   # meebox CLI（cli/，独立 Go module）：纯 Go、无 CGO → 单 runner 交叉编译全平台。出四平台压缩包 +
-  # 校验和，随桌面安装包挂到同一个 GitHub Release（不打进安装包，是独立可分发物）。仅 tag 触发上传；
-  # workflow_dispatch 仍构建做编译冒烟、不上传。本 job 不设 Release 正文（由 build job 注入），仅追加产物。
+  # 校验和，随桌面安装包挂到同一个 GitHub Release（不打进安装包，是独立可分发物）。同样只上传为 artifact，
+  # 由末置 release job 单点发布；workflow_dispatch 仍构建做编译冒烟、不上传（无 tag）。
   cli:
     name: CLI (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
@@ -203,12 +188,54 @@ jobs:
           # linux（.tar.gz 末轮命中）才幸免。直接对已知文件名求 sha256，去掉这个脆弱循环。
           sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
 
-      - name: 上传到 Release
+      # 压缩包 + 校验和上传为 workflow artifact（glob 仅取 meebox-cli-*，排除 dist 里的裸二进制与随包 LICENSE 等）。
+      - name: 上传构建产物
         if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cli/dist/meebox-cli-*
+          if-no-files-found: error
+          retention-days: 1
+
+  # 单点发布：等所有构建产物就绪后，一个 job 汇总下载 + 组装正文 + 一次性上传到 Release。避免多个
+  # matrix job 并发对同一 tag 创建 / finalize Release 触发 `already_exists` 竞态。仅 tag 触发。
+  release:
+    needs: [gui, cli]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # 取 CHANGELOG / RELEASE_NOTES（正文组装用）；无需 LFS
+
+      - name: 下载全部构建产物
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true # 各 job 的产物合并平铺到 dist/（文件名互不相同、无冲突）
+
+      # 组装 Release 正文：把 CHANGELOG 里对应版本的段落注入 RELEASE_NOTES 的占位，
+      # 让 Release 页直接看到本版变更，而不是只给一个链接。找不到对应段落则回退用原说明。
+      - name: 组装 Release 说明
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # 抽取 `## [VERSION] ...` 到下一个 `## [` 之间的正文（index==1 做字面前缀匹配，避开正则元字符）
+          awk -v ver="## [$VERSION]" 'index($0,ver)==1{f=1;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md > changelog-section.md
+          if [ -s changelog-section.md ]; then
+            awk 'FNR==NR{a[++n]=$0;next} /%%CHANGELOG_SECTION%%/{for(i=1;i<=n;i++)print a[i];next} {print}' \
+              changelog-section.md .github/RELEASE_NOTES.md > RELEASE_BODY.md
+          else
+            echo "::warning::CHANGELOG 未找到 [$VERSION] 段，Release 正文回退用 RELEASE_NOTES.md 原文"
+            sed 's/%%CHANGELOG_SECTION%%//' .github/RELEASE_NOTES.md > RELEASE_BODY.md
+          fi
+
+      - name: 上传到 Release（单点）
         uses: softprops/action-gh-release@v2
         with:
-          # 本 matrix 项仅产出自身的压缩包 + .sha256（fresh runner）；不设 body_path 以免覆盖 build job 注入的正文
-          files: cli/dist/meebox-cli-*
+          files: dist/*
           fail_on_unmatched_files: true
+          # alpha / 任何带 - 的预发布 tag（如 v0.1.0-alpha.1）→ 标为 prerelease，且不抢占 Latest
           prerelease: ${{ contains(github.ref_name, '-') }}
           make_latest: ${{ !contains(github.ref_name, '-') }}
+          # 正文 = RELEASE_NOTES（安装 / 首次打开 / 校验和）+ 注入的本版 CHANGELOG 段
+          body_path: RELEASE_BODY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 本项目所有重要变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-## [0.9.0-alpha.1] - 2026-07-02
+## [0.9.0] - 2026-07-02
 
 > 本版重点：
 >
@@ -34,6 +34,7 @@
 
 - 修复 PR 列表分组标题背景色、Windows 窗口右上角控制按钮此前不随主题（编辑器配色主题）变化的问题；现二者均跟随当前主题派生配色，深浅 / 主题切换实时生效。
 - 修复点开带「@我 / 回复我」未读计数的 PR 后，标题处的未读计数 chip 不立即消除、需等下一轮轮询才清零的问题：标为已读时同步乐观清零该计数（此前仅清未读圆点，遗漏了计数 chip）。
+- 修复德语等界面下设置页左侧导航的长标签（如「通知」）溢出被裁切的问题；现长标签自动换行完整显示。
 
 ## [0.8.0] - 2026-06-30
 
@@ -403,7 +404,7 @@
 
 许可证：[Apache-2.0](LICENSE)。打包内含第三方组件（pr-agent、Electron 等），各按其许可证分发，见 [NOTICE](NOTICE)。
 
-[0.9.0-alpha.1]: https://github.com/huhamhire/code-meeseeks/compare/v0.8.0...v0.9.0-alpha.1
+[0.9.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/huhamhire/code-meeseeks/compare/v0.5.0...v0.6.0

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meebox/desktop",
-  "version": "0.9.0-alpha.1",
+  "version": "0.9.0",
   "private": true,
   "description": "meebox Electron desktop app",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/desktop": {
       "name": "@meebox/desktop",
-      "version": "0.9.0-alpha.1",
+      "version": "0.9.0",
       "dependencies": {
         "@iconify-json/material-icon-theme": "^1.2.66",
         "@iconify/react": "^5.2.1",


### PR DESCRIPTION
## 0.9.0 正式版发布 PR（dev → master）

`0.9.0` 定版。重点:**外部集成与 CLI**——开启本机 API 把 PR 浏览与评审 Agent 操作开放给外部集成,并提供跨平台命令行工具 `meebox`。内容承接 `0.9.0-alpha.1`(其构建已含以下全部)。

### 发布前置(同批完成)

- **版本号**:`apps/desktop/package.json` `0.9.0-alpha.1` → `0.9.0`(lockfile 同步)。
- **CHANGELOG**:`[0.9.0-alpha.1]` 段改名为 `[0.9.0] - 2026-07-02`、去掉 alpha 预发布链接引用(内容并入正式版段),并补录「设置导航德语长标签溢出」的修复。
- **校对**:`[0.9.0]` 段覆盖自 0.8.0 以来合入 dev 的全部用户可见要点。

### 一并带入 master 的改动

- **release workflow 两阶段单点发布**(#178):各 matrix job 只出 artifact,末置单个 `release` job 汇总一次性上传 → 根除多 job 并发 finalize 同一 Release 的 `already_exists` 竞态。**本次 `v0.9.0` tag 即用新流程**,不会再出现 alpha.1 那种单 job 掉队。

### 合并后

在 `master` 打 tag `v0.9.0`(名不含 `-` → 标为 Latest、正式版)触发发布。之后 `dev` 切下一版 `-dev` 开发号。
