### PR TITLE
docs(renderer): translate frontend code comments to English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ out-tsc/
 *.tsbuildinfo
 .cache/
 
+# Python bytecode (tools/ scripts, etc.)
+__pycache__/
+*.pyc
+
 # Electron / packaged binaries
 release/
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -29,7 +29,7 @@ import { useGlobalTheme, useEditorAppearanceSync } from './hooks/useTheme';
 export default function App() {
   const { t } = useTranslation();
   const { toast, notifyError, dismiss: dismissToast } = useToast();
-  // PR 列表 / 选中 / 审批 / 合并 / 刷新 —— 领域逻辑归 usePullRequests
+  // PR list / selection / approve / merge / refresh — domain logic lives in usePullRequests
   const {
     prs,
     setPrs,
@@ -43,10 +43,10 @@ export default function App() {
     mergeSelectedPr,
     markRead,
   } = usePullRequests({ notifyError });
-  // 应用启动 / 全局生命周期（boot 加载、语言、poll / focus 刷新、向导完成、连接热生效）
+  // App startup / global lifecycle (boot load, language, poll / focus refresh, wizard completion, connection hot-apply)
   const { boot, fatalError, lastSyncAt, needsOnboarding, completeOnboarding, refreshBootAndPrs, patchConfig } =
     useBootstrap({ setPrs, reloadPrs });
-  // 布局态（左右两栏宽度 / 折叠）、版本更新提示、store 接线、外链防护——各自成 app 级 hook
+  // Layout state (left/right column widths / collapse), version update notice, store wiring, external link guard — each its own app-level hook
   const {
     sidebarWidth,
     setSidebarWidth,
@@ -60,8 +60,8 @@ export default function App() {
   const updateInfo = useUpdateNotice();
   useAppStores();
   useExternalLinkGuard();
-  // 外观（全局主题 + 编辑器字体）：跟随 config 同步到运行时 store + 字体 CSS 变量。boot 前用默认值，
-  // 模块导入时已按 localStorage 缓存定下首帧主题，boot 到达后切到 config 主题。
+  // Appearance (global theme + editor font): sync from config to runtime store + font CSS variables. Use defaults before boot,
+  // module import already pins the first-frame theme from the localStorage cache, switch to config theme once boot arrives.
   useEditorAppearanceSync(
     boot?.config.appearance ?? {
       editor_theme: 'auto',
@@ -69,27 +69,27 @@ export default function App() {
       editor_font_size: 14,
     },
   );
-  // 全局主题：订阅 store 的主题，反推浅 / 深写 data-theme（驱动语义色板）+ 派生 chrome 结构色 +
-  // 持久化 localStorage；'auto' 主题下跟随 OS 深浅切换。
+  // Global theme: subscribe to the store's theme, derive light / dark to write data-theme (drives the semantic palette) + derive chrome structural colors +
+  // persist to localStorage; under the 'auto' theme follow the OS light/dark switch.
   useGlobalTheme();
 
   const [showSettings, setShowSettings] = useState(false);
-  // 设置面板初始分区（命令面板「打开关于 / 模型」等深链用）；缺省由 SettingsModal 落 'general'。
+  // Settings panel initial section (used by command palette deep links like "open About / Model"); default falls to 'general' in SettingsModal.
   const [settingsCategory, setSettingsCategory] = useState<SettingsCategory | undefined>(undefined);
   const openSettings = useCallback((category?: SettingsCategory) => {
     setSettingsCategory(category);
     setShowSettings(true);
   }, []);
-  // PR 状态筛选（待处理 / 全部 / 冲突 / 可合并等）：提升到 App 以便命令面板亦可驱动、折叠侧栏不丢选择。
+  // PR status filter (pending / all / conflict / mergeable etc.): lifted to App so the command palette can also drive it and a collapsed sidebar doesn't lose the selection.
   const [statusFilter, setStatusFilter] = useState<FilterKey>('pending');
-  // 当前 Diff 视图选中的单 commit 范围（DiffView 上报）：作为聊天区命令的隐式范围（见 ChatPane）。
-  // 按 sha 去重，避免 DiffView 每次 render 传新对象引发的重渲染回环。
+  // The single-commit scope currently selected in the Diff view (reported by DiffView): serves as the implicit scope for chat commands (see ChatPane).
+  // Dedupe by sha to avoid a re-render loop from DiffView passing a new object on every render.
   const [viewCommitScope, setViewCommitScope] = useState<ReviewRunCommitScope | null>(null);
   const handleViewCommitScope = useCallback((s: ReviewRunCommitScope | null) => {
     setViewCommitScope((prev) => (prev?.sha === s?.sha ? prev : s));
   }, []);
-  // PR 导航 / 范围领域（发现分类 / 活跃·归档切换 / 归档懒加载 / 按 URL 打开 / 定位跳转 / 通知点击导航 +
-  // 跨组件 Diff·Tab 跳转意图）——领域逻辑归 usePrNavigation；选中态 / 已读仍由 usePullRequests 拥有。
+  // PR navigation / scope domain (discovery filters / active·archived switch / archived lazy load / open by URL / locate jump / notification-click navigation +
+  // cross-component Diff·Tab jump intent) — domain logic lives in usePrNavigation; selection state / read status is still owned by usePullRequests.
   const {
     scope,
     discoveryFilter,
@@ -106,16 +106,16 @@ export default function App() {
     pendingTab,
     setPendingTab,
   } = usePrNavigation({ prs, selectedId, setSelectedId, markRead, notifyError });
-  // macOS dock 角标：活跃 PR「@我 / 回复我」待回应总数 → 主进程落到 dock 图标（系统行为，逻辑见 useDockBadge）。
+  // macOS dock badge: total count of active PRs "@me / replied to me" awaiting response → main process writes it to the dock icon (system behavior, logic in useDockBadge).
   useDockBadge({
     prs,
     platform: boot?.info.platform,
     notifications: boot?.config.notifications,
   });
   const archived = scope === 'archived';
-  // 状态栏「待审 PR」计数：仅计**需我评审且本人尚未评审**的 PR（discovery=review-requested 且 localStatus=pending）。
-  // 不能简单数 localStatus==='pending'——「我创建的」等分类的 PR 本人非评审人、localStatus 恒为 pending，会把计数撑大。
-  // 无发现分类的平台（单一「待我评审」发现）discoveryFilters 为空，视作 review-requested。
+  // Status bar "PRs to review" count: only counts PRs that **need my review and I have not yet reviewed** (discovery=review-requested and localStatus=pending).
+  // Cannot simply count localStatus==='pending' — PRs in categories like "created by me" have me as a non-reviewer, localStatus stays pending forever, inflating the count.
+  // On platforms without discovery categories (a single "awaiting my review" discovery) discoveryFilters is empty, treated as review-requested.
   const pendingReviewCount = useMemo(
     () =>
       prs.filter(
@@ -125,10 +125,10 @@ export default function App() {
       ).length,
     [prs],
   );
-  // 已关闭范围的「可参与」判定：合并 / 仍开放的 PR 可补充评论 + AI 评审；decline 仅浏览。活跃范围恒可参与。
+  // "Can engage" determination for the closed scope: merged / still-open PRs allow adding comments + AI review; declined ones are browse-only. The active scope is always engageable.
   const canEngage = !archived || (selectedPr ? selectedPr.state !== 'declined' : false);
 
-  // 窗口级全局快捷键（F5 自动评审 / DevTools / 查看已关闭 / Ctrl-Cmd+B·J 布局开关）——领域逻辑归 useGlobalShortcuts。
+  // Window-level global shortcuts (F5 auto review / DevTools / view closed / Ctrl-Cmd+B·J layout toggles) — domain logic lives in useGlobalShortcuts.
   useGlobalShortcuts({
     platform: boot?.info.platform,
     selectedId,
@@ -163,26 +163,26 @@ export default function App() {
     );
   }
 
-  // 选中 PR 所属连接：能力位（审批按钮降级）+ 当前 PAT 用户（判「是否自己的 PR」）。
+  // Connection the selected PR belongs to: capability bits (approve-button downgrade) + current PAT user (to judge "is my own PR").
   const selectedConn = selectedPr
     ? boot.connections.find((c) => c.connectionId === selectedPr.connectionId)
     : undefined;
-  // 有 active 连接但 LLM 未配置 → ChatPane 给出「需配置才能启用」提示并禁用输入
+  // Has an active connection but LLM not configured → ChatPane shows a "configure to enable" hint and disables input
   const llmConfigured = boot.config.llm.profiles.some((p) => p.id === boot.config.llm.active_id);
-  // 发现分类标签由活动连接的能力决定（GitHub 四类、Bitbucket 两类、其余无）。
+  // Discovery category tabs are determined by the active connection's capabilities (GitHub four, Bitbucket two, others none).
   const activeConnSummary = boot.connections.find(
     (c) => c.connectionId === boot.config.active_connection_id,
   );
   const availableDiscoveryFilters = activeConnSummary?.capabilities.discoveryFilters ?? [];
   const showDiscoveryFilter = availableDiscoveryFilters.length > 0;
-  // 平台是否支持 needs_work（「需修改」）评审态：GitHub / Bitbucket 支持、GitLab（二元审批）不支持。
-  // 决定非「待我评审」发现分类下是否保留「待处理」状态筛选（见 Sidebar.visibleFilters）。
+  // Whether the platform supports the needs_work ("needs changes") review state: GitHub / Bitbucket support it, GitLab (binary approval) does not.
+  // Determines whether the "pending" status filter is kept under discovery categories other than "awaiting my review" (see Sidebar.visibleFilters).
   const supportsNeedsWork = activeConnSummary?.capabilities.reviewStatuses.includes('needsWork') ?? false;
-  // 选中的分类可能因切换连接而对当前平台无效 → 回落首个可用。
+  // The selected category may be invalid for the current platform after switching connections → fall back to the first available.
   const effectiveDiscoveryFilter = availableDiscoveryFilters.includes(discoveryFilter)
     ? discoveryFilter
     : availableDiscoveryFilters[0];
-  // 命令面板「分类筛选」可选的状态项：与侧栏一致——有发现分类时隐藏决断类（通过 / 需修改）。
+  // Status items selectable in the command palette "category filter": consistent with the sidebar — hide decision types (approved / needs changes) when discovery categories exist.
   const visibleStatusFilters = showDiscoveryFilter
     ? PR_STATUS_FILTERS.filter((f) => !DECISION_STATUS_FILTERS.has(f.value))
     : PR_STATUS_FILTERS;
@@ -193,7 +193,7 @@ export default function App() {
         platform={boot.info.platform}
         title={selectedPr?.title}
         config={boot.config}
-        // 不可参与（decline / 无选中）时「运行自动评审」命令应隐藏：以 null 关掉其 when 门控。
+        // When not engageable (declined / no selection) the "run auto review" command should hide: pass null to close its when gate.
         selectedPrId={canEngage ? selectedId : null}
         patchConfig={patchConfig}
         openSettings={openSettings}
@@ -214,7 +214,7 @@ export default function App() {
             selectedId={selectedId}
             onSelect={(pr) => {
               setSelectedId(pr.localId);
-              // 已关闭范围无未读概念，无需推进已读水位。
+              // The closed scope has no unread concept, no need to advance the read watermark.
               if (!archived) void markRead(pr.localId);
             }}
             width={sidebarWidth}
@@ -240,7 +240,7 @@ export default function App() {
               merging={merging}
               capabilities={selectedConn?.capabilities}
               currentUserName={selectedConn?.user?.name ?? null}
-              // 已关闭范围隐藏 PR 生命周期操作（合并 / 审批）；decline / 不可参与再隐藏评论 / 草稿写入。
+              // The closed scope hides PR lifecycle actions (merge / approve); declined / not-engageable further hides comment / draft writes.
               hideLifecycle={archived}
               readOnly={!canEngage}
               pendingDiffNav={pendingDiffNav}
@@ -254,13 +254,13 @@ export default function App() {
             <PrEmpty hasConnections={boot.config.connections.length > 0} />
           )}
         </MainPane>
-        {/* ChatPane 始终挂载，折叠只是 CSS 隐藏：保住运行中的 run 生命周期（计时器 / runProgress 订阅）。 */}
+        {/* ChatPane is always mounted, collapse is just CSS hiding: preserves the lifecycle of a running run (timers / runProgress subscription). */}
         <ChatPane
           pr={selectedPr}
           prAgent={boot.prAgent}
           width={chatWidth}
           onResize={setChatWidth}
-          // 不可参与（decline / 无选中）时强制折叠对话面板、隐去 AI 评审入口；合并 / 仍开放 PR 仍可补评审。
+          // When not engageable (declined / no selection) force-collapse the chat panel and hide the AI review entry; merged / still-open PRs can still add reviews.
           collapsed={chatCollapsed || !canEngage}
           llmConfigured={llmConfigured}
           onOpenSettings={() => setShowSettings(true)}

--- a/apps/desktop/src/renderer/src/components/common/Avatar.tsx
+++ b/apps/desktop/src/renderer/src/components/common/Avatar.tsx
@@ -3,24 +3,24 @@ import { invoke } from '../../api';
 
 interface AvatarProps {
   connectionId: string;
-  /** 平台用户 slug（Bitbucket 的 user.name 即 slug） */
+  /** Platform user slug (Bitbucket's user.name is the slug) */
   slug: string;
-  /** 给 initials 兜底用；也用作 title / alt */
+  /** Fallback for initials; also used as title / alt */
   displayName: string;
-  /** 头像直链（平台 avatar_url）；有则优先按它拉——GitHub 机器人靠它才取得到。 */
+  /** Direct avatar link (platform avatar_url); if present, prefer fetching by it — GitHub bots are only reachable via it. */
   avatarUrl?: string;
   size?: number;
 }
 
 /**
- * 圆形用户头像。优先用 main 进程拉的平台 avatar（in-memory cache 命中即同步返回），
- * 拉失败 / 加载中 / null 时回退到 initials + hash 色块。
+ * Circular user avatar. Prefers the platform avatar fetched by the main process (returns synchronously on in-memory cache hit),
+ * falling back to initials + hash color block on fetch failure / loading / null.
  */
 export function Avatar({ connectionId, slug, displayName, avatarUrl, size = 22 }: AvatarProps) {
   const [dataUrl, setDataUrl] = useState<string | null>(() => readCached(connectionId, slug));
 
   useEffect(() => {
-    if (dataUrl !== null) return; // 已有缓存或本组件已加载
+    if (dataUrl !== null) return; // already cached or already loaded by this component
     let cancelled = false;
     fetchAvatar(connectionId, slug, avatarUrl).then((url) => {
       if (!cancelled && url) setDataUrl(url);
@@ -28,7 +28,7 @@ export function Avatar({ connectionId, slug, displayName, avatarUrl, size = 22 }
     return () => {
       cancelled = true;
     };
-    //   仅在 (connectionId, slug) 变化时重拉
+    //   re-fetch only when (connectionId, slug) changes
   }, [connectionId, slug, avatarUrl, dataUrl]);
 
   const style = { width: size, height: size, fontSize: Math.round(size * 0.42) };
@@ -58,11 +58,11 @@ export function Avatar({ connectionId, slug, displayName, avatarUrl, size = 22 }
   );
 }
 
-/** "Kyle Wong" → "KW"；中文「张三」→「张」；单字 fallback 首字符大写 */
+/** "Kyle Wong" → "KW"; Chinese「张三」→「张」; single-word fallback uppercases the first character */
 function initialsOf(name: string): string {
   const trimmed = name.trim();
   if (!trimmed) return '?';
-  // 含 CJK：取第一个 CJK 字符
+  // Contains CJK: take the first CJK character
   const cjk = /[一-鿿]/.exec(trimmed);
   if (cjk) return cjk[0]!;
   const parts = trimmed.split(/[\s.\-_]+/).filter(Boolean);
@@ -72,7 +72,7 @@ function initialsOf(name: string): string {
   return trimmed.slice(0, 2).toUpperCase();
 }
 
-/** 名字 → 稳定的 HSL 背景色（同名永远同色，对比度足够白字） */
+/** Name → stable HSL background color (same name always same color, enough contrast for white text) */
 function colorFromName(name: string): string {
   let h = 0;
   for (let i = 0; i < name.length; i++) {
@@ -82,7 +82,7 @@ function colorFromName(name: string): string {
   return `hsl(${String(hue)}, 45%, 38%)`;
 }
 
-// 模块级缓存：跨组件去重，避免同一作者每个 PrItem 各发一次 IPC
+// Module-level cache: dedup across components, avoid one IPC per PrItem for the same author
 const cache = new Map<string, string | null>();
 const inflight = new Map<string, Promise<string | null>>();
 

--- a/apps/desktop/src/renderer/src/components/common/BitbucketImage.tsx
+++ b/apps/desktop/src/renderer/src/components/common/BitbucketImage.tsx
@@ -4,27 +4,27 @@ import { useTranslation } from 'react-i18next';
 import { invoke } from '../../api';
 
 /**
- * react-markdown 默认 url sanitize 只允许 http/https/mailto/tel 协议，
- * 非白名单协议 → src 被吞成空。Bitbucket 评论 markdown 用 `attachment:9/16854` 引用
- * 内嵌附件，必须直通让 BitbucketImage 收到原始 src 走 IPC 代理拉
+ * react-markdown's default url sanitize only allows the http/https/mailto/tel protocols;
+ * non-whitelisted protocols → src is swallowed to empty. Bitbucket comment markdown references
+ * inline attachments with `attachment:9/16854`, which must pass through so BitbucketImage receives the raw src and fetches via the IPC proxy
  */
 export function transformBitbucketUrl(url: string): string {
   if (url.startsWith('attachment:')) return url;
-  // 其他保持 react-markdown 默认安全行为
+  // Others keep react-markdown's default safe behavior
   return /^(https?:|mailto:|tel:|#|\/)/.test(url) ? url : '';
 }
 
 /**
- * 评论 body 内嵌图片：Bitbucket 私有 attachment URL 需要 PAT 鉴权，原生 `<img>`
- * 没法发 Authorization 头取私有资源 → 走 main 端 IPC `comments:fetchAttachment`
- * 代理拉 bytes 转 data URL 显示。
+ * Inline image in the comment body: Bitbucket private attachment URLs require PAT auth, and a native `<img>`
+ * cannot send an Authorization header to fetch private resources → goes through the main-side IPC `comments:fetchAttachment`
+ * to proxy-fetch the bytes and convert to a data URL for display.
  *
- * **不缓存** (用户决策 — 评论图片重复加载概率低，跟头像走磁盘缓存不同)。每次
- * mount 调一次 IPC。
+ * **Not cached** (user decision — comment images have a low chance of repeated loading, unlike avatars which use disk cache). Calls IPC once per
+ * mount.
  *
- * 用工厂 makeBitbucketImageFor(localId, prWebUrl) 包出 ReactMarkdown components.img 用的
- * 组件 — 闭包捕获 localId 给 IPC 用；prWebUrl 为 PR 网页地址，代理失败时降级链接指向它
- * （在系统浏览器里带 session 渲染评论与图片），而非指向拉不到的资产 URL（相对路径会落到 localhost）
+ * Uses the factory makeBitbucketImageFor(localId, prWebUrl) to wrap the component used as ReactMarkdown components.img —
+ * the closure captures localId for the IPC; prWebUrl is the PR web address, and on proxy failure the fallback link points to it
+ * (rendering comments and images with session in the system browser) rather than to the unreachable asset URL (relative paths would resolve to localhost)
  */
 export function makeBitbucketImageFor(localId: string, prWebUrl?: string) {
   return function BitbucketImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
@@ -46,7 +46,7 @@ export function makeBitbucketImageFor(localId: string, prWebUrl?: string) {
       setResolvedSrc(null);
       void (async () => {
         try {
-          // 8s timeout 防 main 端 fetch 卡死 / handler 没注册让 loading 占位永久挂着
+          // 8s timeout to prevent the main-side fetch from hanging / an unregistered handler keeping the loading placeholder up forever
           const ipcPromise = invoke('comments:fetchAttachment', { localId, url: src });
           const timeoutPromise = new Promise<null>((resolve) =>
             setTimeout(() => resolve(null), 8000),
@@ -65,8 +65,8 @@ export function makeBitbucketImageFor(localId: string, prWebUrl?: string) {
     }, [src]);
 
     if (failed && src) {
-      // attachment: 协议浏览器无法加载，fail 时显示明确的"加载失败"文本而不是
-      // 损坏图标；http/https URL fail 时退回原生 <img> (可能是跨 host 公网图)
+      // The attachment: protocol cannot be loaded by the browser; on fail show explicit "load failed" text instead of
+      // a broken icon; on http/https URL fail, fall back to native <img> (may be a cross-host public image)
       if (src.startsWith('attachment:')) {
         return (
           <span className="bitbucket-image-failed muted" aria-label={t('bitbucketImage.loadFailedAria')}>
@@ -74,9 +74,9 @@ export function makeBitbucketImageFor(localId: string, prWebUrl?: string) {
           </span>
         );
       }
-      // 代理拉不到（如 GitLab <17.4 私有上传仅认浏览器 session，PAT 无法代理）：先试浏览器原生
-      // 加载（公网图可成）；原生也失败则降级成链接 —— 指向 PR 网页（在系统浏览器带 session 看
-      // 评论与图片），避免破图标，也避免相对 /uploads 路径被解析成 localhost。
+      // Proxy fetch fails (e.g. GitLab <17.4 private uploads only recognize the browser session, PAT cannot proxy): first try native browser
+      // loading (public images can succeed); if native also fails, degrade to a link — pointing to the PR web page (viewing
+      // comments and images with session in the system browser), avoiding a broken icon and avoiding relative /uploads paths being resolved to localhost.
       if (nativeError) {
         const fallbackHref = prWebUrl ?? (/^https?:\/\//.test(src) ? src : null);
         if (fallbackHref) {
@@ -134,8 +134,8 @@ export function makeBitbucketImageFor(localId: string, prWebUrl?: string) {
 }
 
 /**
- * 全屏大图预览：点击 BitbucketImage 缩略图 → portal 渲染到 document.body 的全屏
- * overlay。点击背景 / Esc 关闭。img 自身 stopPropagation 防点 img 关闭
+ * Full-screen large image preview: clicking a BitbucketImage thumbnail → portal renders a full-screen
+ * overlay into document.body. Click the background / Esc to close. The img itself stopPropagation to prevent closing on img click
  */
 function ImageZoomOverlay({
   src,

--- a/apps/desktop/src/renderer/src/components/common/ConfirmModal.tsx
+++ b/apps/desktop/src/renderer/src/components/common/ConfirmModal.tsx
@@ -7,19 +7,19 @@ interface ConfirmModalProps {
   message: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  /** 危险操作（删除等）时确认按钮显红色 */
+  /** Confirm button shows red for dangerous operations (delete, etc.) */
   danger?: boolean;
-  /** 从二层嵌套子模态弹出时置 true：用嵌套 backdrop（z-index 抬到 nested 层），叠在子模态之上 */
+  /** Set true when popping from a second-level nested child modal: uses a nested backdrop (z-index raised to the nested layer), stacked above the child modal */
   nested?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 /**
- * 通用确认模态框，基于 Modal 壳。经 portal 渲染到 body 避开调用者层级（特别是 Monaco view
- * zone 内的 React tree，那一层 z-index 比 modal 低）。
+ * Generic confirm modal, based on the Modal shell. Renders into body via portal to avoid the caller's layering (especially the React tree inside a Monaco view
+ * zone, whose z-index is lower than the modal).
  *
- * 键盘：Esc 取消，Enter 确认（焦点默认在取消按钮，避免误触）
+ * Keyboard: Esc to cancel, Enter to confirm (focus defaults to the cancel button to avoid mis-clicks)
  */
 export function ConfirmModal({
   title,
@@ -37,8 +37,8 @@ export function ConfirmModal({
   const resolvedCancelLabel = cancelLabel ?? t('common.cancel');
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
-      // 忽略 OS 按键自动重复：若本模态由「按 Enter」打开（如 chat /merge 提交），按住 Enter 期间的
-      // 重复 keydown 会在监听器挂载后触发 → 立即 onConfirm、模态一闪而过。仅响应全新按下（repeat=false）。
+      // Ignore OS key auto-repeat: if this modal was opened by「pressing Enter」(e.g. chat /merge submit), the
+      // repeated keydown while holding Enter fires after the listener mounts → immediate onConfirm, modal flashes past. Only respond to a fresh press (repeat=false).
       if (e.repeat) return;
       if (e.key === 'Escape') {
         e.preventDefault();

--- a/apps/desktop/src/renderer/src/components/common/ErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/src/components/common/ErrorBoundary.tsx
@@ -2,9 +2,9 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
-  /** 可选自定义 fallback；不传走默认灰底提示卡 */
+  /** Optional custom fallback; if omitted, uses the default gray-background notice card */
   fallback?: (err: Error, reset: () => void) => ReactNode;
-  /** 命名出错区域便于 console 定位 (例: "DiffPane") */
+  /** Name the failing region for easier console locating (e.g. "DiffPane") */
   label?: string;
 }
 
@@ -13,11 +13,11 @@ interface ErrorBoundaryState {
 }
 
 /**
- * React 渲染期错误屏障。catch 子树 render / effect-mount 阶段抛出的同步错误，
- * 显示 fallback 而不是整页白屏；不 catch 异步 promise rejection / window onerror
- * （那些走 monaco-setup.ts 的全局过滤器）。
+ * React render-phase error boundary. Catches synchronous errors thrown during the subtree's render / effect-mount phase,
+ * showing a fallback instead of a whole-page white screen; does not catch async promise rejection / window onerror
+ * (those go through monaco-setup.ts's global filter).
  *
- * 仅放在"可隔离"的子树边界（如 DiffPane 区域），避免一个面板挂掉拖死全应用。
+ * Only placed at "isolatable" subtree boundaries (e.g. the DiffPane region), to avoid one panel crashing dragging down the whole app.
  */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   override state: ErrorBoundaryState = { err: null };

--- a/apps/desktop/src/renderer/src/components/common/LlmProviderIcon.tsx
+++ b/apps/desktop/src/renderer/src/components/common/LlmProviderIcon.tsx
@@ -1,9 +1,9 @@
 import type { JSX } from 'react';
 import type { LlmProvider } from '@meebox/shared';
 
-// LLM provider 品牌图标。OpenAI / Anthropic 用官方几何标记；其余几家无干净的
-// 官方单色 SVG 资源，按品牌意象手绘为简洁可辨的彩色图标（鲸鱼 / 云 / 火山 /
-// 通用 API 字形）。后续如放入正式 logo 资源，替换这里对应分支即可。
+// LLM provider brand icons. OpenAI / Anthropic use official geometric marks; the others have no clean
+// official monochrome SVG assets, so they are hand-drawn per brand imagery into concise, recognizable color icons (whale / cloud / volcano /
+// generic API glyph). If official logo assets are added later, just replace the corresponding branch here.
 
 function OpenAiGlyph({ size }: { size: number }) {
   return (
@@ -16,7 +16,7 @@ function OpenAiGlyph({ size }: { size: number }) {
   );
 }
 
-// Anthropic → Claude：放射状 burst 标记（12 道花瓣自中心向外辐射）
+// Anthropic → Claude: radial burst mark (12 petals radiating outward from the center)
 function ClaudeGlyph({ size }: { size: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="#D97757" aria-hidden="true">
@@ -35,7 +35,7 @@ function ClaudeGlyph({ size }: { size: number }) {
   );
 }
 
-// OpenAI 兼容：通用 API 字形（< / >，代表「任何兼容协议」）
+// OpenAI-compatible: generic API glyph (< / >, representing「any compatible protocol」)
 function CompatibleGlyph({ size }: { size: number }) {
   return (
     <svg
@@ -56,29 +56,29 @@ function CompatibleGlyph({ size }: { size: number }) {
   );
 }
 
-// DeepSeek：鲸鱼吉祥物（圆身 + 白肚 + 右上分叉尾鳍 + 眼睛，手绘简化）
+// DeepSeek: whale mascot (round body + white belly + top-right forked tail fin + eye, hand-drawn simplified)
 function DeepSeekGlyph({ size }: { size: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      {/* 圆形身体 */}
+      {/* Round body */}
       <circle cx="10.4" cy="13.8" r="8" fill="#4D6BFE" />
-      {/* 上翘的分叉尾鳍 */}
+      {/* Upturned forked tail fin */}
       <path
         fill="#4D6BFE"
         d="M15.8 9.4c2-1.5 3.5-3.9 4.3-6.3.3 1.5.4 2.8-.2 4 .9-.4 1.9-.3 2.8.1-1.1 1.5-2.7 2.5-4.5 2.9-.8.2-1.6.1-2.4-.7Z"
       />
-      {/* 白色肚腩月牙 */}
+      {/* White belly crescent */}
       <path
         fill="#fff"
         d="M4.6 14.6c0 3.4 2.7 6 6 6 .5 0 1-.1 1.4-.2-1.8-.5-3.3-1.7-4-3.6-.5-1.3-.3-2.6.4-3.6-.5-.3-1.1-.5-1.8-.5-1.1 0-2 .9-2 1.9Z"
       />
-      {/* 眼睛 */}
+      {/* Eye */}
       <circle cx="12.6" cy="11.2" r="1" fill="#fff" />
     </svg>
   );
 }
 
-// 阿里百炼（DashScope）→ 千问（Qwen）：紫色「Q」标记
+// Alibaba Bailian (DashScope) → Qwen: purple「Q」mark
 function QwenGlyph({ size }: { size: number }) {
   return (
     <svg
@@ -97,7 +97,7 @@ function QwenGlyph({ size }: { size: number }) {
   );
 }
 
-// 火山方舟（Volcengine Ark）：火山意象（山体 + 顶部火苗）
+// Volcengine Ark: volcano imagery (mountain body + flame at the top)
 function VolcengineGlyph({ size }: { size: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
@@ -110,7 +110,7 @@ function VolcengineGlyph({ size }: { size: number }) {
   );
 }
 
-// 本地 CLI：终端窗口 + 提示符（>_），代表「调本机命令行工具」
+// Local CLI: terminal window + prompt (>_), representing「invoking a local command-line tool」
 function CliGlyph({ size }: { size: number }) {
   return (
     <svg

--- a/apps/desktop/src/renderer/src/components/common/Loading.tsx
+++ b/apps/desktop/src/renderer/src/components/common/Loading.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
 
 /**
- * 延迟显示的居中 loading：组件挂载后 delayMs 内不出现，超过才显 spinner。
+ * Delayed centered loading: does not appear within delayMs after mount, only shows the spinner past that.
  *
- * 重型组件（Monaco、ChatPane 内容、diff 文件树）在 async init 完成前先渲染空骨架、
- * 各段 ready 时间错开 → 多次布局跳变（可感知抖动）。本组件在 init 期间盖住该区域，
- * ready 后由调用方卸载它即可一次性 reveal。
+ * Heavy components (Monaco, ChatPane content, diff file tree) render an empty skeleton before async init
+ * completes, and their ready times are staggered → multiple layout shifts (perceptible jitter). This component
+ * covers the area during init; once ready, the caller unmounts it to reveal everything at once.
  *
- * **延迟显示**是关键：桌面端切 PR 多在 150ms 内命中本地缓存，快路径下本组件挂载即
- * 很快被卸载、spinner 从不出现 → 零闪烁；只有真慢的场景（Monaco 冷挂载 / 大 diff）
- * 才落到 spinner。复用既有 `.spinner` 视觉，不引入新语言。
+ * **Delayed display** is key: switching PRs on desktop mostly hits the local cache within 150ms, and on the
+ * fast path this component is mounted then quickly unmounted with the spinner never appearing → zero flicker;
+ * only the truly slow cases (Monaco cold mount / large diff) fall through to the spinner. Reuses the existing
+ * `.spinner` visual, introduces no new language.
  */
 export function PaneLoading({
   delayMs = 150,
@@ -18,10 +19,10 @@ export function PaneLoading({
 }: {
   delayMs?: number;
   label?: string;
-  /** 绝对定位铺满父容器（父需 position:relative），用于盖在 Monaco 编辑器之上。 */
+  /** Absolutely positioned to fill the parent (parent needs position:relative), used to cover the Monaco editor. */
   overlay?: boolean;
 }) {
-  // delayMs<=0：确定要盖（如 Monaco overlay），第 0 帧即显，不走延迟。
+  // delayMs<=0: definitely covering (e.g. Monaco overlay), show at frame 0, skip the delay.
   const [show, setShow] = useState(delayMs <= 0);
   useEffect(() => {
     if (delayMs <= 0) return;

--- a/apps/desktop/src/renderer/src/components/common/MermaidDiagram.tsx
+++ b/apps/desktop/src/renderer/src/components/common/MermaidDiagram.tsx
@@ -4,18 +4,18 @@ import { useTranslation } from 'react-i18next';
 import { useResolvedTheme } from '../../hooks/useTheme';
 
 /**
- * Mermaid 渲染：把 ```mermaid 代码块渲染成 SVG 图（Qodo `/describe` 常生成架构图）。
+ * Mermaid rendering: renders ```mermaid code blocks into SVG diagrams (Qodo `/describe` often generates architecture diagrams).
  *
- * - **懒加载**：mermaid 体积大（含 d3 等），仅当真正出现 mermaid 块、组件挂载时才
- *   `import('mermaid')`，不进入口包、不增加启动成本（与 Monaco 懒加载同思路）。
- * - **securityLevel: 'strict'**：内容来自 AI / 远端 PR 描述，strict 下 mermaid 转义
- *   标签文本、禁用点击脚本，产出的 SVG 可安全注入。
- * - **失败回退**：语法错 / 渲染异常时回退展示原始代码块，图画错也能看源码。
- * - 主题随应用深 / 浅色切换（`dark` / `default`）：mermaid 主题为全局态、不走 CSS 自定义属性，
- *   故每次渲染前按当前解析主题 re-initialize，并把主题纳入渲染 effect 依赖、切换时重绘。
+ * - **Lazy load**: mermaid is large (includes d3 etc.), only `import('mermaid')` when a mermaid block actually
+ *   appears and the component mounts, keeping it out of the entry bundle and adding no startup cost (same idea as Monaco lazy loading).
+ * - **securityLevel: 'strict'**: content comes from AI / remote PR descriptions; under strict, mermaid escapes
+ *   label text and disables click scripts, so the produced SVG is safe to inject.
+ * - **Failure fallback**: on syntax errors / render exceptions, fall back to showing the original code block, so the source is readable even when the diagram fails.
+ * - Theme follows the app dark / light switch (`dark` / `default`): mermaid theme is global state and does not go through CSS custom properties,
+ *   so re-initialize with the current resolved theme before each render, and include the theme in the render effect deps to redraw on switch.
  */
 
-// 仅声明本组件用到的最小接口，避免 import() 类型注解（且与 mermaid 内部类型解耦）。
+// Declare only the minimal interface this component uses, avoiding import() type annotations (and decoupling from mermaid's internal types).
 interface MermaidApi {
   initialize(config: Record<string, unknown>): void;
   render(id: string, text: string): Promise<{ svg: string }>;
@@ -23,12 +23,12 @@ interface MermaidApi {
 
 let mermaidLoader: Promise<MermaidApi> | null = null;
 function loadMermaid(): Promise<MermaidApi> {
-  // 失败时重置缓存：否则 rejected promise 被永久缓存，后续调用永远拿到同一个失败结果、
-  // 无法重试（典型「缓存 Promise」陷阱）。
+  // Reset the cache on failure: otherwise the rejected promise is cached forever, and later calls always get the same
+  // failed result with no retry (the classic "cached Promise" trap).
   mermaidLoader ??= import('mermaid')
     .then((m) => {
       const mermaid = m.default as unknown as MermaidApi;
-      // 主题不在此固定：每次渲染前按当前应用主题 re-initialize（见组件渲染 effect）。
+      // Theme is not fixed here: re-initialize with the current app theme before each render (see the component render effect).
       mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
       return mermaid;
     })
@@ -41,10 +41,10 @@ function loadMermaid(): Promise<MermaidApi> {
 
 export function MermaidDiagram({ source }: { source: string }) {
   const { t } = useTranslation();
-  // mermaid 主题为全局态、不走 CSS 自定义属性：随应用解析主题切换（深 'dark' / 浅 'default'）。
+  // mermaid theme is global state and does not go through CSS custom properties: switches with the app resolved theme (dark 'dark' / light 'default').
   const mermaidTheme = useResolvedTheme() === 'light' ? 'default' : 'dark';
-  // mermaid.render 需要唯一 id（内部建临时 DOM 节点）；useId 保证每个实例稳定唯一，
-  // 去掉 `:`（mermaid 用作 DOM id / CSS 选择器，冒号非法）
+  // mermaid.render needs a unique id (it creates temporary DOM nodes internally); useId guarantees each instance is stably unique,
+  // strip `:` (mermaid uses it as a DOM id / CSS selector, where the colon is invalid)
   const renderId = `mmd-${useId().replace(/:/g, '')}`;
   const [svg, setSvg] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
@@ -57,12 +57,12 @@ export function MermaidDiagram({ source }: { source: string }) {
     void (async () => {
       try {
         const mermaid = await loadMermaid();
-        // 渲染前按当前主题 re-initialize（全局态，幂等）：主题切换后重渲即换配色。
+        // Re-initialize with the current theme before rendering (global state, idempotent): re-rendering after a theme switch swaps the color scheme.
         mermaid.initialize({ startOnLoad: false, theme: mermaidTheme, securityLevel: 'strict' });
         const out = await mermaid.render(renderId, source);
         if (!cancelled) setSvg(out.svg);
       } catch (e) {
-        // 记一次日志便于排查（语法错 / 加载失败）；UI 回退到原始代码块
+        // Log once to aid debugging (syntax error / load failure); UI falls back to the original code block
         console.error('[mermaid] render failed', e);
         if (!cancelled) setFailed(true);
       }
@@ -73,7 +73,7 @@ export function MermaidDiagram({ source }: { source: string }) {
   }, [source, renderId, mermaidTheme]);
 
   if (failed) {
-    // 回退：保留原始 mermaid 源码，至少可读
+    // Fallback: keep the original mermaid source, at least it stays readable
     return (
       <pre className="mermaid-fallback">
         <code>{source}</code>
@@ -83,7 +83,7 @@ export function MermaidDiagram({ source }: { source: string }) {
   if (svg === null) {
     return <div className="mermaid-loading muted">{t('mermaidDiagram.rendering')}</div>;
   }
-  // mermaid strict 模式产出的 SVG 已转义不可信内容，可安全注入。点击图表 → 模态预览。
+  // SVG produced by mermaid strict mode has escaped untrusted content and is safe to inject. Click the diagram → modal preview.
   return (
     <>
       <div
@@ -103,7 +103,7 @@ export function MermaidDiagram({ source }: { source: string }) {
       {zoomed &&
         createPortal(
           <MermaidZoomModal
-            // 重写 id（含 <style> 选择器 / 箭头 marker 引用），避免与内联副本同 id 冲突
+            // Rewrite the id (which appears in <style> selectors / arrow marker references) to avoid id collisions with the inline copy
             svgHtml={svg.replaceAll(renderId, `${renderId}-zoom`)}
             onClose={() => setZoomed(false)}
           />,
@@ -118,20 +118,21 @@ const MAX_SCALE = 8;
 const clampScale = (s: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
 
 /**
- * mermaid 模态预览：固定纯色背景的预览区 + 可缩放/拖拽视图。
+ * mermaid modal preview: a preview area with a fixed solid background + a zoomable/draggable view.
  *
- * 不再手动测量 svg 内容并算缩放 —— mermaid 的 svg 在「width:100% / 内联 max-width / 绝对定位
- * 容器 / transform」相互作用下，渲染像素尺寸在「测量时」与「绘制后」并不一致，手算 fit 必然偏差。
- * 改为让浏览器原生处理「适应」：svg `width/height:100%` 充满预览区 + `preserveAspectRatio`
- * （默认 xMidYMid meet）自动等比缩放并居中；缩放/拖拽只是在其上叠加一层 transform。
- * - 默认（scale=1）：图自动适应窗口、居中（原生）。
- * - 滚轮缩放（锚定光标）、左键拖拽平移、工具栏放大/缩小/复位、Esc / 点遮罩关闭。
+ * No longer manually measures the svg content and computes the scale — under the interaction of mermaid's svg
+ * "width:100% / inline max-width / absolutely positioned container / transform", the rendered pixel size differs
+ * between "at measurement" and "after paint", so a hand-computed fit is bound to be off. Instead let the browser
+ * natively handle "fit": svg `width/height:100%` fills the preview area + `preserveAspectRatio`
+ * (default xMidYMid meet) auto-scales proportionally and centers; zoom/drag just layer a transform on top.
+ * - Default (scale=1): the diagram auto-fits the window and centers (native).
+ * - Wheel zoom (anchored to the cursor), left-button drag pan, toolbar zoom in/out/reset, Esc / click backdrop to close.
  */
 function MermaidZoomModal({ svgHtml, onClose }: { svgHtml: string; onClose: () => void }) {
   const { t } = useTranslation();
   const stageRef = useRef<HTMLDivElement>(null);
   const drag = useRef<{ x: number; y: number } | null>(null);
-  // scale=1 即「原生适应窗口」基准；缩放/平移在其上叠加。
+  // scale=1 is the "native fit-to-window" baseline; zoom/pan layer on top of it.
   const [scale, setScale] = useState(1);
   const [tx, setTx] = useState(0);
   const [ty, setTy] = useState(0);
@@ -142,7 +143,7 @@ function MermaidZoomModal({ svgHtml, onClose }: { svgHtml: string; onClose: () =
     setTy(0);
   };
 
-  // Esc 关闭
+  // Esc to close
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') onClose();
@@ -151,7 +152,7 @@ function MermaidZoomModal({ svgHtml, onClose }: { svgHtml: string; onClose: () =
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  // 以预览区内 (px,py) 为锚点缩放：保持光标下的点不动。
+  // Zoom anchored at (px,py) within the preview area: keep the point under the cursor fixed.
   const zoomAt = (px: number, py: number, factor: number): void => {
     const ns = clampScale(scale * factor);
     const k = ns / scale;

--- a/apps/desktop/src/renderer/src/components/common/Modal.tsx
+++ b/apps/desktop/src/renderer/src/components/common/Modal.tsx
@@ -14,29 +14,29 @@ const SIZE_CLASS: Record<ModalSize, string> = {
 
 interface ModalProps {
   onClose: () => void;
-  /** 弹窗尺寸 → 容器类名：md=modal · sm=modal-sm · confirm=modal-confirm */
+  /** Modal size → container class name: md=modal · sm=modal-sm · confirm=modal-confirm */
   size?: ModalSize;
-  /** 二层嵌套模态：加 modal-backdrop-nested，背景点击 stopPropagation 防冒泡关掉外层模态 */
+  /** Second-level nested modal: adds modal-backdrop-nested, backdrop-click stopPropagation prevents bubbling that would close the outer modal */
   nested?: boolean;
-  /** 经 createPortal 渲染到 body：避开调用者所在层级（如 Monaco view zone 内 z-index 偏低） */
+  /** Rendered to body via createPortal: avoids the caller's stacking context (e.g. low z-index inside a Monaco view zone) */
   portal?: boolean;
-  /** 点背景是否关闭（默认 true） */
+  /** Whether clicking the backdrop closes (default true) */
   closeOnBackdrop?: boolean;
-  /** 标题（不传则不渲染 header） */
+  /** Title (header is not rendered if omitted) */
   title?: ReactNode;
-  /** 标题元素 id，配合 aria-labelledby */
+  /** Title element id, paired with aria-labelledby */
   titleId?: string;
-  /** header 右侧关闭按钮样式：图标按钮 / 文案按钮（不传则无） */
+  /** Close button style on the right of the header: icon button / text button (none if omitted) */
   headerClose?: 'icon' | 'text';
-  /** header 右侧、关闭键左侧的自定义动作（如「打开目录」按钮）；与关闭键同组右对齐。 */
+  /** Custom actions on the right of the header, left of the close button (e.g. an "open directory" button); right-aligned in the same group as the close button. */
   headerActions?: ReactNode;
-  /** modal-body 追加类名（如 confirm-body） */
+  /** Extra class name appended to modal-body (e.g. confirm-body) */
   bodyClassName?: string;
-  /** 底部 footer 区内容（作为 modal-body 的兄弟渲染）；不传则无 footer 区 */
+  /** Bottom footer area content (rendered as a sibling of modal-body); no footer area if omitted */
   footer?: ReactNode;
-  /** footer 容器类名（默认 modal-footer-bar；确认框用 modal-actions） */
+  /** Footer container class name (default modal-footer-bar; confirm dialogs use modal-actions) */
   footerClassName?: string;
-  /** 容器内联样式（个别弹窗自定宽度用） */
+  /** Container inline style (used by individual modals with custom widths) */
   style?: CSSProperties;
   ariaLabel?: string;
   ariaLabelledby?: string;
@@ -44,8 +44,8 @@ interface ModalProps {
 }
 
 /**
- * 通用模态壳：统一 backdrop（点外关闭 + 嵌套防冒泡）、dialog 容器、可选 header（标题 + 关闭键）、
- * modal-body 包裹、可选 footer 区。键盘交互（Esc / Enter）由各调用方按需自管——壳只负责结构与样式语言。
+ * Generic modal shell: unified backdrop (click-outside to close + nested bubbling guard), dialog container, optional header (title + close button),
+ * modal-body wrapper, optional footer area. Keyboard interaction (Esc / Enter) is managed by each caller as needed — the shell only handles structure and the styling language.
  */
 export function Modal({
   onClose,
@@ -69,8 +69,8 @@ export function Modal({
   const tree = (
     <div
       className={`modal-backdrop${nested ? ' modal-backdrop-nested' : ''}`}
-      // 背景点击只关本层：stopPropagation 防止冒泡到外层模态 backdrop（嵌套时不拦会连外层一起关）。
-      // 顶层用法下 stopPropagation 无副作用。
+      // Backdrop click closes only this layer: stopPropagation prevents bubbling to the outer modal backdrop (without it, nesting would close the outer one too).
+      // In top-level usage stopPropagation has no side effect.
       onClick={(e) => {
         e.stopPropagation();
         if (closeOnBackdrop) onClose();

--- a/apps/desktop/src/renderer/src/components/common/PlatformIcon.tsx
+++ b/apps/desktop/src/renderer/src/components/common/PlatformIcon.tsx
@@ -1,5 +1,5 @@
-// 代码平台品牌图标。沿用 icons.tsx 的内联 SVG 惯例，但平台 logo 用各自品牌色
-// （而非 currentColor），让首启向导的平台选择列表一眼可辨。viewBox 统一 24。
+// Code platform brand icons. Follows the inline SVG convention of icons.tsx, but platform logos use their own brand colors
+// (rather than currentColor), so the first-launch wizard's platform selection list is instantly distinguishable. viewBox unified at 24.
 
 import type { JSX } from 'react';
 import type { PlatformKind } from '@meebox/shared';
@@ -8,7 +8,7 @@ interface PlatformIconProps {
   size?: number;
 }
 
-/** Bitbucket：蓝色「桶」标记（简化字形，非官方资源） */
+/** Bitbucket: blue "bucket" mark (simplified glyph, not an official asset) */
 export function BitbucketIcon({ size = 24 }: PlatformIconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
@@ -25,9 +25,9 @@ export function BitbucketIcon({ size = 24 }: PlatformIconProps) {
 }
 
 /**
- * GitHub：Octocat 猫头剪影（品牌单色 logo）。随主题切换 fill —— 暗底官方反白 invertocat、
- * 浅底官方近黑（见 _theme.scss 的 --github-logo）。SVG fill **属性**不解析 var()，故经 CSS
- * fill **属性**（style）注入变量。
+ * GitHub: Octocat cat-head silhouette (monochrome brand logo). fill switches with the theme — on dark the official inverted-white invertocat,
+ * on light the official near-black (see --github-logo in _theme.scss). The SVG fill **attribute** does not resolve var(), so the variable is injected
+ * via the CSS fill **property** (style).
  */
 export function GitHubIcon({ size = 24 }: PlatformIconProps) {
   return (
@@ -40,7 +40,7 @@ export function GitHubIcon({ size = 24 }: PlatformIconProps) {
   );
 }
 
-/** GitLab：tanuki 狐狸标记（simple-icons 路径，品牌橙 #FC6D26 一眼可辨） */
+/** GitLab: tanuki fox mark (simple-icons path, brand orange #FC6D26 instantly recognizable) */
 export function GitLabIcon({ size = 24 }: PlatformIconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
@@ -52,12 +52,12 @@ export function GitLabIcon({ size = 24 }: PlatformIconProps) {
   );
 }
 
-// 平台展示顺序的唯一准绳：GitHub → Bitbucket → GitLab，新增平台一律追加在末尾。
-// 设置页下拉、使用文档（docs/guide/01-code-platform.md）等各处展示顺序均以此为准。
+// The single source of truth for platform display order: GitHub → Bitbucket → GitLab, new platforms are always appended at the end.
+// The settings-page dropdown, usage docs (docs/guide/01-code-platform.md), and all other display orders follow this.
 export const PLATFORM_META: ReadonlyArray<{
   kind: PlatformKind;
   label: string;
-  /** i18n key（在消费端用 t() 翻译；含技术性副标题与「即将支持」等状态文案） */
+  /** i18n key (translated with t() on the consumer side; covers the technical subtitle and status text like "coming soon") */
   subKey: string;
   available: boolean;
   Icon: (p: PlatformIconProps) => JSX.Element;

--- a/apps/desktop/src/renderer/src/components/common/StatusChip.tsx
+++ b/apps/desktop/src/renderer/src/components/common/StatusChip.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from 'react';
 type ChipTone = 'ok' | 'err';
 
 interface StatusChipProps {
-  /** 渲染元素：默认有 onClick 时为 button、否则 span */
+  /** Render element: defaults to button when onClick is present, otherwise span */
   as?: 'span' | 'button';
-  /** 语义色调 → statusbar-chip-ok / statusbar-chip-err */
+  /** Semantic tone → statusbar-chip-ok / statusbar-chip-err */
   tone?: ChipTone;
-  /** 追加的专属类名（如 statusbar-pragent-chip / statusbar-llm-chip） */
+  /** Appended dedicated class name (e.g. statusbar-pragent-chip / statusbar-llm-chip) */
   className?: string;
   title?: string;
   ariaLabel?: string;
@@ -18,9 +18,9 @@ interface StatusChipProps {
 }
 
 /**
- * 状态栏 chip 通用壳：统一 `statusbar-chip` 基类 + 可选语义色调（ok/err），按是否可点
- * 渲染为 button / span，并透传 title / aria / disabled。各 chip 内部结构（图标 / 文案 /
- * 下拉）作为 children 自管，专属样式经 className 追加。
+ * Generic status-bar chip shell: unified `statusbar-chip` base class + optional semantic tone (ok/err), rendered as
+ * button / span depending on whether it is clickable, passing through title / aria / disabled. Each chip's internal
+ * structure (icon / text / dropdown) is managed as children, with dedicated styles appended via className.
  */
 export function StatusChip({
   as,

--- a/apps/desktop/src/renderer/src/components/common/Switch.tsx
+++ b/apps/desktop/src/renderer/src/components/common/Switch.tsx
@@ -1,6 +1,6 @@
 /**
- * 通用开关（switch）：受控布尔输入，无障碍走 role="switch" + aria-checked。点击 / 空格 / 回车切换。
- * 视觉为轨道 + 滑块，开态走 accent 色（样式见 base.scss .switch）。
+ * Generic switch: controlled boolean input, accessibility via role="switch" + aria-checked. Toggles on click / space / enter.
+ * Visually a track + knob, on-state uses accent color (styles in base.scss .switch).
  */
 export function Switch({
   checked,

--- a/apps/desktop/src/renderer/src/components/common/icons.tsx
+++ b/apps/desktop/src/renderer/src/components/common/icons.tsx
@@ -1,15 +1,15 @@
-// 跨组件复用的内联 SVG 图标。统一 currentColor 描边，跟随主题色 / 父元素文字色，
-// 离线无网络依赖。需要不同尺寸时传 size（viewBox 固定 16，缩放即可）。
+// Inline SVG icons reused across components. Uniform currentColor stroke, follows theme color / parent element's text color,
+// offline with no network dependency. Pass size when a different size is needed (viewBox fixed at 16, just scale).
 
 interface IconProps {
   size?: number;
-  /** 个别图标需要外部 class（如 ChevronIcon 的 tree-chevron 旋转动画）；其余忽略。 */
+  /** Some icons need an external class (e.g. ChevronIcon's tree-chevron rotation animation); the rest ignore it. */
   className?: string;
 }
 
 /**
- * git pull-request / 分支合并字形：两条分支汇入 + 指向合并点的箭头。
- * 既用于 PR 列表分支行前缀，也用于"合并"按钮 / 可合并 chip —— 同一语义同一图形。
+ * git pull-request / branch merge glyph: two branches converging + an arrow pointing to the merge point.
+ * Used both as the PR list branch row prefix and for the "merge" button / mergeable chip — same semantics, same graphic.
  */
 export function PullRequestIcon({ size = 12 }: IconProps) {
   return (
@@ -34,7 +34,7 @@ export function PullRequestIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 关闭叉号：模态框右上角通用关闭按钮用，图标免国际化。 */
+/** Close cross: for the modal top-right generic close button, icon needs no i18n. */
 export function CloseIcon({ size = 16 }: IconProps) {
   return (
     <svg
@@ -53,7 +53,7 @@ export function CloseIcon({ size = 16 }: IconProps) {
   );
 }
 
-/** 三角警示（叹号）：合并冲突等需要用户注意的状态。文件树冲突文件行用。 */
+/** Triangle warning (exclamation): states needing user attention such as merge conflicts. Used on file tree conflict file rows. */
 export function ConflictIcon({ size = 14, className }: IconProps) {
   return (
     <svg
@@ -75,7 +75,7 @@ export function ConflictIcon({ size = 14, className }: IconProps) {
   );
 }
 
-/** 文件夹：选择目录按钮用 */
+/** Folder: for the choose directory button */
 export function FolderIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -93,7 +93,7 @@ export function FolderIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 铅笔：编辑按钮用 */
+/** Pencil: for the edit button */
 export function PencilIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -113,7 +113,7 @@ export function PencilIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 睁眼：密钥/令牌「显示」状态用 */
+/** Open eye: for the key/token "shown" state */
 export function EyeIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -133,7 +133,7 @@ export function EyeIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 闭眼（带斜杠）：密钥/令牌「隐藏」状态用 */
+/** Closed eye (with slash): for the key/token "hidden" state */
 export function EyeOffIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -154,7 +154,7 @@ export function EyeOffIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 垃圾桶：删除按钮用 */
+/** Trash can: for the delete button */
 export function TrashIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -177,7 +177,7 @@ export function TrashIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 纸飞机（横向，Lucide send-horizontal 风格）：发送 / 提交按钮用 */
+/** Paper plane (horizontal, Lucide send-horizontal style): for the send / submit button */
 export function SendIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -197,7 +197,7 @@ export function SendIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 实心圆角方块：停止 / 取消（媒体停止键视觉惯例）。fill 版，无描边 */
+/** Solid rounded square: stop / cancel (media stop-key visual convention). Fill version, no stroke */
 export function StopIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -206,7 +206,7 @@ export function StopIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 圆圈内 `?`：/ask 用户提问 chip 前缀（跟答案区分） */
+/** `?` inside a circle: prefix for the /ask user question chip (distinguishes it from the answer) */
 export function QuestionIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -227,7 +227,7 @@ export function QuestionIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 循环箭头（refresh-cw 风格）：重试动作，chip 内嵌小尺寸。与 SyncIcon（双箭头）区分语义 */
+/** Loop arrow (refresh-cw style): retry action, small size embedded in chips. Distinct in semantics from SyncIcon (double arrow) */
 export function RetryIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -247,7 +247,7 @@ export function RetryIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 转发 / 分享箭头（社交媒体「转发」实心弯箭头）：finding 卡片「引用」按钮用。 */
+/** Forward / share arrow (social media "share" solid curved arrow): for the finding card "quote" button. */
 export function ShareIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -256,7 +256,7 @@ export function ShareIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 拼图块（extension / plugin）：集成 / 扩展 的通用隐喻。设置「集成」分区导航用。 */
+/** Puzzle piece (extension / plugin): common metaphor for integration / extension. For the settings "integrations" section navigation. */
 export function PuzzleIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -265,7 +265,7 @@ export function PuzzleIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 评论：带文字行的对话气泡。finding 卡「编辑成评论草稿」动作用（与 ChatIcon 区分：内含文字行）。 */
+/** Comment: a speech bubble with text lines. For the finding card "edit into comment draft" action (distinct from ChatIcon: contains text lines). */
 export function CommentIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -286,7 +286,7 @@ export function CommentIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 圆形禁止（no-entry）：圆 + 斜杠。finding 卡「拒绝」动作用。 */
+/** Circular ban (no-entry): circle + slash. For the finding card "reject" action. */
 export function BanIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -305,7 +305,7 @@ export function BanIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 对话气泡：chat 面板触发 / 空态。large 场景传 size（如 28） */
+/** Speech bubble: chat panel trigger / empty state. Pass size for large scenarios (e.g. 28) */
 export function ChatIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -324,7 +324,7 @@ export function ChatIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 图片占位（相框 + 山峦 + 太阳）：评论「上传图片附件」按钮。 */
+/** Image placeholder (frame + mountains + sun): the comment "upload image attachment" button. */
 export function ImageIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -345,7 +345,7 @@ export function ImageIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 笑脸 + 加号：评论「添加表情反应」按钮（viewBox 24 以对齐 lucide 笔形比例）。 */
+/** Smiley + plus: the comment "add emoji reaction" button (viewBox 24 to align with lucide stroke proportions). */
 export function SmilePlusIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -369,7 +369,7 @@ export function SmilePlusIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 文件树（三横线带项目符号）：DiffView 退出搜索 / tree 模式指示 */
+/** File tree (three horizontal lines with bullets): DiffView exit search / tree mode indicator */
 export function FileTreeIcon({ size = 12 }: IconProps) {
   return (
     <svg
@@ -392,7 +392,7 @@ export function FileTreeIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 放大镜：进入搜索模式 */
+/** Magnifying glass: enter search mode */
 export function SearchIcon({ size = 12 }: IconProps) {
   return (
     <svg
@@ -412,7 +412,7 @@ export function SearchIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 右向折角箭头：树节点展开 / 折叠。className 供旋转动画（FileTree 传 tree-chevron） */
+/** Right-pointing chevron: tree node expand / collapse. className for rotation animation (FileTree passes tree-chevron) */
 export function ChevronIcon({ size = 10, className }: IconProps) {
   return (
     <svg
@@ -432,7 +432,7 @@ export function ChevronIcon({ size = 10, className }: IconProps) {
   );
 }
 
-/** 地球经纬网格：在远端浏览器打开 */
+/** Globe with lat/long grid: open in remote browser */
 export function GlobeIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -453,7 +453,7 @@ export function GlobeIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 头肩剪影：作者行前缀 / blame 视图 / 账户指示（统一的「人」图标，合并原 PersonIcon、BlameIcon、UserIcon） */
+/** Head-and-shoulders silhouette: author row prefix / blame view / account indicator (unified "person" icon, merging the original PersonIcon, BlameIcon, UserIcon) */
 export function PersonIcon({ size = 12 }: IconProps) {
   return (
     <svg
@@ -473,7 +473,7 @@ export function PersonIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 空白字符可视化（·→·）：显示 space / tab */
+/** Whitespace visualization (·→·): show space / tab */
 export function WhitespaceIcon({ size = 12 }: IconProps) {
   return (
     <svg
@@ -492,7 +492,7 @@ export function WhitespaceIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 圆圈内对勾：审批通过 */
+/** Checkmark inside a circle: approved */
 export function ApproveIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -512,7 +512,7 @@ export function ApproveIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 圆圈内感叹号：需要修改 */
+/** Exclamation inside a circle: needs work */
 export function NeedsWorkIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -533,7 +533,7 @@ export function NeedsWorkIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 纯对勾字形（无外圆环）：用于实心彩底角标，只留内部符号。 */
+/** Plain checkmark glyph (no outer ring): for solid colored-background badges, keeping only the inner symbol. */
 export function CheckGlyphIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -552,7 +552,7 @@ export function CheckGlyphIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 复制字形：前景方片 + 左上后衬纸，标准「复制到剪贴板」语义。 */
+/** Copy glyph: foreground sheet + top-left backing sheet, standard "copy to clipboard" semantics. */
 export function CopyIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -572,7 +572,7 @@ export function CopyIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 纯感叹号字形（无外圆环）：用于实心彩底角标，只留内部符号。 */
+/** Plain exclamation glyph (no outer ring): for solid colored-background badges, keeping only the inner symbol. */
 export function AlertGlyphIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -592,7 +592,7 @@ export function AlertGlyphIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** git commit 字形：横线上一个实心节点（活动时间线提交事件用）。 */
+/** git commit glyph: a solid node on a horizontal line (for activity timeline commit events). */
 export function CommitIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -613,7 +613,7 @@ export function CommitIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 机器人头像：AutoPilot 启用态。天线 + 头框 + 双眼 + 两侧耳。 */
+/** Robot head: AutoPilot enabled state. Antenna + head frame + two eyes + ears on both sides. */
 export function RobotIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -638,7 +638,7 @@ export function RobotIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 铃铛：设置页「通知」分区图标。钟体 + 顶钮 + 底部摆锤。 */
+/** Bell: the settings page "notifications" section icon. Bell body + top button + bottom clapper. */
 export function BellIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -659,7 +659,7 @@ export function BellIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** CPU / 芯片：设置页「模型」分区图标（LLM 模型）。外框 + 内核 + 四边引脚。 */
+/** CPU / chip: the settings page "model" section icon (LLM model). Outer frame + core + pins on all four sides. */
 export function CpuIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -680,8 +680,8 @@ export function CpuIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 实心四角星（AI 常见 sparkle）：评审建议徽标（手动 / AutoPilot 一视同仁）。四条边向中心内凹，
- *  四个尖角居中对称，SVG 保证字形居中、跨平台一致。 */
+/** Solid four-pointed star (AI's common sparkle): review suggestion badge (manual / AutoPilot treated alike). The four edges curve inward toward the center,
+ *  the four points are centered and symmetric, and the SVG guarantees the glyph is centered and consistent across platforms. */
 export function StarIcon({ size = 11 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -690,7 +690,7 @@ export function StarIcon({ size = 11 }: IconProps) {
   );
 }
 
-/** 机器人头像 + 斜杠：AutoPilot 关闭态。 */
+/** Robot head + slash: AutoPilot disabled state. */
 export function RobotOffIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -716,7 +716,7 @@ export function RobotOffIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 双星火花（sparkles）：AI 自动评审动作。两颗四角星，区别于工具命令的 `/` 触发器 */
+/** Double sparkles: AI auto-review action. Two four-pointed stars, distinct from the tool commands' `/` trigger */
 export function AutoReviewIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -726,7 +726,7 @@ export function AutoReviewIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 双向循环箭头（Lucide refresh-cw-2 风格）：同步状态。与 RetryIcon（单箭头，重试动作）区分语义 */
+/** Bidirectional loop arrows (Lucide refresh-cw-2 style): sync status. Distinct in semantics from RetryIcon (single arrow, retry action) */
 export function SyncIcon({ size = 12 }: IconProps) {
   return (
     <svg
@@ -748,7 +748,7 @@ export function SyncIcon({ size = 12 }: IconProps) {
   );
 }
 
-/** 数据库柱体（Lucide database，viewBox 24）：表示提示缓存命中量（cache_read） */
+/** Database cylinder (Lucide database, viewBox 24): represents prompt cache hit volume (cache_read) */
 export function DatabaseIcon({ size = 12, className }: IconProps) {
   return (
     <svg
@@ -770,7 +770,7 @@ export function DatabaseIcon({ size = 12, className }: IconProps) {
   );
 }
 
-/** 循环箭头（Lucide repeat，viewBox 24）：表示模型交互轮次（agentic 多轮） */
+/** Loop arrow (Lucide repeat, viewBox 24): represents model interaction rounds (agentic multi-turn) */
 export function RepeatIcon({ size = 12, className }: IconProps) {
   return (
     <svg
@@ -793,7 +793,7 @@ export function RepeatIcon({ size = 12, className }: IconProps) {
   );
 }
 
-/** 齿轮（Lucide settings，viewBox 24）：设置按钮 */
+/** Gear (Lucide settings, viewBox 24): settings button */
 export function SettingsIcon({ size = 14 }: IconProps) {
   return (
     <svg
@@ -814,8 +814,8 @@ export function SettingsIcon({ size = 14 }: IconProps) {
 }
 
 /**
- * 面板开关：矩形 + 分隔细条。`side` 决定细条 / 收起态实心块在左（侧栏）还是右（chat 面板）——
- * 原 SidebarIcon 与镜像版 ChatPanelIcon 合并为一个参数化图标。collapsed 时细条侧变实心。
+ * Panel toggle: rectangle + thin divider bar. `side` decides whether the divider / collapsed-state solid block is on the left (sidebar) or right (chat panel) —
+ * the original SidebarIcon and its mirrored ChatPanelIcon merged into one parameterized icon. When collapsed, the divider side becomes solid.
  */
 export function PanelToggleIcon({
   side,
@@ -842,8 +842,8 @@ export function PanelToggleIcon({
 }
 
 /**
- * 完成徽章：大圆环 + 对勾。onboarding 完成步使用。path 带 `onboarding-check-path` class
- * 供 CSS 描边动画（stroke-dashoffset）。默认 76px（viewBox 52）。
+ * Completion badge: large ring + checkmark. Used by the onboarding completion step. The path carries the `onboarding-check-path` class
+ * for the CSS stroke animation (stroke-dashoffset). Defaults to 76px (viewBox 52).
  */
 export function SuccessBadgeIcon({ size = 76 }: IconProps) {
   return (
@@ -861,7 +861,7 @@ export function SuccessBadgeIcon({ size = 76 }: IconProps) {
   );
 }
 
-/** GitHub Octocat 标记（随文字色，用于「关于」链接的 GitHub / Star 入口）。 */
+/** GitHub Octocat mark (follows text color, for the "about" link's GitHub / Star entry). */
 export function GitHubMarkIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
@@ -873,7 +873,7 @@ export function GitHubMarkIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** GitHub issue 字形：空心圆 + 实心圆点。用于「提交反馈 / Issue」入口。 */
+/** GitHub issue glyph: hollow circle + solid dot. For the "submit feedback / Issue" entry. */
 export function IssueIcon({ size = 14 }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -883,7 +883,7 @@ export function IssueIcon({ size = 14 }: IconProps) {
   );
 }
 
-/** 历史字形：时钟 + 逆时针回溯箭头。用于「已关闭 / 历史」PR 范围切换。 */
+/** History glyph: clock + counterclockwise rewind arrow. For the "closed / history" PR scope toggle. */
 export function HistoryIcon({ size = 14, className }: IconProps) {
   return (
     <svg
@@ -905,7 +905,7 @@ export function HistoryIcon({ size = 14, className }: IconProps) {
   );
 }
 
-/** 标签 / 发布字形：带孔的 tag。用于「发布记录」入口。 */
+/** Tag / release glyph: a tag with a hole. For the "release history" entry. */
 export function TagIcon({ size = 14 }: IconProps) {
   return (
     <svg

--- a/apps/desktop/src/renderer/src/components/common/index.ts
+++ b/apps/desktop/src/renderer/src/components/common/index.ts
@@ -1,7 +1,7 @@
-// components/common 对外公共 API barrel：通用展示组件 + 图标 + markdown 渲染工具。
-// 跨域消费方（features/* · layout/* · App 等）经此 barrel 引入；common 内部模块相互引用
-// （markdownMermaid → MermaidDiagram、Modal → icons、ConfirmModal → Modal）走相对路径，
-// 不经此 barrel，避免循环依赖。
+// components/common public API barrel: generic presentational components + icons + markdown rendering utilities.
+// Cross-domain consumers (features/* · layout/* · App etc.) import via this barrel; common's internal modules reference each other
+// (markdownMermaid → MermaidDiagram, Modal → icons, ConfirmModal → Modal) via relative paths,
+// not through this barrel, to avoid circular dependencies.
 export * from './Avatar';
 export * from './BitbucketImage';
 export * from './ConfirmModal';

--- a/apps/desktop/src/renderer/src/components/common/markdownMermaid.tsx
+++ b/apps/desktop/src/renderer/src/components/common/markdownMermaid.tsx
@@ -4,17 +4,17 @@ import { MermaidDiagram } from './MermaidDiagram';
 const MERMAID_LANG = /\blanguage-mermaid\b/;
 
 /**
- * react-markdown components 覆盖：把 ```mermaid 代码块渲染成图（见 MermaidDiagram），
- * 其余代码块保持默认。合并进各 markdown 面的 `components`（评论 / PR 描述 / chat 输出）。
+ * react-markdown components override: render ```mermaid code blocks as diagrams (see MermaidDiagram),
+ * keep other code blocks at their default. Merged into the `components` of each markdown surface (comments / PR description / chat output).
  *
- * - `code`：命中 language-mermaid → 渲染图；否则原样 <code>。
- * - `pre`：mermaid 块去掉外层 <pre>（图自带容器，避免被代码块的 monospace / 边框框住）。
+ * - `code`: matches language-mermaid → render diagram; otherwise verbatim <code>.
+ * - `pre`: mermaid blocks drop the outer <pre> (the diagram brings its own container, avoiding the code block's monospace / border framing).
  */
 export const mermaidComponents: Components = {
   code({ node: _node, className, children, ...rest }) {
     if (className && MERMAID_LANG.test(className)) {
-      // children 可能是数组（react-markdown 常见形态）：String(array) 会用逗号拼接破坏
-      // mermaid DSL，需先拼接其中字符串项（非字符串忽略）再传入。
+      // children may be an array (a common react-markdown shape): String(array) joins with commas and breaks
+      // the mermaid DSL, so concatenate its string items (ignoring non-strings) before passing them in.
       const text = Array.isArray(children)
         ? children.map((c) => (typeof c === 'string' ? c : '')).join('')
         : typeof children === 'string'
@@ -35,7 +35,7 @@ export const mermaidComponents: Components = {
         ? (first as { props?: { className?: unknown } }).props?.className
         : undefined;
     if (typeof cls === 'string' && MERMAID_LANG.test(cls)) {
-      // mermaid：直接渲染 code 覆盖产出的图，不套 <pre>
+      // mermaid: render the diagram produced by the code override directly, without wrapping in <pre>
       return <>{children}</>;
     }
     return <pre {...rest}>{children}</pre>;
@@ -43,9 +43,9 @@ export const mermaidComponents: Components = {
 };
 
 /**
- * describe「文件变更」walkthrough 专用 components：在 mermaid 覆盖之上再去掉 <details> 的 open
- * 属性。pr-agent 把各文件分类（功能增强 / 配置变更 …）输出为 <details open> 默认展开，文件多时正文
- * 很长；去掉 open 让每个分类默认折叠收起，点 <summary> 标题按需展开（原生 <details> 交互、不持久化）。
+ * Dedicated components for the describe "file changes" walkthrough: on top of the mermaid override, also strip the <details> open
+ * attribute. pr-agent outputs each file category (feature enhancement / config change …) as <details open> expanded by default; with many files the body
+ * gets very long; removing open makes each category collapse by default, click the <summary> title to expand on demand (native <details> interaction, not persisted).
  */
 export const walkthroughMdComponents: Components = {
   ...mermaidComponents,

--- a/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/ChatPane.tsx
@@ -37,56 +37,56 @@ interface ChatPaneProps {
   prAgent: PrAgentStatus;
   width: number;
   onResize: (next: number) => void;
-  /** 折叠时仍然挂载组件 (保住进行中的 run 计时器 / runProgress 订阅)，
-      只用 CSS 隐藏。展开后用户看到的就是当前实时状态 */
+  /** Keep the component mounted when collapsed (preserves the in-progress run timer / runProgress
+      subscription); hide with CSS only. On expand the user sees the current live state */
   collapsed?: boolean;
   /**
-   * 跳到 Diff 视图编辑某条 finding 对应的草稿 (M4)。父组件 (MainPane)
-   * 实现：切 tab='diff' + DiffView scroll/highlight/open edit zone + 懒创建 draft
-   * 如果还没有。anchor 已由 finding.anchor 直接给到。
+   * Jump to the Diff view to edit the draft for a finding (M4). Parent (MainPane)
+   * implements: switch tab='diff' + DiffView scroll/highlight/open edit zone + lazily create draft
+   * if it doesn't exist yet. anchor is passed directly via finding.anchor.
    */
   onJumpToDraftEditor?: (target: {
     runId: string;
     findingId: string;
     anchor: { path: string; startLine: number; endLine: number };
   }) => void;
-  /** /approve /needswork 命令触发的 PR review 决断；由 MainPane 接到 prs:setLocalStatus */
+  /** PR review verdict triggered by the /approve /needswork commands; wired to prs:setLocalStatus by MainPane */
   onSetReviewStatus?: (status: LocalPrStatus) => void;
-  /** /merge 命令触发的合并（弹二次确认后调用，跟 PR header 合并按钮共用 prs:merge）；仅 canMerge 时可用。 */
+  /** Merge triggered by the /merge command (called after the confirm dialog, shares prs:merge with the PR header merge button); only available when canMerge. */
   onMerge?: () => void;
   /**
-   * 点击 finding 的文件行锚点 → 仅跳转到 Diff 对应行（scroll+highlight，不进编辑态）。
-   * 跟 onJumpToDraftEditor 的区别：不带 runId/findingId，不创建 / 打开草稿。
+   * Click a finding's file-line anchor → only jump to the corresponding Diff line (scroll+highlight, no edit mode).
+   * Difference from onJumpToDraftEditor: no runId/findingId, does not create / open a draft.
    */
   onNavigateToAnchor?: (anchor: { path: string; startLine: number; endLine: number }) => void;
   /**
-   * 当前 active LLM profile 的 model 名 — RunningView meta chip 显示。
-   * null = 无 active profile / 还在加载，UI 不展示 model chip
+   * Model name of the currently active LLM profile — shown in the RunningView meta chip.
+   * null = no active profile / still loading, UI does not show the model chip
    */
   currentLlmModel?: string | null;
   /**
-   * 是否已配置可用的 LLM（存在与 active_id 匹配的 profile）。false 时即便 pr-agent
-   * 运行时就绪，也无法发起调用 —— 空态 / 输入栏给出「需配置」提示并禁用。
+   * Whether a usable LLM is configured (a profile matching active_id exists). When false, even if the
+   * pr-agent runtime is ready, no call can be started — the empty state / input bar shows a "needs config" hint and is disabled.
    */
   llmConfigured?: boolean;
-  /** 打开设置面板（LLM 未配置提示里的「去设置」按钮用） */
+  /** Open the settings panel (used by the "Go to settings" button in the LLM-not-configured hint) */
   onOpenSettings?: () => void;
   /**
-   * 当前 Diff 视图选中的单 commit 范围（无 / root commit 为 null）：作为本 PR 聊天区命令的**隐式范围**——
-   * 直接键入的 /describe /review /improve /ask 自动限定在该 commit（输入栏显示可撤销范围 chip）。撤销该 chip
-   * 后本会话不再随视图范围（直到切换到别的 commit）。auto review 微流程不受此影响、恒作用于 PR 全量。
+   * The single-commit scope currently selected in the Diff view (null when none / root commit): serves as the **implicit scope**
+   * for this PR's chat commands — directly typed /describe /review /improve /ask are automatically limited to that commit (the input bar shows a dismissible scope chip). After
+   * dismissing that chip, this session no longer follows the view scope (until switching to another commit). The auto review micro-flow is unaffected and always operates on the full PR.
    */
   viewCommitScope?: ReviewRunCommitScope | null;
 }
 
 /**
- * pr-agent 调用面板（M3-D1）。
- * - 头部：两个动作按钮 (/describe /review)，pr-agent 不可用时禁用并指引到 Settings
- * - 运行中：实时滚动 stdout（main 通过 pragent:runProgress 流式推送）
- * - 运行后：展示最新 ReviewRun 的 findings 列表（markdown body + 可选 anchor）
+ * pr-agent invocation panel (M3-D1).
+ * - Header: two action buttons (/describe /review), disabled and pointing to Settings when pr-agent is unavailable
+ * - Running: live-scrolling stdout (streamed from main via pragent:runProgress)
+ * - After running: shows the latest ReviewRun's findings list (markdown body + optional anchor)
  *
- * 本组件是「容器」：状态与生命周期归 useChatSession，业务动作归 useChatActions，时间线归并归
- * useChatTimeline；展示与工具方法拆到 ./components 与 ./utils。这里只做布局编排与少量纯 UI 态。
+ * This component is the "container": state and lifecycle go to useChatSession, business actions to useChatActions, timeline merging to
+ * useChatTimeline; presentation and utility methods are split into ./components and ./utils. Here we only do layout orchestration and a bit of pure UI state.
  */
 export function ChatPane({
   pr,
@@ -108,7 +108,7 @@ export function ChatPane({
     e.preventDefault();
     const startX = e.clientX;
     const startWidth = width;
-    // 拖右边 = 缩小 chat (远离左侧的 dx 是正)
+    // Dragging the right edge = shrink chat (dx away from the left is positive)
     const onMove = (ev: MouseEvent): void => {
       const dx = ev.clientX - startX;
       const next = Math.min(CHAT_MAX_WIDTH, Math.max(CHAT_MIN_WIDTH, startWidth - dx));
@@ -128,34 +128,34 @@ export function ChatPane({
 
   const prLocalId = pr?.localId;
 
-  // 全局活动 run + 实时 stdout 缓存。store 来源于 main 的 'pragent:activeChanged'
-  // / 'pragent:runProgress' 事件，PR 切换不丢，所以这里只读，不在本组件维护
+  // Global active runs + live stdout cache. The store is fed by main's 'pragent:activeChanged'
+  // / 'pragent:runProgress' events and survives PR switches, so this is read-only here, not maintained in this component
   const { active, waiting, linesByRunId } = useChatRunStore();
-  // 并发模型：active 是多条并发运行中的 run。本 PR 的运行中 run 可能 >1（用户对同一
-  // PR 连发多个工具）；其它 PR 的并发数用于「别处在跑」提示。
+  // Concurrency model: active is a list of concurrently running runs. This PR's running runs may be >1 (user fires multiple
+  // tools at the same PR); other PRs' concurrency count feeds the "running elsewhere" hint.
   const myActiveRuns = active.filter((a) => a.prLocalId === pr?.localId);
   const hasMyActive = myActiveRuns.length > 0;
-  // 本 PR 排队中的任务（FIFO，前面的先跑），在 chat 末尾以「排队中」卡片展示
+  // This PR's queued tasks (FIFO, earlier ones run first), shown as "queued" cards at the end of the chat
   const myWaiting = waiting.filter((w) => w.prLocalId === pr?.localId);
   const myActiveIds = myActiveRuns.map((a) => a.runId);
 
-  // M4 草稿池：从 main 进程拉本 PR 的草稿，跟 finding 通过 source 字段反查关联
+  // M4 draft pool: fetch this PR's drafts from the main process, associated with findings via the source field
   const drafts = useDraftsForPr(prLocalId);
-  // 复评关闭关系池（只读）：复评 /ask 裁决 replace/drop 时由后端自动关闭原 finding（见 asks-step →
-  // closeFinding）并广播；这里据 (runId,findingId) 反查、在 FindingCard 上以只读 chip 标注「已被复评取代/关闭」。
+  // Re-review closure-relation pool (read-only): when a re-review /ask verdict is replace/drop, the backend automatically closes the original finding (see asks-step →
+  // closeFinding) and broadcasts it; here we look up by (runId,findingId) and mark it on FindingCard with a read-only chip "superseded/closed by re-review".
   const closures = useFindingClosuresForPr(prLocalId) ?? [];
 
-  // 复评引用态：点 finding「引用」→ 仅挂到输入栏（chip）；不自动填写问题，用户自行输入。发送时携带该引用。
+  // Re-review reference state: clicking a finding's "reference" → only attaches to the input bar (chip); does not auto-fill the question, the user types it. The reference is carried on send.
   const [refFinding, setRefFinding] = useState<{ finding: Finding; run: ReviewRun } | null>(null);
-  // 「脱离视图范围」态：用户 ✕ 掉范围 chip 后，本会话命令不再随 Diff 视图选中的 commit（直到切到别的 commit
-  // 或切 PR 才复位）。默认跟随视图范围。
+  // "Detached from view scope" state: after the user ✕'s the scope chip, this session's commands no longer follow the commit selected in the Diff view (until switching to another commit
+  // or switching PR resets it). Follows the view scope by default.
   const [scopeDetached, setScopeDetached] = useState(false);
-  // PR 切换清掉引用态、复位脱离态，避免跨 PR 残留。
+  // On PR switch, clear the reference state and reset the detached state to avoid cross-PR residue.
   useEffect(() => {
     setRefFinding(null);
     setScopeDetached(false);
   }, [prLocalId]);
-  // 切到别的 commit（或清空视图范围）时复位脱离态：新选中的 commit 重新作为隐式范围生效。
+  // On switching to another commit (or clearing the view scope), reset the detached state: the newly selected commit becomes the implicit scope again.
   useEffect(() => {
     setScopeDetached(false);
   }, [viewCommitScope?.sha]);
@@ -163,29 +163,29 @@ export function ChatPane({
     setRefFinding({ finding, run });
   };
 
-  // Diff 选区（归属当前 PR）：用于输入栏「N 行已选中」角标 + 把选中代码作为隐式上下文带进提问。
+  // Diff selection (belonging to the current PR): used for the input bar's "N lines selected" badge + carrying the selected code as implicit context into a question.
   const { selection: diffSelection, ignored: selectionIgnored } = useDiffSelection(prLocalId);
-  // 未忽略时把选区拼成引用串；/ask 与自然语言提问共用。忽略 / 无选区 → undefined（本条不带引用）。
+  // When not ignored, format the selection into a reference string; shared by /ask and natural-language questions. Ignored / no selection → undefined (this message carries no reference).
   const referencedContext =
     diffSelection && !selectionIgnored ? formatReferencedContext(diffSelection) : undefined;
 
-  // 本 PR 聊天区命令的生效范围：跟随 Diff 视图选中的 commit，除非用户已脱离（scopeDetached）。
-  // 同一时刻只允许一个 scope 生效——存在 Diff 选区时以选区为准（更细粒度），commit 范围暂挂起、其 chip
-  // 亦隐藏（见 commitScopeChip），取消选区后自动还原。
+  // The effective scope for this PR's chat commands: follows the commit selected in the Diff view, unless the user has detached (scopeDetached).
+  // Only one scope may be in effect at a time — when a Diff selection exists it takes precedence (finer-grained), the commit scope is suspended and its chip
+  // is hidden too (see commitScopeChip), auto-restored after the selection is cleared.
   const effectiveScope = diffSelection || scopeDetached ? null : (viewCommitScope ?? null);
 
-  // 会话态 + 生命周期（切 PR 重载 / 流式步骤 / 分页 / 自动滚动）
+  // Session state + lifecycle (reload on PR switch / streaming steps / pagination / auto-scroll)
   const session = useChatSession(prLocalId, myActiveIds);
 
-  // 切走再回来时，正在跑的 run 已落盘 (status=running) → listRuns 把它读进 runs，
-  // 同时它又是实时运行中 run，会重复渲染 (历史卡片 + RunningView 各一条)。这里把
-  // 所有运行中 run 从历史列表剔除，运行中的展示统一交给下方 RunningView 负责。
+  // When switching away and back, the running run has been persisted (status=running) → listRuns reads it into runs,
+  // while it is also a live running run, causing duplicate rendering (a history card + a RunningView). Here we
+  // remove all running runs from the history list; running ones are shown solely by the RunningView below.
   const myActiveIdSet = new Set(myActiveIds);
   const visibleRuns = hasMyActive
     ? session.runs.filter((r) => !myActiveIdSet.has(r.id))
     : session.runs;
 
-  // 业务动作集合（触发工具 / 自动评审 / 对话 / 取消 / 清空 / finding→草稿）
+  // Business action set (trigger tool / auto review / conversation / cancel / clear / finding→draft)
   const actions = useChatActions({
     pr,
     prAgent,
@@ -207,8 +207,8 @@ export function ChatPane({
   });
   const { agentRunningHere } = actions;
 
-  // 发送一条复评 /ask：携带被引用 finding 的结构化引用 + 正文上下文，走 /ask 直达工具（出裁决 +
-  // 采纳/关闭动作）；发送后清空引用态。
+  // Send a re-review /ask: carries the referenced finding's structured reference + body context, going through the /ask direct tool (produces a verdict +
+  // adopt/close action); clears the reference state after sending.
   const sendReferencedAsk = (q: string): void => {
     if (!refFinding) return;
     const { finding, run } = refFinding;
@@ -220,13 +220,13 @@ export function ChatPane({
     setRefFinding(null);
   };
 
-  // 发送一条限定在当前视图 commit 的 /ask：把生效范围随问题带下去（限定 parent..sha 的 diff）。
+  // Send an /ask limited to the currently viewed commit: carries the effective scope along with the question (limited to the parent..sha diff).
   const sendScopedAsk = (q: string): void => {
     if (!effectiveScope) return;
     void actions.handleRun('ask', q, undefined, undefined, effectiveScope);
   };
 
-  // 历史时间线归并 + 「思考中」实时计时锚点
+  // History timeline merge + live timing anchor for "thinking"
   const { timeline, thinkingSince } = useChatTimeline({
     visibleRuns,
     myActiveRuns,
@@ -236,16 +236,16 @@ export function ChatPane({
     prLocalId,
   });
 
-  // 纯 UI 态：规则预览弹窗 / 清空确认弹窗 / 合并确认弹窗
+  // Pure UI state: rule preview modal / clear confirm modal / merge confirm modal
   const [showRulePreview, setShowRulePreview] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [showMergeConfirm, setShowMergeConfirm] = useState(false);
 
   const { runs, error, loadingSession, matchedRules, bodyRef, hasMoreOlder, loadingOlder } = session;
 
-  // 复评卡 ↔ 原 finding 卡互链：滚动定位 + 短暂高亮。flash class 因目标而异：run 卡用 chat-run-flash
-  // （背景渐隐，run 卡本身透明底可见）；finding 卡用 chat-finding-flash（覆盖式高亮环——finding 卡有
-  // 实底 $bg-elev，背景渐隐会被洗掉、看不出闪烁）。
+  // Re-review card ↔ original finding card cross-link: scroll to and briefly highlight. The flash class differs by target: run cards use chat-run-flash
+  // (fading background, visible on the run card's transparent base); finding cards use chat-finding-flash (an overlay highlight ring — finding cards have
+  // a solid $bg-elev base, so a fading background would be washed out and the flash unnoticeable).
   const flash = (el: Element, cls: 'chat-run-flash' | 'chat-finding-flash'): void => {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     el.classList.add(cls);
@@ -255,8 +255,8 @@ export function ChatPane({
     const el = bodyRef.current?.querySelector(`[data-run-id="${CSS.escape(runId)}"]`);
     if (el) flash(el, 'chat-run-flash');
   };
-  // 点击复评卡顶部引用徽标：精确定位到原 run 内被引用的那条 finding 卡片并闪烁高亮（找不到该卡片——
-  // 如已分页移出 / 折叠——回退到整条 run 高亮，至少给出定位反馈）。
+  // Clicking the reference badge at the top of a re-review card: precisely locate and flash-highlight the referenced finding card within the original run (if the card isn't found —
+  // e.g. paged out / collapsed — fall back to highlighting the whole run, giving at least positional feedback).
   const scrollToFinding = (runId: string, findingId: string): void => {
     const runEl = bodyRef.current?.querySelector(`[data-run-id="${CSS.escape(runId)}"]`);
     if (!runEl) return;
@@ -286,7 +286,7 @@ export function ChatPane({
             #{pr.remoteId}
           </span>
         )}
-        {/* 运行时策略 chip 撤掉：部署细节用户不关心，状态栏已有 PR Agent 版本 chip */}
+        {/* Runtime strategy chip removed: users don't care about deployment details, and the status bar already has a PR Agent version chip */}
         {pr && runs.length > 0 && (
           <button
             type="button"
@@ -300,8 +300,8 @@ export function ChatPane({
         )}
       </header>
 
-      {/* 当前 PR 命中的规则 chip：rules.dir 未配置 / 整体禁用 / 无命中 → 不显示。
-          点击展开正文预览，让用户能确认本次 review 会被哪条规则约束 */}
+      {/* Chip for rules matched by the current PR: not shown when rules.dir is unconfigured / globally disabled / no match.
+          Click to expand the body preview so the user can confirm which rule will constrain this review */}
       {matchedRules.length > 0 && (
         <button
           type="button"
@@ -318,16 +318,16 @@ export function ChatPane({
         </button>
       )}
 
-      {/* 规划 Agent 的计划面板：运行中据 agent:planUpdated 实时刷新、随新输入重排；空计划不渲染。
-          置于 header 之下、滚动区之上，始终可见。 */}
+      {/* The planning Agent's plan panel: refreshes live from agent:planUpdated while running and re-orders with new input; empty plans are not rendered.
+          Placed below the header and above the scroll area, always visible. */}
       <PlanPanel todo={session.todo} />
 
       <div className="chat-pane-body" ref={bodyRef}>
-        {/* 初次拉取会话期间盖延迟 loading（>150ms 才显），遮住「清空 → 内容 pop-in」抖动；
-            加载完成才落到下方的真实空态，避免空 PR 误显 loading。 */}
+        {/* Overlay a delayed loading indicator during the initial session fetch (shown only after >150ms), masking the "clear → content pop-in" jitter;
+            only fall through to the real empty state below once loading completes, avoiding an empty PR falsely showing loading. */}
         {loadingSession && <PaneLoading />}
-        {/* 使用提示仅在「全无会话内容」时显示：一旦有用户输入气泡 / run / 步骤 / 收尾结果，
-            或 Agent 正在运行 / 有排队任务，即隐藏，避免输入后仍残留提示。 */}
+        {/* The usage hint shows only when there is "no session content at all": as soon as there's a user input bubble / run / step / final result,
+            or the Agent is running / has queued tasks, it hides, to avoid the hint lingering after input. */}
         {!loadingSession &&
           timeline.length === 0 &&
           !agentRunningHere &&
@@ -340,25 +340,25 @@ export function ChatPane({
               onOpenSettings={onOpenSettings}
             />
           )}
-        {/* 还有更早的 run 未拉到本地 → 顶部出加载提示。继续向上滚自动游标拉一页 */}
+        {/* There are still older runs not fetched locally → show a loading hint at the top. Keep scrolling up to auto-cursor-fetch a page */}
         {(hasMoreOlder || loadingOlder) && (
           <div className="chat-run-more-hint muted" role="status">
             {loadingOlder ? t('common.loading') : t('chatPane.scrollUpForOlder')}
           </div>
         )}
-        {/* 历史 run 按时间升序堆叠，每条独立卡片 (内部维护自己的 raw stdout 折叠状态)。
-            初始只拉最新 RUNS_PAGE_SIZE 条；向上滚到顶后再用游标拉更早一批 */}
+        {/* History runs stacked in ascending time order, each an independent card (maintaining its own raw stdout collapse state).
+            Initially only the latest RUNS_PAGE_SIZE are fetched; after scrolling up to the top, fetch an earlier batch by cursor */}
         {timeline.map((entry, i) =>
           entry.run ? (
-            // data-run-id：供复评卡 ↔ 原 finding 卡互链滚动定位（scrollToRun）。
+            // data-run-id: for re-review card ↔ original finding card cross-link scroll targeting (scrollToRun).
             <div key={entry.key} data-run-id={entry.run.id}>
               <RunResultView
                 run={entry.run}
                 onRetry={actions.handleRetry}
                 onDelete={actions.handleDeleteRun}
-                // 只有"时间线里最后一条 run + 没有正在跑的"这一种情形下，失败 / 取消的 run
-                // 才可重试；用户已经发起新动作 (无论成功或正在跑) → 旧失败不再展示重试，
-                // 避免回头再点重新插队、打乱对话顺序
+                // Only in the single case of "the last run in the timeline + nothing running" can a failed / cancelled run
+                // be retried; once the user has started a new action (whether succeeded or running) → old failures no longer show retry,
+                // avoiding a back-click re-queue that would disrupt conversation order
                 canRetry={i === timeline.length - 1 && !hasMyActive}
                 drafts={drafts ?? []}
                 closures={closures}
@@ -371,8 +371,8 @@ export function ChatPane({
               />
             </div>
           ) : entry.active ? (
-            // 正在跑：进度条 + 实时 stdout 流，按启动时间穿插在时间线里（startedAt 入队时为 null、
-            // 起跑时设值，fallback enqueuedAt）。prAgent 未就绪时不渲染。
+            // Running: progress bar + live stdout stream, interleaved into the timeline by start time (startedAt is null when enqueued,
+            // set when it starts, falling back to enqueuedAt). Not rendered when prAgent is not ready.
             prAgent.available ? (
               <RunningView
                 key={entry.key}
@@ -391,8 +391,8 @@ export function ChatPane({
             <ConversationMessage key={entry.key} message={entry.message} />
           ) : null,
         )}
-        {/* 本 PR 排队中的任务：贴在运行中之后，可单条取消。位次取**全局**队列位序（队列跨 PR 共享，
-            否则每个 PR 都显示「第 1 位」会误导）——以 runId 在全局 waiting 数组里的下标 +1 为序。 */}
+        {/* This PR's queued tasks: placed after running ones, each cancellable individually. The position uses the **global** queue order (the queue is shared across PRs,
+            otherwise every PR showing "position 1" would be misleading) — the runId's index in the global waiting array +1. */}
         {myWaiting.map((w) => (
           <QueuedView
             key={w.runId}
@@ -402,10 +402,10 @@ export function ChatPane({
             onCancel={() => void actions.handleCancel(w.runId)}
           />
         ))}
-        {/* 过程化跟踪（类 Claude Code）：已完成的思考步骤已按时间穿插进上面的时间线（AgentStepRow），
-            此处只在 Agent 自身 LLM 正在推理（无 pr-agent 工具 run 占用 / 排队）时补一条实时「思考中」
-            指示——等待工具调用不算思考。计时锚定到「最近一次活动结束」（run 起点 / 末步 / 末个完成
-            run 的结束时刻取最晚者）而非组件挂载——切换 PR 再切回不会清零（runningPrs 与 run 历史持久）。 */}
+        {/* Procedural tracking (Claude Code-like): completed thinking steps are already interleaved into the timeline above by time (AgentStepRow),
+            here we only add a live "thinking" indicator when the Agent's own LLM is reasoning (no pr-agent tool run occupying / queued) —
+            waiting on a tool call doesn't count as thinking. The timer is anchored to "the end of the most recent activity" (the latest of run start / last step / last completed
+            run's end time) rather than component mount — switching PR and back doesn't reset it (runningPrs and run history persist). */}
         {agentRunningHere && !hasMyActive && myWaiting.length === 0 && (
           <ThinkingLive since={thinkingSince} />
         )}
@@ -421,11 +421,11 @@ export function ChatPane({
         pr={pr}
         prAgent={prAgent}
         llmConfigured={llmConfigured}
-        // 队列模型下输入永远开启 (新提交进队列 / 并发执行)；runningTool 仅决定是否额外
-        // 渲染 stop 按钮 (本 PR 有运行中 run 时可点终止)。多并发时 stop 终止最近一条。
+        // Under the queue model input is always enabled (new submissions enter the queue / execute concurrently); runningTool only decides whether to additionally
+        // render the stop button (clickable to terminate when this PR has a running run). With multiple concurrent, stop terminates the most recent one.
         runningTool={myActiveRuns[myActiveRuns.length - 1]?.tool ?? null}
-        // referencedContext 仅 /ask 与自然语言提问携带选区引用（describe/review 不带）。
-        // 引用了 finding 时：本条强制走复评 /ask（携带 finding 引用 + 正文上下文），发送后清空引用。
+        // referencedContext carries the selection reference only for /ask and natural-language questions (not describe/review).
+        // When a finding is referenced: this message is forced through re-review /ask (carrying the finding reference + body context), clearing the reference after sending.
         onRun={(tool, q) => {
           if (tool === 'ask' && refFinding) {
             sendReferencedAsk(q ?? '');
@@ -435,7 +435,7 @@ export function ChatPane({
             sendScopedAsk(q ?? '');
             return;
           }
-          // describe/review/improve 亦跟随视图 commit 范围（effectiveScope）；无范围时为 PR 全量。
+          // describe/review/improve also follow the view commit scope (effectiveScope); when no scope, the full PR.
           void actions.handleRun(
             tool,
             q,
@@ -449,7 +449,7 @@ export function ChatPane({
             sendReferencedAsk(q);
             return;
           }
-          // 视图选中某 commit 时，自然语言提问也走该 commit 范围的 /ask（限定该 commit 的 diff）。
+          // When a commit is selected in the view, natural-language questions also go through /ask scoped to that commit (limited to that commit's diff).
           if (effectiveScope) {
             sendScopedAsk(q);
             return;
@@ -458,18 +458,18 @@ export function ChatPane({
         }}
         onCancel={hasMyActive || agentRunningHere ? actions.handleStopAll : undefined}
         onSetReviewStatus={onSetReviewStatus}
-        // /merge：仅远端可直接合并时在命令菜单出现；触发先弹二次确认，确认后才实际合并。
+        // /merge: appears in the command menu only when the remote can be merged directly; triggering first shows a confirm dialog, merging only after confirmation.
         canMerge={pr?.mergeStatus?.canMerge ?? false}
         onMerge={onMerge ? () => setShowMergeConfirm(true) : undefined}
-        // 一键自动评审：图标按钮置于 `/` 命令触发器右侧。runningHere=跑在当前 PR（高亮 / 运行中文案 +
-        // 禁用重复发起）；其它 PR 在跑不禁用本 PR 的触发（可并发 / 排队）。
+        // One-click auto review: icon button placed to the right of the `/` command trigger. runningHere=running on the current PR (highlight / running text +
+        // disable re-triggering); another PR running does not disable this PR's trigger (can run concurrently / queue).
         agentRunningHere={agentRunningHere}
         onAgentReview={() => void actions.handleAgentReview()}
-        // Diff 选区角标：N 行已选中 / 点击切忽略；无选区时 null（不渲染）。
+        // Diff selection badge: N lines selected / click to toggle ignore; null when no selection (not rendered).
         selectionLineCount={diffSelection?.lineCount ?? null}
         selectionIgnored={selectionIgnored}
         onToggleSelection={() => selectionStore.toggleIgnored()}
-        // 复评引用：chip（直接显示引用定位 <file:line> + 清除）；点 finding「引用」时挂上，不自动填写问题。
+        // Re-review reference: chip (directly shows the reference location <file:line> + clear); attached when clicking a finding's "reference", does not auto-fill the question.
         referenceChip={
           refFinding
             ? {
@@ -480,13 +480,13 @@ export function ChatPane({
               }
             : null
         }
-        // 单 commit 范围 chip：视图选中某 commit 时显示（选中态源自视图）；点击切换启用/禁用——
-        // 禁用（scopeDetached）时命令回到 PR 全量、chip 置灰，切到别的 commit 或切 PR 复位为启用。
-        // 同一时刻只允许一个 scope：存在 Diff 选区时让位于选区 chip（隐藏本 chip），取消选区后自动还原。
+        // Single-commit scope chip: shown when a commit is selected in the view (the selected state comes from the view); click to toggle enabled/disabled —
+        // when disabled (scopeDetached) commands revert to the full PR and the chip greys out; switching to another commit or switching PR resets it to enabled.
+        // Only one scope at a time: when a Diff selection exists it yields to the selection chip (hides this chip), auto-restored after the selection is cleared.
         commitScopeChip={
           viewCommitScope && !diffSelection
             ? {
-                // 仅展示短 hash，不带主题（避免 chip 内容过长）；主题在 Diff 视图与结果卡徽标已可见。
+                // Show only the short hash, without the subject (to avoid overly long chip content); the subject is already visible in the Diff view and result-card badge.
                 label: viewCommitScope.abbreviatedSha,
                 disabled: scopeDetached,
                 onToggle: () => {

--- a/apps/desktop/src/renderer/src/components/features/chat/commands.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/commands.ts
@@ -1,20 +1,20 @@
 import type { LocalPrStatus, ReviewRunTool } from '@meebox/shared';
 
-/** 槽位定义：键盘操作 / 命令按钮 / 自动补全菜单都从这里取 */
+/** Slot definitions: keyboard actions / command buttons / autocomplete menu all draw from here */
 /**
- * Chat 命令分三类：
- *  - 'pragent': pr-agent 工具 (review / describe / ask)，触发 pragent:run
- *  - 'review-action': PR review 决断 (approve / needswork)，写 Bitbucket reviewer status
- *    通过 prs:setLocalStatus 触发，跟 PR header 按钮共用同一路径
- *  - 'pr-action': PR 远端动作 (merge)，触发 prs:merge，跟 PR header 合并按钮共用同一路径；
- *    仅 mergeStatus.canMerge 时可用，输入栏会弹二次确认
+ * Chat commands fall into three kinds:
+ *  - 'pragent': pr-agent tools (review / describe / ask), trigger pragent:run
+ *  - 'review-action': PR review verdicts (approve / needswork), write Bitbucket reviewer status
+ *    triggered via prs:setLocalStatus, sharing the same path as the PR header buttons
+ *  - 'pr-action': PR remote actions (merge), trigger prs:merge, sharing the same path as the PR header merge button;
+ *    only available when mergeStatus.canMerge, the input bar shows a confirm dialog
  */
 export type CommandSpec =
   | {
       kind: 'pragent';
       name: ReviewRunTool;
       label: string;
-      /** i18n key (chatPane 命名空间) 解析命令描述，渲染时用 t(descKey) */
+      /** i18n key (chatPane namespace) resolving the command description, rendered via t(descKey) */
       descKey: string;
       insertAs: string;
     }
@@ -22,7 +22,7 @@ export type CommandSpec =
       kind: 'review-action';
       name: 'approve' | 'needswork';
       label: string;
-      /** i18n key (chatPane 命名空间) 解析命令描述，渲染时用 t(descKey) */
+      /** i18n key (chatPane namespace) resolving the command description, rendered via t(descKey) */
       descKey: string;
       insertAs: string;
       reviewStatus: LocalPrStatus;
@@ -31,12 +31,12 @@ export type CommandSpec =
       kind: 'pr-action';
       name: 'merge';
       label: string;
-      /** i18n key (chatPane 命名空间) 解析命令描述，渲染时用 t(descKey) */
+      /** i18n key (chatPane namespace) resolving the command description, rendered via t(descKey) */
       descKey: string;
       insertAs: string;
     };
 
-// 分组顺序：pr-agent 工具 → 分隔线 → review 决断
+// Group order: pr-agent tools → separator → review verdicts
 export const COMMANDS: ReadonlyArray<CommandSpec> = [
   // pr-agent
   {
@@ -53,9 +53,9 @@ export const COMMANDS: ReadonlyArray<CommandSpec> = [
     descKey: 'chatPane.cmdDescribeDesc',
     insertAs: '/describe',
   },
-  // /improve：shim 强制 gfm_markdown=True 后，improve 走「汇总建议 → publish_comment →
-  // review.md」路径（非 committable，inline 模式仍不可用），parse-output 按
-  // generate_summarized_suggestions 的 <details> 模板解析出带重要度评分的 finding。
+  // /improve: after the shim forces gfm_markdown=True, improve takes the "summarized suggestions → publish_comment →
+  // review.md" path (non-committable, inline mode still unavailable), and parse-output parses findings with importance scores
+  // per the <details> template of generate_summarized_suggestions.
   {
     kind: 'pragent',
     name: 'improve',
@@ -70,7 +70,7 @@ export const COMMANDS: ReadonlyArray<CommandSpec> = [
     descKey: 'chatPane.cmdAskDesc',
     insertAs: '/ask ',
   },
-  // review 决断 (跟 PR header 按钮共用 prs:setLocalStatus，写 Bitbucket reviewer status)
+  // review verdicts (share prs:setLocalStatus with the PR header buttons, write Bitbucket reviewer status)
   {
     kind: 'review-action',
     name: 'approve',
@@ -87,7 +87,7 @@ export const COMMANDS: ReadonlyArray<CommandSpec> = [
     insertAs: '/needswork',
     reviewStatus: 'needs_work',
   },
-  // PR 远端动作：合并（跟 PR header 合并按钮共用 prs:merge）。仅 canMerge 时在输入栏可见，弹二次确认。
+  // PR remote action: merge (shares prs:merge with the PR header merge button). Visible in the input bar only when canMerge, shows a confirm dialog.
   {
     kind: 'pr-action',
     name: 'merge',

--- a/apps/desktop/src/renderer/src/components/features/chat/components/AgentStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/AgentStep.tsx
@@ -6,15 +6,18 @@ import { formatElapsed } from '../utils/format';
 import { Md, Spinner, TokenStat } from './shared';
 
 /**
- * 内联思考步骤（类 Claude Code「先思考→定步骤→执行步骤」）：穿插在时间线里、排在所选工具的 run
- * 卡片之前。两行展示——首行带 bullet 标记的「已思考 xx s」（单步思考耗时，非总累计），次行另起展示
- * 步骤结果（思考内容 / 判读结论）。不展示选了哪个工具（由随后的 run 卡片体现）；工具执行的进度 /
- * 计时也归 run 卡片。
+ * Inline thinking step (Claude Code-like "think first → decide steps → execute steps"): interleaved
+ * in the timeline, ordered before the selected tool's run card. Two-line display — the first line has
+ * a bullet marker "thought for xx s" (single-step thinking time, not cumulative total), the second
+ * line separately shows the step result (thinking content / judgment conclusion). Does not show which
+ * tool was selected (reflected by the subsequent run card); tool execution progress / timing also
+ * belong to the run card.
  */
 export function AgentStepRow({ step }: { step: AgentStep }) {
   const { t } = useTranslation();
-  // 首行始终带 bullet 标记：有思考计时 → 「已思考 xx s」；无计时（如微流程固定派发步）→ 用思考内容
-  // 当首行，保证每一步都可见、都有分段标记，绝不渲染成空行。
+  // The first line always has a bullet marker: with thinking timer → "thought for xx s"; without a
+  // timer (e.g. a micro-flow's fixed dispatch step) → use the thinking content as the first line,
+  // ensuring every step is visible and has a segment marker, never rendered as an empty line.
   const hasTime = step.thinkMs != null;
   const headText = hasTime
     ? t('chatPane.agent.thoughtFor', { time: formatElapsed(step.thinkMs ?? 0) })
@@ -25,16 +28,17 @@ export function AgentStepRow({ step }: { step: AgentStep }) {
         <span className="chat-agent-step-bullet" aria-hidden>
           •
         </span>
-        {/* AutoPilot 后台评审的首步打机器人 chip，标识「这次评审由 AutoPilot 触发」。 */}
+        {/* The first step of an AutoPilot background review gets a robot chip, marking "this review was triggered by AutoPilot". */}
         {step.autopilot && (
           <span className="chat-agent-step-autopilot" title={t('chatPane.autopilotRun')}>
             <RobotIcon size={12} />
           </span>
         )}
         {headText && <span>{headText}</span>}
-        {/* 本步**单独**的 token 用量（不累计）：judge / 总结 / 规划等经独立 LLM 通道的推理步带值；
-            与 run 卡片同款 ↑输入(绿)[⛁缓存]/↓输出(红)，输入输出各自独立 hover、靠行尾对齐。
-            describe/review/ask 的开销在各自 run 卡片上。 */}
+        {/* This step's **standalone** token usage (not cumulative): reasoning steps via an independent LLM
+            channel like judge / summary / planning carry a value; same style as the run card ↑input(green)
+            [⛁cache]/↓output(red), input and output hover independently, aligned to the line end.
+            describe/review/ask costs are on their respective run cards. */}
         {step.usage &&
         (step.usage.promptTokens !== undefined || step.usage.completionTokens !== undefined) ? (
           <span className="chat-agent-step-tokens">
@@ -47,8 +51,9 @@ export function AgentStepRow({ step }: { step: AgentStep }) {
           </span>
         ) : null}
       </div>
-      {/* 思考 / 判读正文走 markdown：保留换行并渲染预格式化内容（代码块 / 列表 / 内联代码），
-          与助手回复一致；纯文本内容渲染结果不变。 */}
+      {/* Thinking / judgment body goes through markdown: preserves line breaks and renders preformatted
+          content (code blocks / lists / inline code), consistent with assistant replies; plain-text
+          content renders unchanged. */}
       {hasTime && step.thought && (
         <div className="chat-agent-step-body markdown">
           <Md>{step.thought}</Md>
@@ -64,10 +69,13 @@ export function AgentStepRow({ step }: { step: AgentStep }) {
 }
 
 /**
- * 实时「思考中」指示：仅在 Agent 自身 LLM 正在推理（无工具 run 占用 / 排队）时挂载。计时锚定到传入的
- * `since`（最近一次活动结束时刻，由父级从持久数据算出），而非组件挂载——切走再切回不清零；新一步产生
- * 后 since 前移 → 计时回到当前步从零起算（仍是单步思考时长，非总累计）。
- * 首行布局与已完成步骤对齐：spinner 充当进行中的 bullet 标记，「思考中」后紧贴计时。
+ * Live "thinking" indicator: mounted only when the Agent's own LLM is reasoning (no tool run occupying /
+ * queued). The timer is anchored to the passed-in `since` (the moment the most recent activity ended,
+ * computed by the parent from persisted data) rather than component mount — switching away and back does
+ * not reset it; once a new step is produced, since advances forward → the timer restarts from zero for
+ * the current step (still single-step thinking duration, not cumulative total).
+ * The first-line layout aligns with completed steps: the spinner acts as the in-progress bullet marker,
+ * with the timer right after "thinking".
  */
 export function ThinkingLive({ since }: { since: number }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/chat/components/ChatEmpty.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/ChatEmpty.tsx
@@ -26,7 +26,7 @@ export function ChatEmpty({
       </div>
     );
   }
-  // pr-agent 运行时就绪但没有可用 LLM → 引导去设置配置一条模型
+  // pr-agent runtime is ready but no usable LLM → guide the user to settings to configure a model
   if (!llmConfigured) {
     return (
       <div className="chat-empty">

--- a/apps/desktop/src/renderer/src/components/features/chat/components/ChatInputBar.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/ChatInputBar.tsx
@@ -19,55 +19,58 @@ import { useTextareaAutosizeDrag } from '../hooks/useTextareaAutosizeDrag';
 interface ChatInputBarProps {
   pr: StoredPullRequest | null;
   prAgent: PrAgentStatus;
-  /** LLM 是否已配置；未配置时禁用输入（即便 pr-agent 运行时就绪也无法调用） */
+  /** Whether the LLM is configured; when not, the input is disabled (even if the pr-agent runtime is ready it cannot be invoked) */
   llmConfigured: boolean;
   /**
-   * 本 PR 上的活动 run 工具；非空时在 send 按钮旁额外渲染 stop 按钮。
-   * 队列模型下输入永不因此禁用 (新提交进队列)。
+   * The active run tool on this PR; when non-null, an extra stop button is rendered beside the send button.
+   * Under the queue model the input is never disabled because of this (new submissions enter the queue).
    */
   runningTool: ReviewRunTool | null;
   onRun: (tool: ReviewRunTool, question?: string) => void;
-  /** 无 '/' 前缀的自然语言输入 → 交给自由规划 Agent（对话即委派，见设计「会话 Agent 化」）。 */
+  /** Natural-language input without a '/' prefix → handed to the free-planning Agent (conversation is delegation, see design "conversation as Agent"). */
   onAgentAsk: (question: string) => void;
   /**
-   * 终止当前活动 run。仅 runningTool 非空时有意义；ChatPane 已绑好对应 runId。
-   * stop 按钮跟 send 共用槽位：runningTool 时点击触发此回调而非 onRun
+   * Terminates the current active run. Only meaningful when runningTool is non-null; ChatPane has already bound the corresponding runId.
+   * The stop button shares a slot with send: when runningTool is set, a click triggers this callback instead of onRun
    */
   onCancel?: () => void;
-  /** /approve /needswork 命令触发的 review 决断，跟 PR header 按钮共用 prs:setLocalStatus */
+  /** review decision triggered by the /approve /needswork commands, shares prs:setLocalStatus with the PR header buttons */
   onSetReviewStatus?: (status: LocalPrStatus) => void;
-  /** PR 远端可直接合并（mergeStatus.canMerge）：决定 /merge 是否在命令菜单 / 补全出现。 */
+  /** The PR can be merged directly on the remote (mergeStatus.canMerge): decides whether /merge appears in the command menu / completion. */
   canMerge: boolean;
-  /** /merge 命令触发（弹二次确认后实际合并，跟 PR header 合并按钮共用 prs:merge）。 */
+  /** Triggered by the /merge command (actually merges after a confirmation dialog, shares prs:merge with the PR header merge button). */
   onMerge?: () => void;
-  /** Agent 是否跑在当前 PR：决定图标按钮高亮 + 运行中文案 + 禁用重复发起（其它 PR 在跑不禁用本 PR）。 */
+  /** Whether the Agent is running on the current PR: decides the icon button highlight + running text + disabling re-invocation (an Agent running on another PR does not disable this PR). */
   agentRunningHere: boolean;
-  /** 触发一键自动评审微流程（describe→review→条件追问→总结）。 */
+  /** Triggers the one-click auto-review micro-flow (describe→review→conditional follow-up ask→summary). */
   onAgentReview: () => void;
   /**
-   * 当前 Diff 选区行数；null = 无选区（不渲染选区角标）。角标位于 AutoReview 右侧，提示「N 行已选中」，
-   * 发送时把选中代码作为隐式上下文带进提问。
+   * Current Diff selection line count; null = no selection (the selection badge is not rendered). The badge sits to the
+   * right of AutoReview, hinting "N lines selected", and carries the selected code into the question as implicit context on send.
    */
   selectionLineCount: number | null;
-  /** 选区忽略态：true 时本条消息不带选区引用（角标置灰 + eye-slash）。 */
+  /** Selection ignored state: when true this message carries no selection reference (badge greyed out + eye-slash). */
   selectionIgnored: boolean;
-  /** 点击选区角标 → 切换忽略态。 */
+  /** Click the selection badge → toggle the ignored state. */
   onToggleSelection: () => void;
-  /** 复评引用 chip：引用了某条 finding 时展示「复评 <file:line>」+ 清除；null = 不渲染。 */
+  /** Re-review reference chip: shows "re-review <file:line>" + clear when a finding is referenced; null = not rendered. */
   referenceChip?: { label: string; onClear: () => void } | null;
   /**
-   * 单 commit 范围 chip：跟随 Diff 视图选中的 commit 展示「短 SHA · 主题」。存在选中即显示，点击**切换启用/禁用**
-   * （禁用不删除 chip，本会话命令回到 PR 全量；禁用态置灰 + eye-slash）——选中态源自视图，可手动禁用。
+   * Single-commit scope chip: follows the commit selected in the Diff view, showing "short SHA · subject". Shown whenever there is
+   * a selection, click to **toggle enable/disable** (disabling does not remove the chip, this session's commands revert to the whole
+   * PR; disabled state greyed out + eye-slash) — the selected state originates from the view and can be disabled manually.
    */
   commitScopeChip?: { label: string; disabled: boolean; onToggle: () => void } | null;
 }
 
 /**
- * 输入栏：textarea + 命令按钮 + `/` 触发的自动补全。状态机（输入 / 命令解析 / 补全 / 历史回放 /
- * 停止）见 [useChatInput](../hooks/useChatInput.ts)；命令解析纯逻辑见 ../utils/parse-command。
+ * Input bar: textarea + command button + autocomplete triggered by `/`. State machine (input / command
+ * parsing / completion / history replay / stop) see [useChatInput](../hooks/useChatInput.ts); the pure
+ * command-parsing logic is in ../utils/parse-command.
  *
- * 提交语义：空不提交；`/describe` `/review` 等触发对应工具；`/ask <文本>` 触发 ask；未知 `/xxx` 报错；
- * 不以 `/` 开头 = 自然语言委派给自由规划 Agent。Shift+Enter 换行，Enter 提交。
+ * Submit semantics: empty does not submit; `/describe` `/review` etc. trigger the corresponding tool;
+ * `/ask <text>` triggers ask; unknown `/xxx` errors; not starting with `/` = natural language delegated
+ * to the free-planning Agent. Shift+Enter for a newline, Enter to submit.
  */
 export function ChatInputBar({
   pr,
@@ -147,7 +150,7 @@ export function ChatInputBar({
                   onClick={() => handleInsertCommand(c)}
                   onMouseEnter={() => setAutocompleteIdx(i)}
                   onMouseDown={(e) => {
-                    // 防止 textarea 失焦后 blur 处理把菜单收掉
+                    // Prevent the blur handler from collapsing the menu after the textarea loses focus
                     e.preventDefault();
                   }}
                   role="option"
@@ -162,7 +165,7 @@ export function ChatInputBar({
         </ul>
       )}
       <div className="chat-pane-textarea-wrap">
-        {/* 顶边拖动 handle：向上拖 → textarea 高度增加，跟视觉扩展方向一致 */}
+        {/* Top-edge drag handle: drag up → textarea height increases, consistent with the visual expansion direction */}
         <div
           className="chat-pane-textarea-resize-handle"
           onMouseDown={handleTextareaResizeStart}
@@ -203,7 +206,7 @@ export function ChatInputBar({
               <ul className="chat-cmd-menu" role="menu">
                 {visibleCommands.map((c, i) => {
                   const prev = visibleCommands[i - 1];
-                  // pragent → review-action 边界插一道分隔线
+                  // Insert a divider at the pragent → review-action boundary
                   const needDivider = prev !== undefined && prev.kind !== c.kind;
                   return (
                     <li key={c.name} className={needDivider ? 'chat-cmd-menu-group' : undefined}>
@@ -222,9 +225,11 @@ export function ChatInputBar({
               </ul>
             )}
           </div>
-          {/* 自动评审：图标按钮紧贴 `/` 命令触发器右侧。仅 pr-agent 就绪时出现，LLM 未配置 / 本 PR 评审
-            进行中则禁用触发（其它 PR 在跑不禁用——可并发 / 排队）。停止统一由发送区的停止按钮负责（取消
-            进行中的子任务即终止流程），不再单独提供 Agent 停止按钮，避免两个语义重叠的停止入口。 */}
+          {/* Auto-review: icon button right beside the `/` command trigger. Appears only when pr-agent is ready;
+            disabled when the LLM is not configured / a review on this PR is in progress (a review running on another
+            PR does not disable it — concurrency / queueing allowed). Stopping is handled uniformly by the stop button
+            in the send area (cancelling the in-progress subtask terminates the flow); no separate Agent stop button is
+            provided, avoiding two semantically overlapping stop entry points. */}
           {pr && prAgent.available && (
             <button
               type="button"
@@ -241,8 +246,9 @@ export function ChatInputBar({
               <AutoReviewIcon />
             </button>
           )}
-          {/* Diff 选区角标：竖线分隔后展示「N 行已选中」。点击切忽略态（eye-slash + 置灰）——忽略时
-              本条消息不带选区引用。选中代码以隐式上下文随提问发出，不进入会话气泡。 */}
+          {/* Diff selection badge: shows "N lines selected" after a vertical divider. Click to toggle the ignored
+              state (eye-slash + greyed out) — when ignored this message carries no selection reference. The selected
+              code is sent as implicit context with the question and does not enter the conversation bubble. */}
           {selectionLineCount !== null && (
             <>
               <span className="chat-cmd-divider" aria-hidden="true" />
@@ -261,8 +267,8 @@ export function ChatInputBar({
               </button>
             </>
           )}
-          {/* 复评引用 chip：引用了某条 review/improve finding 时展示「复评 <file:line>」，点 ✕ 清除引用。
-              发送时本条 /ask 会携带该 finding 引用走复评模式（出裁决 + 采纳/关闭动作）。 */}
+          {/* Re-review reference chip: shows "re-review <file:line>" when a review/improve finding is referenced, click ✕ to clear the reference.
+              On send this /ask carries the finding reference into re-review mode (produces a verdict + adopt/close actions). */}
           {referenceChip && (
             <>
               <span className="chat-cmd-divider" aria-hidden="true" />
@@ -281,8 +287,8 @@ export function ChatInputBar({
               </span>
             </>
           )}
-          {/* 单 commit 范围 chip：跟随视图选中的 commit 展示「短 SHA · 主题」。点击切换启用/禁用（不删除）——
-              启用时命令限定在该 commit（parent..sha），禁用则回到 PR 全量、置灰 + eye-slash。 */}
+          {/* Single-commit scope chip: follows the commit selected in the view, showing "short SHA · subject". Click to toggle enable/disable (without removing) —
+              when enabled the commands are scoped to that commit (parent..sha), when disabled they revert to the whole PR, greyed out + eye-slash. */}
           {commitScopeChip && (
             <>
               <span className="chat-cmd-divider" aria-hidden="true" />
@@ -302,8 +308,8 @@ export function ChatInputBar({
             </>
           )}
         </div>
-        {/* 队列模型下 send 永远在 (新提交进队列)；本 PR active 时 stop 紧贴 send 左侧。
-            包到一个 group 里避免 input-row 的 space-between 把 stop 推到中央 */}
+        {/* Under the queue model send is always present (new submissions enter the queue); when this PR is active, stop sits right to the left of send.
+            Wrapped in a group to prevent input-row's space-between from pushing stop to the center */}
         <div className="chat-pane-send-group">
           {running && onCancel && (
             <button

--- a/apps/desktop/src/renderer/src/components/features/chat/components/ConversationMessage.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/ConversationMessage.tsx
@@ -5,8 +5,9 @@ import { VERDICT_LABEL_KEY } from '../constants';
 import { Md } from './shared';
 
 /**
- * 一条多轮对话消息的展示：用户 → 右对齐气泡；助手评审类（带 recommendation）→「评审总结」卡片 +
- * 判定徽标；助手对话类（无 recommendation）→ 左对齐专属对话回复包装。
+ * Display of a single multi-turn conversation message: user → right-aligned bubble; assistant review type
+ * (with recommendation) → "review summary" card + verdict badge; assistant conversation type (no
+ * recommendation) → left-aligned dedicated conversation reply wrapper.
  */
 export function ConversationMessage({ message }: { message: AgentMessage }) {
   const { t } = useTranslation();
@@ -14,8 +15,8 @@ export function ConversationMessage({ message }: { message: AgentMessage }) {
     return (
       <div className="chat-user-row">
         <div className="chat-user-bubble">{message.content}</div>
-        {/* 提问携带的引用上下文（Diff 选区代码）：气泡下方折叠展示，默认收起保持紧凑。
-            referencedContext 自带路径 / 行范围 / 代码围栏，走 markdown 渲染。 */}
+        {/* Reference context carried by the question (Diff selection code): collapsed display below the bubble, collapsed by default to stay compact.
+            referencedContext comes with its own path / line range / code fence, rendered via markdown. */}
         {message.referencedContext && (
           <details className="chat-user-ref markdown">
             <summary>{t('chatPane.referencedContextLabel')}</summary>

--- a/apps/desktop/src/renderer/src/components/features/chat/components/FindingCard.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/FindingCard.tsx
@@ -23,13 +23,13 @@ import {
 } from '../utils/findings';
 import { BreakablePath, MdInline, withInlineSummary } from './shared';
 
-// 折叠标题（<details><summary>）支持内联 markdown：思路建议各方案标题里的 `代码` / **强调** 等生效。
-// 预算在模块级，避免每次渲染重建 components 对象。
+// Collapsible titles (<details><summary>) support inline markdown: `code` / **emphasis** etc. in the suggestion option titles take effect.
+// Budgeted at module level to avoid rebuilding the components object on every render.
 const DEFAULT_MD_COMPONENTS = withInlineSummary(mermaidComponents);
 const WALKTHROUGH_MD_COMPONENTS = withInlineSummary(walkthroughMdComponents);
 
-// chip 配色 tone → chat-chip-<tone>（色板见 styles/features/chat/chip.scss）。
-// finding 类别：元信息/图/工作量→accent，内容/测试/安全→approved，代码反馈/建议→warning，评分/兜底→neutral。
+// chip color tone → chat-chip-<tone> (palette see styles/features/chat/chip.scss).
+// finding categories: meta-info/diagram/effort→accent, content/tests/security→approved, code-feedback/suggestion→warning, score/fallback→neutral.
 const CAT_TONE: Record<PrDocSectionKey, 'accent' | 'approved' | 'warning' | 'neutral'> = {
   title: 'accent',
   'pr-type': 'accent',
@@ -43,14 +43,14 @@ const CAT_TONE: Record<PrDocSectionKey, 'accent' | 'approved' | 'warning' | 'neu
   security: 'approved',
   'code-feedback': 'warning',
   'code-suggestion': 'warning',
-  // /ask 结构化分段：结论高亮(绿)、建议高亮(琥珀)、过程分析中性(灰，默认收起)
+  // /ask structured segments: conclusion highlight (green), suggestion highlight (amber), process analysis neutral (grey, collapsed by default)
   'ask-summary': 'approved',
   'ask-analysis': 'neutral',
   'ask-suggestions': 'warning',
   score: 'neutral',
   general: 'neutral',
 };
-// 草稿状态：待处理/已编辑→accent，已发布→approved，已拒绝→neutral
+// Draft status: pending/edited→accent, posted→approved, rejected→neutral
 const DRAFT_TONE: Record<NonNullable<ReviewDraft['status']>, 'accent' | 'approved' | 'neutral'> = {
   pending: 'accent',
   edited: 'accent',
@@ -59,9 +59,9 @@ const DRAFT_TONE: Record<NonNullable<ReviewDraft['status']>, 'accent' | 'approve
 };
 
 /**
- * Finding 卡头部右上角的操作图标栏：编辑（评论气泡）/ 拒绝（圆形禁止）+ 引用（转发箭头）。
- * 仅代码类 finding（/review code-feedback 与 /improve code-suggestion）+ anchor 完整、未关闭时出现，
- * 排在折叠 chevron 之左。编辑动作随草稿状态切换语义（编辑 / 查看 / 撤销）；posted / rejected 不出拒绝。
+ * The action icon bar in the top-right of the Finding card header: edit (comment bubble) / reject (circular ban) + reference (forward arrow).
+ * Appears only for code-type findings (/review code-feedback and /improve code-suggestion) + complete anchor, not closed,
+ * ordered to the left of the collapse chevron. The edit action switches semantics with draft status (edit / view / undo); posted / rejected do not show reject.
  */
 function FindingHeadActions({
   relatedDraft,
@@ -76,11 +76,11 @@ function FindingHeadActions({
 }) {
   const { t } = useTranslation();
   const status = relatedDraft?.status;
-  // posted（远端已存，不撤销）/ rejected（已是拒绝态）不出拒绝按钮。
+  // posted (already exists on the remote, not undone) / rejected (already in the rejected state) do not show the reject button.
   const canReject = status !== 'posted' && status !== 'rejected';
   return (
     <div className="chat-finding-head-actions">
-      {/* 编辑→评论草稿。posted 跳转即「查看」；rejected 跳转即「撤销并继续编辑」。 */}
+      {/* Edit→comment draft. For posted, jumping means "view"; for rejected, jumping means "undo and keep editing". */}
       {onJump && (
         <button
           type="button"
@@ -115,7 +115,7 @@ function FindingHeadActions({
           <BanIcon size={16} />
         </button>
       )}
-      {/* 引用：发起复评 /ask（挂到输入栏），社媒「转发」箭头图标，排在编辑 / 拒绝之右。 */}
+      {/* Reference: initiate a re-review /ask (attached to the input bar), social-media "forward" arrow icon, ordered to the right of edit / reject. */}
       {onReference && (
         <button
           type="button"
@@ -132,10 +132,11 @@ function FindingHeadActions({
 }
 
 /**
- * Finding 卡 anchor 行右侧的状态展示。仅代码类 finding（/review code-feedback 与 /improve
- * code-suggestion）+ anchor 完整时出现。动作按钮已上移到头部图标栏（见 FindingHeadActions），
- * 此处只承载**状态**：被复评裁决 replace/drop 自动关闭时的只读关闭 chip（+「查看复评」导航，不提供
- * 撤销/关闭等用户操作——关闭由后端 ask 任务驱动），否则草稿状态 chip（待处理 / 已编辑 / 已发布 / 已拒绝）。
+ * Status display to the right of the Finding card's anchor row. Appears only for code-type findings (/review
+ * code-feedback and /improve code-suggestion) + complete anchor. The action buttons have been moved up to the
+ * header icon bar (see FindingHeadActions), so this only carries **status**: a read-only closed chip when auto-closed
+ * by a re-review verdict of replace/drop (+ "view re-review" navigation, no user operations like undo/close — closing
+ * is driven by the backend ask task), otherwise the draft status chip (pending / edited / posted / rejected).
  */
 function FindingDraftActions({
   relatedDraft,
@@ -143,13 +144,13 @@ function FindingDraftActions({
   onViewAsk,
 }: {
   relatedDraft?: ReviewDraft;
-  /** 被复评裁决自动关闭/取代时的关闭关系（只读展示驱动）。 */
+  /** The closure relationship when auto-closed/replaced by a re-review verdict (drives read-only display). */
   closure?: FindingClosure;
-  /** 「查看复评」导航回调：滚动定位到关闭它的复评 /ask 卡片（只读导航，非关闭操作）。 */
+  /** "View re-review" navigation callback: scroll to and locate the re-review /ask card that closed it (read-only navigation, not a close operation). */
   onViewAsk?: () => void;
 }) {
   const { t } = useTranslation();
-  // 已被复评取代/关闭：只读 chip（+ 查看复评导航）。关闭由后端 ask 裁决驱动，不提供撤销按钮。
+  // Already replaced/closed by a re-review: read-only chip (+ view re-review navigation). Closing is driven by the backend ask verdict, no undo button is provided.
   if (closure) {
     return (
       <div className="chat-finding-draft-actions">
@@ -198,50 +199,50 @@ export function FindingCard({
   onViewAsk,
 }: {
   finding: Finding;
-  /** 该 finding 关联的草稿；undefined = 尚未交互过；不为空 = 已 pending / edited / rejected / posted */
+  /** The draft associated with this finding; undefined = not interacted with yet; non-null = already pending / edited / rejected / posted */
   relatedDraft?: ReviewDraft;
-  /** 「→ 跳到代码编辑」按钮回调 */
+  /** "→ Jump to code editing" button callback */
   onJump?: () => void;
-  /** 「✗ 拒绝」按钮回调 */
+  /** "✗ Reject" button callback */
   onReject?: () => void;
-  /** 点击锚点：仅导航到 Diff 对应行（不进编辑态） */
+  /** Click the anchor: only navigate to the corresponding Diff line (does not enter edit state) */
   onNavigate?: () => void;
-  /** 「引用」按钮回调：把本 finding 挂到输入栏发起复评 /ask（仅 code 类 finding 出现）。 */
+  /** "Reference" button callback: attaches this finding to the input bar to initiate a re-review /ask (only appears for code-type findings). */
   onReference?: () => void;
-  /** 本 finding 被复评裁决 replace/drop 自动关闭时的关闭关系（只读展示驱动）。 */
+  /** The closure relationship when this finding is auto-closed by a re-review verdict of replace/drop (drives read-only display). */
   closure?: FindingClosure;
-  /** 「查看复评」导航回调：滚动定位到关闭它的复评 /ask 卡片。 */
+  /** "View re-review" navigation callback: scroll to and locate the re-review /ask card that closed it. */
   onViewAsk?: () => void;
 }) {
   const { t } = useTranslation();
-  // 已拒绝：左色条 + 类别 chip 置灰，卡片默认折叠收起（仅留头部 chip + 锚点行）。点头部的展开/收起
-  // 切换可临时回看正文，不影响草稿状态。
+  // Rejected: left color bar + category chip greyed out, card collapsed by default (only the header chip + anchor row remain). Clicking the
+  // header's expand/collapse toggle can temporarily review the body without affecting the draft status.
   const isRejected = relatedDraft?.status === 'rejected';
-  // 被复评取代/关闭：同样收起降饱和（与已拒绝同套视觉），anchor 行出只读关闭 chip。
+  // Replaced/closed by a re-review: likewise collapsed and desaturated (same visual as rejected), the anchor row shows a read-only closed chip.
   const isClosed = !!closure;
-  // sectionKey 优先（新解析的），fallback 到 category (旧持久化的 run)
+  // sectionKey takes priority (newly parsed), fallback to category (from an older persisted run)
   const key: PrDocSectionKey = finding.sectionKey ?? 'general';
-  // 可操作的代码类 finding（/review code-feedback、/improve code-suggestion 且 anchor 带行号）：
-  // 才出头部编辑 / 拒绝 / 引用图标栏 + anchor 行的草稿状态 / 关闭态。
+  // Actionable code-type findings (/review code-feedback, /improve code-suggestion with an anchor line number):
+  // only these show the header edit / reject / reference icon bar + the anchor row's draft status / closed state.
   const isActionableCode =
     (key === 'code-feedback' || key === 'code-suggestion') &&
     finding.anchor?.startLine !== undefined;
-  // 默认折叠：已拒绝 / 被复评关闭 finding，或 /ask「分析过程」段（过程性讨论默认收起、可展开）。
+  // Collapsed by default: rejected / re-review-closed findings, or the /ask "analysis process" segment (process discussion collapsed by default, expandable).
   const collapsibleByDefault = isRejected || isClosed || key === 'ask-analysis';
   const [expanded, setExpanded] = useState(false);
   const collapsed = collapsibleByDefault && !expanded;
   const label = sectionLabel(key, t);
-  // 标题在已知 sectionKey 上**通常**跟 chip label 内容重复 (h4 显示 "PR Type" + chip
-  // 显示 "类型")，所以默认只有 general 段才出 title。但 pr-agent 把若干段的"值"放在
-  // 标题里 (e.g., `Estimated effort to review: 3 🔵🔵🔵⚪⚪` / `Score: 85 🟢🟢...`)，
-  // body 是空的；这种情况强制把 title 渲染出来，否则卡片只剩 chip 一片空白。
-  // 先剥 [file:...] 末尾 marker (pr-agent /review 的 anchor 注入用，用户不可见)
-  // 再走 pr-agent 模板翻译。bodyEmpty 也按 stripped 后判断
+  // On a known sectionKey the title **usually** duplicates the chip label content (h4 shows "PR Type" + chip
+  // shows "类型"), so by default only the general segment shows the title. But pr-agent puts some segments' "values"
+  // in the title (e.g., `Estimated effort to review: 3 🔵🔵🔵⚪⚪` / `Score: 85 🟢🟢...`),
+  // with an empty body; in this case force the title to render, otherwise the card is left with just the chip and blank space.
+  // First strip the trailing [file:...] marker (used for pr-agent /review's anchor injection, invisible to the user)
+  // then run pr-agent template translation. bodyEmpty is also judged after stripping
   const strippedBody = stripFindingMarker(finding.body);
   const bodyEmpty = !strippedBody.trim();
   const showTitle = !!finding.title && (key === 'general' || bodyEmpty);
-  // pr-agent 把若干 section 标题 / 固定模板字符串硬编码成英文 (CONFIG__RESPONSE_LANGUAGE
-  // 只翻译 LLM 内容值)，渲染前替换成中文。工作量已用 emoji 圆点表分值，去掉冗余的数字分数。
+  // pr-agent hard-codes some section titles / fixed template strings in English (CONFIG__RESPONSE_LANGUAGE
+  // only translates LLM content values), replaced with Chinese before rendering. Effort already uses emoji dots for the score value, so drop the redundant numeric score.
   const translatedBody =
     key === 'effort'
       ? stripEffortScoreNumber(translatePrAgentLabels(strippedBody))
@@ -253,15 +254,15 @@ export function FindingCard({
     : undefined;
   return (
     <li
-      // data-finding-id：供复评卡顶部引用徽标点击后在原 run 内精确定位到这条原 finding 卡片并闪烁高亮。
+      // data-finding-id: lets the reference badge at the top of the re-review card, when clicked, precisely locate this original finding card within the original run and flash-highlight it.
       data-finding-id={finding.id}
       className={`chat-finding chat-finding-${key}${isRejected || isClosed ? ' chat-finding-rejected' : ''}${collapsed ? ' chat-finding-collapsed' : ''}`}
     >
       <header
         className={`chat-finding-head${collapsibleByDefault ? ' chat-finding-head-toggle' : ''}`}
-        // 可折叠卡（分析过程 / 已拒绝 / 被复评关闭的代码反馈）：整行标题区即展开/收起热区，扩大可点面积。
-        // 忽略来自内部按钮（编辑/拒绝/引用/chevron）的点击——它们各自处理、不应误触折叠（chevron 的
-        // 点击经此处冒泡，由它自身的 onClick 处理一次即可，故 closest('button') 命中时直接跳过）。
+        // Collapsible cards (analysis process / rejected / re-review-closed code feedback): the whole title row is the expand/collapse hot zone, enlarging the clickable area.
+        // Ignore clicks from inner buttons (edit/reject/reference/chevron) — they handle themselves and should not accidentally trigger collapse (the chevron's
+        // click bubbles through here, its own onClick handles it once, so skip directly when closest('button') hits).
         onClick={
           collapsibleByDefault
             ? (e) => {
@@ -271,13 +272,13 @@ export function FindingCard({
             : undefined
         }
       >
-        {/* 已知 sectionKey 用中文标签 chip；general / 未知不显示，避免 UI 噪音 */}
+        {/* Known sectionKey uses a Chinese label chip; general / unknown are not shown, avoiding UI noise */}
         {label && (
           <span className={`chat-chip chat-chip-md chat-finding-cat chat-chip-${CAT_TONE[key]}`}>
             {label}
           </span>
         )}
-        {/* PR Type 段：值胶囊与「类型」标签同排、右对齐（不再上下两排，提升空间利用率） */}
+        {/* PR Type segment: value pills on the same row as the "type" label, right-aligned (no longer two stacked rows, improving space utilization) */}
         {key === 'pr-type' && (
           <div className="chat-finding-pills chat-finding-pills-inline">
             {splitTypeLabels(translatedBody).map((t) => (
@@ -292,8 +293,8 @@ export function FindingCard({
             <MdInline>{translatedTitle}</MdInline>
           </h4>
         )}
-        {/* 头部操作图标栏：编辑（评论）/ 拒绝（圆形禁止）/ 引用（转发箭头）。仅可锚定的 code 类
-            finding 且未被复评关闭时出现，排在折叠 chevron 之左；与标题同排、右上角成组。 */}
+        {/* Header action icon bar: edit (comment) / reject (circular ban) / reference (forward arrow). Appears only for anchorable code-type
+            findings not closed by a re-review, ordered to the left of the collapse chevron; on the same row as the title, grouped in the top-right. */}
         {isActionableCode && !isClosed && (onJump || onReject || onReference) && (
           <FindingHeadActions
             relatedDraft={relatedDraft}
@@ -302,7 +303,7 @@ export function FindingCard({
             onReference={onReference}
           />
         )}
-        {/* 可默认折叠的段（已拒绝 / ask 分析过程）出现展开 / 收起切换：chevron 收起态指右、展开态转下 */}
+        {/* Segments collapsible by default (rejected / ask analysis process) get an expand / collapse toggle: chevron points right when collapsed, turns down when expanded */}
         {collapsibleByDefault && (
           <button
             type="button"
@@ -317,7 +318,7 @@ export function FindingCard({
       {finding.anchor && (
         <div className="chat-finding-anchor muted">
           {finding.anchor.startLine !== undefined && onNavigate ? (
-            // 可点击：跳转到 Diff 对应行（scroll+highlight，不进编辑态）
+            // Clickable: jump to the corresponding Diff line (scroll+highlight, does not enter edit state)
             <button
               type="button"
               className="chat-finding-anchor-link"
@@ -349,7 +350,7 @@ export function FindingCard({
               )}
             </>
           )}
-          {/* /improve 建议带的 1-10 重要度评分；高分加 warning 着色提示 reviewer */}
+          {/* The 1-10 importance score carried by /improve suggestions; high scores get warning coloring to alert the reviewer */}
           {typeof finding.score === 'number' && (
             <span
               className={`chat-finding-score${finding.score >= 8 ? ' chat-finding-score-high' : ''}`}
@@ -358,8 +359,8 @@ export function FindingCard({
               {finding.score}/10
             </span>
           )}
-          {/* M4 草稿状态 chip / 复评关闭态：锚到具体行的代码类 finding 才展示（操作按钮已上移到头部
-              图标栏）。仅在有草稿状态或被复评关闭时出现，否则不占位。 */}
+          {/* M4 draft status chip / re-review closed state: only shown for code-type findings anchored to a specific line (action buttons
+              have been moved up to the header icon bar). Appears only when there is a draft status or it is closed by a re-review, otherwise takes no space. */}
           {isActionableCode && (isClosed || relatedDraft?.status) && (
             <FindingDraftActions
               relatedDraft={relatedDraft}
@@ -369,30 +370,30 @@ export function FindingCard({
           )}
         </div>
       )}
-      {/* 可折叠内容（正文 + 代码对比）：grid-rows 0fr↔1fr 平滑收展（auto 高度可动画）。内容始终挂载，
-          由 CSS 按 .chat-finding-collapsed 收起、inner overflow:hidden 裁切——故折叠/展开有高度过渡动画。
-          pr-type 的值胶囊已并入头部行、无正文段；无 codeChange 时整体不渲染。 */}
+      {/* Collapsible content (body + code comparison): grid-rows 0fr↔1fr for smooth collapse/expand (auto height can be animated). Content is always mounted,
+          collapsed by CSS via .chat-finding-collapsed with inner overflow:hidden clipping — hence the height transition animation on collapse/expand.
+          pr-type's value pills have been merged into the header row, no body segment; when there is no codeChange the whole thing does not render. */}
       {(key !== 'pr-type' || finding.codeChange) && (
         <div className="chat-finding-collapsible">
           <div className="chat-finding-collapsible-inner">
             {key !== 'pr-type' && (
               <div className="chat-finding-body markdown">
-                {/* remarkBreaks 把 finding body 里的单换行也当成 <br>。pr-agent 的 trace、
-                    或一般段落里 reviewer 习惯按软换行折行，不加 remarkBreaks 会被 markdown
-                    合并成长一行。Findings 主要是富文本说明，不存在"故意软换行连接"的场景 */}
+                {/* remarkBreaks treats single line breaks in the finding body as <br> too. In pr-agent's trace,
+                    or in general paragraphs where reviewers habitually wrap by soft line breaks, without remarkBreaks markdown
+                    would merge them into one long line. Findings are mainly rich-text descriptions, there is no "deliberate soft-break joining" scenario */}
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm, remarkBreaks]}
                   rehypePlugins={REMOTE_REHYPE_PLUGINS}
-                  // 「文件变更」walkthrough 用去掉 <details open> 的覆盖，使各文件分类默认折叠收起。
-                  // 两套均叠加「<summary> 内联 markdown」（折叠标题支持 `代码` 等预格式化）。
+                  // The "file changes" walkthrough uses an override without <details open>, so each file category is collapsed by default.
+                  // Both sets add "<summary> inline markdown" on top (collapsible titles support preformatting like `code`).
                   components={key === 'walkthrough' ? WALKTHROUGH_MD_COMPONENTS : DEFAULT_MD_COMPONENTS}
                 >
                   {translatedBody}
                 </ReactMarkdown>
               </div>
             )}
-            {/* /improve 给的 existing → improved 代码对比。两段都是片段，独立 <pre> 块
-                + 红/绿背景 模拟 diff 视觉 (不用 Monaco DiffEditor 节省开销) */}
+            {/* The existing → improved code comparison given by /improve. Both are fragments, independent <pre> blocks
+                + red/green background to mimic the diff visual (not using Monaco DiffEditor, saving overhead) */}
             {finding.codeChange && (
               <div className="chat-finding-code-change">
                 {finding.codeChange.existing && (

--- a/apps/desktop/src/renderer/src/components/features/chat/components/PlanPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/PlanPanel.tsx
@@ -2,8 +2,9 @@ import { useTranslation } from 'react-i18next';
 import type { AgentTodoItem } from '@meebox/shared';
 
 /**
- * 规划 Agent 的计划面板：展示当前 todo（勾选 = 已完成）。运行中据 agent:planUpdated 实时刷新、随新输入
- * 重排；切 PR / 重启经 agent:getSession 水合。空计划不渲染。
+ * Plan panel for the planning Agent: shows the current todo (checked = done). Refreshes live from
+ * agent:planUpdated while running, reorders with new input; hydrates via agent:getSession on PR switch /
+ * restart. Empty plan is not rendered.
  */
 export function PlanPanel({ todo }: { todo: AgentTodoItem[] }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/chat/components/QueuedView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/QueuedView.tsx
@@ -5,8 +5,8 @@ import { CloseIcon } from '../../../common';
 import { AskQuestion } from './shared';
 
 /**
- * 排队中的任务卡片：贴在运行中之后，按队列顺序展示 tool / 位置 / (ask 的提问)，
- * 提供单条取消。跟 RunningView / RunMeta 共用 chat-run-meta 骨架，视觉一致。
+ * Queued task card: sits after the running one, showing tool / position / (ask's question) in queue order,
+ * with per-item cancel. Shares the chat-run-meta skeleton with RunningView / RunMeta for visual consistency.
  */
 export function QueuedView({
   tool,

--- a/apps/desktop/src/renderer/src/components/features/chat/components/RulePreviewModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/RulePreviewModal.tsx
@@ -9,8 +9,9 @@ import { invoke } from '../../../../api';
 import type { MatchedRules } from '../types';
 
 /**
- * 命中规则预览。单条沿用「Rule: <id>」标题；多条时标题改为计数，正文按 `Ruleset N` 分段逐条列出
- * （与评审注入的拼接口径一致），让用户确认本次 review 会被哪些规约约束。
+ * Matched rule preview. A single match keeps the「Rule: <id>」title; multiple matches switch the title to a
+ * count and list each in the body split by `Ruleset N` (matching the review injection's concatenation),
+ * letting the user confirm which rules will constrain this review.
  */
 export function RulePreviewModal({
   rules,
@@ -53,7 +54,7 @@ export function RulePreviewModal({
           )}
           <div className="modal-kv">
             <div className="modal-kv-key">{t('chatPane.ruleFilePath')}</div>
-            {/* 相对 Agent 目录展示（`rules/<id>`），避免暴露冗长的机器绝对路径；打开目录按钮在标题栏统一提供。 */}
+            {/* Shown relative to the Agent dir (`rules/<id>`), to avoid exposing the long machine absolute path; the open-dir button is provided uniformly in the title bar. */}
             <div className="modal-kv-val">
               <code>rules/{rule.id}</code>
             </div>

--- a/apps/desktop/src/renderer/src/components/features/chat/components/RunResultView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/RunResultView.tsx
@@ -11,8 +11,8 @@ import { FindingCard } from './FindingCard';
 function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
   const { t } = useTranslation();
   const duration = run.durationMs ? `${(run.durationMs / 1000).toFixed(1)}s` : '—';
-  // 优先用 run.tokenUsage（litellm callback 捕获的 API 真实 usage，见 sitecustomize）；
-  // 历史 run 没这字段时回退到从 stdout 抓取的旧估算，保持向后兼容。
+  // Prefer run.tokenUsage (the real API usage captured by the litellm callback, see sitecustomize);
+  // fall back to the old estimate scraped from stdout when historical runs lack this field, for backward compatibility.
   const usage: TokenUsage = run.tokenUsage
     ? {
         prompt: run.tokenUsage.promptTokens,
@@ -30,8 +30,8 @@ function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
       <span className={`chat-chip chat-run-status chat-run-status-${run.status}`}>
         {runStatusLabel(run.status, t)}
       </span>
-      {/* 单 commit 评审范围徽标：本次 run 限定在某 commit 自身改动（parent..sha）时展示短 SHA；
-          全量 PR 范围（无 scope）不渲染。 */}
+      {/* Single-commit review scope badge: shows the short SHA when this run is limited to a commit's own changes (parent..sha);
+          not rendered for full PR scope (no scope). */}
       {run.scope && (
         <span
           className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-scope"
@@ -41,8 +41,8 @@ function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
           {run.scope.abbreviatedSha}
         </span>
       )}
-      {/* 模型 chip 取代运行时策略 chip — strategy 是部署细节用户不
-          关心，model 是真正影响 review 质量的变量 */}
+      {/* Model chip replaces the runtime strategy chip — strategy is a deployment detail users don't
+          care about, model is the variable that actually affects review quality */}
       {run.model && (
         <span
           className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-model"
@@ -51,7 +51,7 @@ function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
           {run.model}
         </span>
       )}
-      {/* 输入(↑绿)[⛁缓存]/输出(↓红)：输入输出各自独立 hover；缓存为输入一部分、无命中不显示。旧 run 可能只有 prompt */}
+      {/* input(↑green)[⛁cache]/output(↓red): input and output each hover independently; cache is part of input, hidden on no match. Old runs may have only prompt */}
       {usage.prompt !== undefined || usage.completion !== undefined ? (
         <span className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-tokens">
           <TokenStat
@@ -61,7 +61,7 @@ function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
           />
         </span>
       ) : null}
-      {/* 模型交互轮次：循环箭头图标 + 次数（取代「N 轮」文案，省空间 / 免复数）；仅多轮(agentic) 时展示 */}
+      {/* Model interaction turns: loop arrow icon + count (replaces the「N turns」text, saving space / avoiding plurals); shown only for multi-turn (agentic) */}
       {usage.turns !== undefined && usage.turns > 1 ? (
         <span
           className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-turns"
@@ -74,15 +74,15 @@ function RunMeta({ run, onDelete }: { run: ReviewRun; onDelete: () => void }) {
       <span className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-duration">
         {duration}
       </span>
-      {/* 开始时间：纯文本不带胶囊背景，margin-left:auto 顶到最右 — 跟左侧
-          tool/status/strategy chip 拉开距离，视觉权重比 chip 轻一档 */}
+      {/* Start time: plain text with no pill background, margin-left:auto pushes it to the far right — spaced apart from the left-side
+          tool/status/strategy chips, one visual weight lighter than a chip */}
       <span
         className="chat-run-time"
         title={t('chatPane.startedAtTitle', { time: new Date(run.startedAt).toLocaleString() })}
       >
         {formatStartTime(run.startedAt)}
       </span>
-      {/* 删除本条 run 记录：状态行最右的小垃圾桶按钮（仅删该 run，不影响其它记录 / 徽标）。 */}
+      {/* Delete this run record: the small trash button at the far right of the status row (deletes only this run, no effect on other records / badges). */}
       <button
         type="button"
         className="chat-run-delete"
@@ -112,45 +112,45 @@ export function RunResultView({
 }: {
   run: ReviewRun;
   onRetry: (run: ReviewRun) => void;
-  /** 删除本条 run 记录（仅该 run）。 */
+  /** Delete this run record (this run only). */
   onDelete: (runId: string) => void;
-  /** 由父组件按"最后一条 + 无活动 run"判定；false 时失败 / 取消 run 也不显示重试键 */
+  /** Determined by the parent as "last one + no active run"; when false, failed / cancelled runs also don't show the retry button */
   canRetry: boolean;
-  /** 本 PR 当前草稿池快照；FindingCard 据此显示 status chip + 决定 reject 行为 */
+  /** Snapshot of this PR's current draft pool; FindingCard uses it to show the status chip + decide reject behavior */
   drafts: ReadonlyArray<ReviewDraft>;
-  /** 本 PR 的 finding 关闭关系快照（只读）；据 (run.id,finding.id) 反查复评关闭态，标注只读 chip。 */
+  /** Snapshot of this PR's finding closure relations (read-only); looks up the review-closed state by (run.id,finding.id), marking the read-only chip. */
   closures: ReadonlyArray<FindingClosure>;
-  /** 点击 finding card 上"→ 跳到代码编辑"时触发。父组件做懒创建 + 跳转 */
+  /** Fired when clicking "→ jump to code edit" on a finding card. The parent does lazy creation + jump */
   onJumpToDraft: (finding: Finding, run: ReviewRun) => void;
-  /** 拒绝某条 finding：创建 / 更新草稿到 status='rejected' */
+  /** Reject a finding: create / update a draft to status='rejected' */
   onRejectFinding: (finding: Finding, run: ReviewRun) => void;
-  /** 点击 finding 锚点：仅导航到 Diff 对应行（不进编辑态） */
+  /** Click a finding anchor: only navigate to the corresponding Diff line (no edit mode) */
   onNavigateToFinding: (finding: Finding) => void;
-  /** 「引用」一条 code finding 发起复评 /ask（挂到输入栏）。 */
+  /** 「Reference」a code finding to start a re-review /ask (attach to the input bar). */
   onReferenceFinding: (finding: Finding, run: ReviewRun) => void;
-  /** 滚动定位到指定 run 卡片（复评关闭态「查看复评」→ 关闭它的 ask run）。 */
+  /** Scroll to a given run card (review-closed state「view re-review」→ the ask run that closed it). */
   onScrollToRun: (runId: string) => void;
-  /** 滚动定位到指定 run 内的某条 finding 卡片并闪烁高亮（复评卡顶部引用徽标 → 原 finding 卡）。 */
+  /** Scroll to a given finding card within a run and flash-highlight it (reference badge at the top of the re-review card → original finding card). */
   onScrollToFinding: (runId: string, findingId: string) => void;
 }) {
   const { t } = useTranslation();
   const findings = run.findings ?? [];
-  // 失败 + 取消都用红 banner 提示。取消是用户主动行为，UI 用更轻文案区分
+  // Both failed + cancelled use a red banner. Cancel is a deliberate user action, so the UI distinguishes it with lighter wording
   const isFailed = run.status === 'failed';
   const isCancelled = run.status === 'cancelled';
   const isFailedOrCancelled = isFailed || isCancelled;
   const stdout = run.stdout ?? '';
-  // "原始输出" 折叠区独立 per-run 维护状态，互不影响。失败 / 取消默认展开方便排障，
-  // 成功默认关闭只是诊断兜底
+  // The "raw output" collapse region maintains per-run state independently, unaffecting each other. Failed / cancelled default to expanded for easier troubleshooting,
+  // success defaults to closed as just a diagnostic fallback
   const [showRawStdout, setShowRawStdout] = useState(isFailedOrCancelled);
-  // /ask 工具：把用户提问展示在 meta 行**下方**，跟 /ask 这个动作绑成一组；
-  // 上方再放用户气泡会跟 meta 行重复信息源，移到动作下方更符合"动作 → 输入"语序
+  // /ask tool: show the user's question **below** the meta row, grouped with the /ask action;
+  // putting a user bubble above would duplicate the meta row's info source, moving it below the action better fits the "action → input" order
   const userMessage = run.tool === 'ask' ? run.question?.trim() : undefined;
   return (
     <div className="chat-run-result">
       <RunMeta run={run} onDelete={() => onDelete(run.id)} />
-      {/* 复评 /ask：顶部引用定位徽标（转发箭头 + 完整路径:行号），点击滚动定位到被引用的原 finding 所在 run。
-          直接显示完整定位信息（不再用「复评自」文案，省 i18n）；路径换行规则同代码建议定位（BreakablePath 软断点）。 */}
+      {/* Re-review /ask: top reference-locator badge (forward arrow + full path:line), click to scroll to the run of the referenced original finding.
+          Shows the full locator info directly (no more「re-reviewed from」text, saving i18n); path wrapping follows code-suggestion location (BreakablePath soft break points). */}
       {run.referencedFinding && (
         <button
           type="button"
@@ -180,8 +180,8 @@ export function RunResultView({
         </button>
       )}
       {userMessage && <AskQuestion text={userMessage} />}
-      {/* 原始输出：始终紧跟 meta 行，让用户在任何状态下都能在固定位置找到日志。
-          失败 / 取消默认展开，成功默认收起 */}
+      {/* Raw output: always right after the meta row, so users can find logs in a fixed position in any state.
+          Failed / cancelled default to expanded, success defaults to collapsed */}
       {stdout.length > 0 && (
         <details
           className="chat-run-raw"
@@ -204,8 +204,8 @@ export function RunResultView({
                 : run.errorReason
                   ? t('chatPane.runFailedReason', { reason: run.errorReason })
                   : t('chatPane.runFailed')}
-            {/* llm-error 时 exitCode 是 0 (pr-agent 自己 catch 了)，显示出来反而
-                让用户误以为没出错，所以跳过 */}
+            {/* On llm-error the exitCode is 0 (pr-agent caught it itself), showing it would instead
+                mislead users into thinking nothing went wrong, so skip it */}
             {run.exitCode != null &&
               !isCancelled &&
               run.errorReason !== 'llm-error' &&
@@ -229,28 +229,28 @@ export function RunResultView({
           {run.errorMessage && !isCancelled && (
             <pre className="chat-error-detail">{run.errorMessage}</pre>
           )}
-          {/* 失败 / 取消不再单独展示输出区块：pr-agent 日志已在上方可折叠的「原始输出」（stdout 含
-              [pr-agent stdout log] 段，与 stderr 同源），避免同一份日志重复成两块。 */}
+          {/* Failed / cancelled no longer show a separate output block: the pr-agent log is already in the collapsible「raw output」above (stdout contains
+              the [pr-agent stdout log] segment, same source as stderr), avoiding duplicating the same log into two blocks. */}
         </div>
       )}
 
-      {/* 失败 / 取消不渲染 findings：取消的 /describe 会把部分 stdout 解析成「段落」误当结果展示。
-          失败 / 取消统一只保留上方可折叠的「原始输出」+ 状态横幅，不在下方另起输出区块。 */}
+      {/* Failed / cancelled don't render findings: a cancelled /describe would parse part of stdout into「paragraphs」and mistakenly show them as results.
+          Failed / cancelled uniformly keep only the collapsible「raw output」above + the status banner, not opening another output block below. */}
       {!isFailedOrCancelled &&
         (findings.length > 0 ? (
           <ul className="chat-finding-list">
             {orderFindings(findings).map((f) => {
-              // 同 run 内 finding 跟草稿一对一：source.runId+findingId 反查。命中后
-              // FindingCard 据此显示状态 chip + 跳转/拒绝按钮行为分支
+              // Findings within the same run map one-to-one to drafts: looked up by source.runId+findingId. On match,
+              // FindingCard uses it to show the status chip + branch the jump/reject button behavior
               const relatedDraft = drafts.find(
                 (d) =>
                   d.source !== undefined &&
                   d.source.runId === run.id &&
                   d.source.findingId === f.id,
               );
-              // 复评关闭态（只读）：该 finding 被复评 /ask 裁决 replace/drop 自动关闭时反查到。
+              // Review-closed state (read-only): looked up when this finding was auto-closed by a re-review /ask ruling replace/drop.
               const closure = closures.find((c) => c.runId === run.id && c.findingId === f.id);
-              // 「引用」仅对可锚定的 code 类 finding（review/improve）提供——它们才是可被复评的代码评论。
+              // 「Reference」is only offered for anchorable code-type findings (review/improve) — they are the code comments that can be re-reviewed.
               const canReference =
                 (f.sectionKey === 'code-feedback' || f.sectionKey === 'code-suggestion') &&
                 typeof f.anchor?.startLine === 'number';

--- a/apps/desktop/src/renderer/src/components/features/chat/components/RunningView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/RunningView.tsx
@@ -16,25 +16,25 @@ export function RunningView({
 }: {
   tool: ReviewRunTool;
   runId: string;
-  /** /ask 的提问：执行中也直接展示（与排队 / 完成态一致；问题在派发时已生成）。 */
+  /** /ask's question: shown directly while running too (consistent with queued / done state; the question was generated at dispatch). */
   question?: string;
-  /** 单 commit 评审范围（parent..sha）；限定在某 commit 时展示范围徽标，与完成态卡片一致。 */
+  /** Single-commit review scope (parent..sha); shows the scope badge when limited to a commit, consistent with the done-state card. */
   scope?: ReviewRunCommitScope;
   lines: ReadonlyArray<string>;
   startedAt: number;
-  /** 当前 active LLM profile.model — 跟 RunMeta 同源放在 chip 行，让 running
-      跟 succeeded 视觉一致；可选 (无 active profile 时不显示) */
+  /** The current active LLM profile.model — placed in the chip row from the same source as RunMeta, keeping running
+      visually consistent with succeeded; optional (not shown when there's no active profile) */
   model: string | null;
 }) {
   const { t } = useTranslation();
-  // 末行追加时自动滚到底
+  // Auto-scroll to bottom when the last line is appended
   const ref = useRef<HTMLPreElement | null>(null);
   useEffect(() => {
     const el = ref.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [lines.length]);
 
-  // 计时器：pr-agent stdout 长间隔时让用户感知到不是卡死。1s 粒度即可
+  // Timer: lets users perceive it isn't stuck during long gaps in pr-agent stdout. 1s granularity is enough
   const [elapsedMs, setElapsedMs] = useState(0);
   useEffect(() => {
     setElapsedMs(Date.now() - startedAt);
@@ -45,9 +45,9 @@ export function RunningView({
   const phase = useMemo(() => inferPhase(lines, t), [lines, t]);
   const text = useMemo(() => lines.join('\n'), [lines]);
 
-  // 跟 RunMeta 完全同结构的 chip 行。running 跟 succeeded/failed 共享一套视觉
-  // 骨架，用户从列表扫一眼能在固定位置看到 tool / 状态 / 模型 / 时长。strategy
-  // 运行时策略是部署细节用户不关心，撤掉；model 是真正影响 review 质量的变量
+  // A chip row structurally identical to RunMeta. running shares one visual
+  // skeleton with succeeded/failed, so a glance down the list shows tool / status / model / duration in fixed positions. strategy
+  // runtime strategy is a deployment detail users don't care about, removed; model is the variable that actually affects review quality
   return (
     <div className="chat-run-running" data-run-id={runId}>
       <header className="chat-run-meta">
@@ -56,7 +56,7 @@ export function RunningView({
           <Spinner />
           {runStatusLabel('running', t)}
         </span>
-        {/* 单 commit 范围徽标：与完成态 RunMeta 一致，让运行中也能看到本次限定的提交。 */}
+        {/* Single-commit scope badge: consistent with the done-state RunMeta, so the limited commit is visible while running too. */}
         {scope && (
           <span
             className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-scope"
@@ -77,8 +77,8 @@ export function RunningView({
         <span className="chat-chip chat-chip-quiet chat-chip-neutral chat-run-duration">
           {formatElapsed(elapsedMs)}
         </span>
-        {/* 开始时间：跟 RunMeta 同模 — 纯文本右对齐，让 running 跟 succeeded
-            两态最右侧元素位置稳定 */}
+        {/* Start time: same pattern as RunMeta — plain text right-aligned, keeping the far-right element's position stable
+            across the running and succeeded states */}
         <span
           className="chat-run-time"
           title={t('chatPane.startedAtTitle', { time: new Date(startedAt).toLocaleString() })}
@@ -86,14 +86,14 @@ export function RunningView({
           {formatStartTime(startedAt)}
         </span>
       </header>
-      {/* /ask 的提问执行中也直接展示（问题已生成，不必等排队 / 完成才可见）。 */}
+      {/* /ask's question is shown directly while running too (the question is already generated, no need to wait for queued / done to be visible). */}
       {tool === 'ask' && question?.trim() && <AskQuestion text={question.trim()} />}
       {phase && (
         <div className="chat-chip chat-chip-md chat-chip-quiet chat-chip-accent chat-run-phase">
           {phase}
         </div>
       )}
-      {/* 控制台输出：执行中默认折叠收起、可手动展开（与完成态「原始输出」同款折叠效果）。 */}
+      {/* Console output: collapsed by default while running, manually expandable (same collapse effect as the done-state「raw output」). */}
       <details className="chat-run-raw">
         <summary>{t('chatPane.rawOutput', { n: text.length })}</summary>
         <AnsiPre

--- a/apps/desktop/src/renderer/src/components/features/chat/components/shared.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/components/shared.tsx
@@ -21,7 +21,7 @@ export function Bullet({ children }: { children: ReactNode }) {
   );
 }
 
-/** chat 区统一的 markdown 渲染（与 finding 卡片同套 remark/rehype 配置）。 */
+/** Unified markdown rendering for the chat area (same remark/rehype config as finding cards). */
 export function Md({ children }: { children: string }) {
   return (
     <ReactMarkdown
@@ -34,10 +34,10 @@ export function Md({ children }: { children: string }) {
   );
 }
 
-/** 行内 markdown：用于标题等单行文本，渲染内联代码 / 强调，去掉块级 <p> 包裹保持行内排版。 */
+/** Inline markdown: for single-line text such as titles, rendering inline code / emphasis, dropping the block-level <p> wrapper to keep inline layout. */
 export function MdInline({ children }: { children: string }) {
-  // 标题以「2. 」「- 」这类列表标记开头时，markdown 会把它解析成 <ol>/<ul> 块塞进 <h4>，撑破内联布局
-  // 并溢出。转义行首列表标记，按字面渲染序号 / 符号（保留文字），不再生成列表块。
+  // When a title starts with a list marker like "2. " or "- ", markdown parses it into an <ol>/<ul> block stuffed into <h4>, breaking the inline layout
+  // and overflowing. Escape leading list markers to render the number / symbol literally (keeping the text), no longer generating a list block.
   const inlineSafe = children
     .replace(/^(\s*)(\d+)\.(\s)/, '$1$2\\.$3')
     .replace(/^(\s*)([-*+])(\s)/, '$1\\$2$3');
@@ -53,9 +53,9 @@ export function MdInline({ children }: { children: string }) {
 }
 
 /**
- * `<summary>` 内联 markdown 渲染：raw HTML 的折叠标题（如「思路建议」各方案的 <details><summary>）内的
- * 文本不会被 markdown 二次解析，反引号 / 强调等会原样漏出。这里把其纯文本走 {@link MdInline}，让标题里的
- * `代码` / **强调** 生效。children 多为纯文本串；含非文本节点时原样渲染兜底。
+ * `<summary>` inline markdown rendering: text inside raw-HTML collapse titles (e.g. the <details><summary> of each option under "suggestions")
+ * is not re-parsed by markdown, so backticks / emphasis leak through verbatim. Here we route its plain text through {@link MdInline}, so that
+ * `code` / **emphasis** in the title take effect. children is usually a plain-text string; falls back to rendering verbatim when it contains non-text nodes.
  */
 const SummaryInlineMd: Components['summary'] = ({ children }) => {
   const text =
@@ -73,14 +73,14 @@ const SummaryInlineMd: Components['summary'] = ({ children }) => {
   );
 };
 
-/** 在给定 markdown components 之上叠加「<summary> 内联 markdown」渲染（折叠标题支持 md 预格式化）。 */
+/** Layer "<summary> inline markdown" rendering on top of the given markdown components (collapse titles support md pre-formatting). */
 export function withInlineSummary(base: Components): Components {
   return { ...base, summary: SummaryInlineMd };
 }
 
 /**
- * 代码路径折行优化：在分隔符 `/` 与连接符 `.` `_` `-` 之后插入 <wbr> 软断点，配合 CSS
- * `word-break: normal`，让长路径优先按这些字符折断（而非从单词中间断开），保证可读性。
+ * Code-path line-break optimization: insert <wbr> soft break points after the separator `/` and the connectors `.` `_` `-`, combined with CSS
+ * `word-break: normal`, so long paths preferentially break at these characters (rather than mid-word), ensuring readability.
  */
 export function BreakablePath({ path }: { path: string }) {
   const parts = path.split(/(?<=[/._-])/);
@@ -92,7 +92,7 @@ export function BreakablePath({ path }: { path: string }) {
   return <>{nodes}</>;
 }
 
-/** 把含 ANSI 转义的 stdout 文本渲染成带颜色的 <pre>。空文本时显示占位 */
+/** Render ANSI-escaped stdout text into a colored <pre>. Shows a placeholder when the text is empty */
 export function AnsiPre({
   className,
   text,
@@ -124,9 +124,9 @@ export function AnsiPre({
 }
 
 /**
- * Token 用量内联展示：↑输入(绿) [⛁缓存命中] / ↓输出(红)。输入、输出**各自独立 hover 提示**；
- * 缓存命中(cache_read)为输入的一部分，柱体图标拆分展示（间距在 cache 前，无命中时整段不渲染、不留空），
- * 悬浮另给说明。run 卡片(RunMeta) 与思考步骤(AgentStep) 共用；分隔符按上下文传入（chip 内 ` / `、步骤行空格）。
+ * Inline token-usage display: ↑input(green) [⛁cache hit] / ↓output(red). Input and output **each get their own hover tooltip**;
+ * the cache hit (cache_read) is part of the input, shown split out with a bar icon (spacing before cache, the whole segment not rendered and leaving no gap when there's no hit),
+ * with its own tooltip on hover. Shared by the run card (RunMeta) and the thinking step (AgentStep); the separator is passed by context (` / ` inside a chip, a space on step rows).
  */
 export function TokenStat({
   prompt,
@@ -169,7 +169,7 @@ export function TokenStat({
   );
 }
 
-/** /ask 提问行：问号图标 + markdown 渲染的提问内容（Agent 自拟的追问常含内联代码 / 列表）。 */
+/** /ask question row: a question-mark icon + markdown-rendered question content (the Agent's self-composed follow-up asks often contain inline code / lists). */
 export function AskQuestion({ text }: { text: string }) {
   const { t } = useTranslation();
   return (

--- a/apps/desktop/src/renderer/src/components/features/chat/constants.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/constants.ts
@@ -1,9 +1,9 @@
 export const CHAT_MIN_WIDTH = 280;
 export const CHAT_MAX_WIDTH = 720;
-/** 历史 run 的分页大小：进入 PR 默认展示最新 N 条，向上滚动到顶端再追加一批 */
+/** Page size for history runs: on entering a PR, show the latest N by default, then append another batch when scrolling to the top */
 export const RUNS_PAGE_SIZE = 10;
 
-/** Agent 建议 verdict → i18n key（chatPane.agent.*）。 */
+/** Agent suggestion verdict → i18n key (chatPane.agent.*). */
 export const VERDICT_LABEL_KEY: Record<string, string> = {
   approve: 'chatPane.agent.verdictApprove',
   needs_work: 'chatPane.agent.verdictNeedsWork',

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatActions.ts
@@ -21,13 +21,13 @@ interface UseChatActionsParams {
   prAgent: PrAgentStatus;
   llmConfigured: boolean;
   prLocalId: string | undefined;
-  /** 本 PR 运行中的活动 run（去重 / 停止全部用）。 */
+  /** Active runs in progress for this PR (used for dedup / stop-all). */
   myActiveRuns: ReadonlyArray<PragentRunInfo>;
-  /** 本 PR 排队中的任务（去重用）。 */
+  /** Queued tasks for this PR (used for dedup). */
   myWaiting: ReadonlyArray<PragentRunInfo>;
-  /** 本 PR 当前草稿池快照；finding ↔ draft 反查。 */
+  /** Current draft pool snapshot for this PR; finding ↔ draft reverse lookup. */
   drafts: ReadonlyArray<ReviewDraft> | null | undefined;
-  // 会话态写入口（由 useChatSession 提供）
+  // Session-state write entry points (provided by useChatSession)
   setError: Dispatch<SetStateAction<string | null>>;
   setRuns: Dispatch<SetStateAction<ReviewRun[]>>;
   setHasMoreOlder: Dispatch<SetStateAction<boolean>>;
@@ -36,7 +36,7 @@ interface UseChatActionsParams {
   setTodo: Dispatch<SetStateAction<AgentTodoItem[]>>;
   currentPrIdRef: MutableRefObject<string | undefined>;
   reloadConversation: (localId: string) => Promise<void>;
-  // 跨组件跳转回调（由 MainPane / App 注入）
+  // Cross-component jump callbacks (injected by MainPane / App)
   onJumpToDraftEditor?: (target: {
     runId: string;
     findingId: string;
@@ -46,9 +46,9 @@ interface UseChatActionsParams {
 }
 
 export interface ChatActions {
-  /** Agent 运行态（自动评审微流程 / 自由规划对话）：记录各 PR 的起跑时刻（localId → since）。 */
+  /** Agent running state (auto-review micro-flow / free-planning conversation): records the start time of each PR (localId → since). */
   runningPrs: Map<string, number>;
-  /** 仅「跑在当前 PR」才在本会话显示运行态 / 思考中。 */
+  /** Only when "running on the current PR" does this session show running / thinking state. */
   agentRunningHere: boolean;
   handleRun: (
     tool: ReviewRunTool,
@@ -70,9 +70,10 @@ export interface ChatActions {
 }
 
 /**
- * ChatPane 的业务动作集合：触发 pr-agent 工具 / 自动评审 / 对话即委派、取消与停止、清空历史、
- * 以及 finding → 草稿的懒创建 / 拒绝 / 导航。并发模型——不同 PR 的 agent 任务可并发 / 排队，仅禁止
- * 对**同一 PR**重复发起；运行态按发起 PR 归属，不串到其它 PR 会话。
+ * ChatPane's set of business actions: trigger pr-agent tools / auto-review / conversation-as-delegation,
+ * cancel and stop, clear history, plus lazy creation / rejection / navigation of finding → draft. Concurrency
+ * model — agent tasks on different PRs can run concurrently / queue; only repeated triggers on the **same PR**
+ * are forbidden; running state belongs to the initiating PR and does not bleed into other PR sessions.
  */
 export function useChatActions(params: UseChatActionsParams): ChatActions {
   const {
@@ -96,21 +97,21 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
   } = params;
   const { t } = useTranslation();
 
-  // 记录**各 PR** 的起跑时刻（localId → since）。不同 PR 的 agent 任务可并发 / 排队，仅禁止对同一 PR 重复发起。
-  // 本地态只承载**用户手动发起**的乐观即时反馈（不等 main 广播回环）；AutoPilot 后台评审不经此处。
+  // Records the start time of **each PR** (localId → since). Agent tasks on different PRs can run concurrently / queue; only repeated triggers on the same PR are forbidden.
+  // Local state only carries the optimistic immediate feedback of **user manual triggers** (does not wait for the main broadcast round-trip); AutoPilot background review does not go through here.
   const [runningPrs, setRunningPrs] = useState<Map<string, number>>(() => new Map());
-  // 编排 Agent 运行中的 PR 集合（含纯思考阶段）——来自 store 的 `agent:runningChanged`，手动与 AutoPilot
-  // 一并计入，是「是否在跑」的权威来源。
+  // Set of PRs with the orchestrating Agent running (including pure thinking phase) — from the store's `agent:runningChanged`, counting both manual and AutoPilot;
+  // it is the authoritative source for "is it running".
   const { agentPrs } = useChatRunStore();
-  // 仅「跑在当前 PR」才在本会话显示运行态 / 思考中；其它 PR 在跑不影响本会话发起（可并发 / 排队）。
-  // 取「本地乐观态 ∪ store 权威态」：手动发起即时点亮（本地），AutoPilot 后台评审经 store 点亮——
-  // 否则后台评审的纯思考阶段（工具 run 跑完后的 judge / 总结）因 agentRunningHere=false 不显示「思考中」。
+  // Only when "running on the current PR" does this session show running / thinking state; other PRs running does not affect triggering in this session (can run concurrently / queue).
+  // Takes "local optimistic state ∪ store authoritative state": manual triggers light up immediately (local), AutoPilot background review lights up via the store —
+  // otherwise the pure thinking phase of background review (judge / summary after the tool run finishes) would not show "thinking" because agentRunningHere=false.
   const agentRunningHere =
     prLocalId !== undefined && (runningPrs.has(prLocalId) || agentPrs.includes(prLocalId));
 
-  // 触发 /describe / /review / /ask。队列模型下 active 非空也允许提交，新 run 进
-  // 队列，main 端先后串行执行。失败抛 banner；成功不需要手动 setRuns，session effect
-  // 会在 active 切换时自动 refresh
+  // Triggers /describe / /review / /ask. Under the queue model, submitting is allowed even when active is non-empty; the new run enters
+  // the queue and main executes them serially in order. Failures throw a banner; success needs no manual setRuns, the session effect
+  // auto-refreshes when active changes
   const handleRun = async (
     tool: ReviewRunTool,
     question?: string,
@@ -119,8 +120,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     scope?: ReviewRun['scope'],
   ): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured) return;
-    // 去重（即时反馈）：同一 PR 同一工具已在执行 / 排队 → 阻止重复触发（main 端亦有
-    // 权威校验兜底）。/ask 每次问题不同、单 commit 范围（scope）是定向动作，均不限制（与后端 dedup 同口径）。
+    // Dedup (immediate feedback): if the same tool for the same PR is already executing / queued → block the repeated trigger (main also has
+    // authoritative validation as a fallback). /ask has a different question each time, and single-commit scope is a targeted action, so neither is restricted (same criteria as backend dedup).
     if (
       tool !== 'ask' &&
       !scope &&
@@ -144,10 +145,10 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     }
   };
 
-  // 一键自动评审：触发 main 的 agent:run（评审微流程）。describe/review/ask 子 run 经既有运行
-  // 队列展示在历史里；收尾评审作为一条 assistant 消息落入多轮对话，完成后重载对话呈现。
+  // One-click auto-review: triggers main's agent:run (review micro-flow). The describe/review/ask sub-runs are shown in history via the existing run
+  // queue; the concluding review lands as an assistant message in the multi-turn conversation, and the conversation is reloaded for display after completion.
   const handleAgentReview = async (): Promise<void> => {
-    // 仅禁止对同一 PR 重复发起；其它 PR 在跑不阻塞（并发 / 排队）。
+    // Only repeated triggers on the same PR are forbidden; other PRs running does not block (concurrent / queued).
     if (!pr || !prAgent.available || !llmConfigured || runningPrs.has(pr.localId)) return;
     const startedId = pr.localId;
     setError(null);
@@ -172,15 +173,15 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     }
   };
 
-  // 自然语言「对话即委派」：交给自由规划 Agent（agent:ask）。用户输入即时 optimistic 回显，
-  // 收尾后以落盘对话（含用户 + 助手消息）整体对齐。
+  // Natural-language "conversation-as-delegation": hand off to the free-planning Agent (agent:ask). User input is echoed optimistically at once,
+  // and after completion aligned wholesale against the persisted conversation (including user + assistant messages).
   const handleAgentAsk = async (question: string, referencedContext?: string): Promise<void> => {
     if (!pr || !prAgent.available || !llmConfigured) return;
     const startedId = pr.localId;
-    // 中途输入（已有 Agent 在跑）走 enqueueMessage，后端不持久化引用上下文 → 该路径不带 ref，
-    // 避免重载对齐时引用块闪烁消失；仅新一轮提问的气泡附带引用上下文。
+    // Mid-flight input (an Agent already running) goes through enqueueMessage; the backend does not persist referenced context → this path carries no ref,
+    // to avoid the reference block flickering away on reload alignment; only the bubble of a new-round ask carries referenced context.
     const enqueueing = runningPrs.has(startedId);
-    // 即时 optimistic 回显用户气泡（运行中 / 新轮都先冒泡，不再静默丢弃中途输入）。
+    // Echo the user bubble optimistically at once (both running / new-round bubble first, no longer silently discarding mid-flight input).
     setMessages((prev) => [
       ...prev,
       {
@@ -190,7 +191,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
         at: new Date().toISOString(),
       },
     ]);
-    // 本 PR 已有 Agent 在跑：不另起一轮，入队到下一主 Agent 周期并入、据最新指令重排（中途输入转向）。
+    // An Agent is already running for this PR: do not start another round; enqueue to be merged into the next main Agent cycle and reordered per the latest instruction (mid-flight input redirect).
     if (enqueueing) {
       try {
         await invoke('agent:enqueueMessage', { localId: startedId, message: question });
@@ -227,9 +228,9 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     }
   };
 
-  // 清空当前 PR 的执行历史（仅该 PR）：删远端记录 + 清本地列表，并一并清掉 Agent 收尾结果 /
-  // 步骤 / 错误横幅（含「已停止 / 失败」提示），避免清空后仍残留陈旧反馈。进行中的 run 不受影响
-  // （在 chatRunStore，跑完会重新落盘）。
+  // Clear this PR's execution history (this PR only): delete remote records + clear the local list, and also clear the Agent conclusion result /
+  // steps / error banner (including "stopped / failed" hints), to avoid stale feedback lingering after clearing. In-progress runs are unaffected
+  // (they live in chatRunStore and are re-persisted on completion).
   const handleClearRuns = async (): Promise<void> => {
     if (!prLocalId) return;
     try {
@@ -245,7 +246,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     }
   };
 
-  // 取消 / 重试 在 store 模型里就是简单两步：cancel 走 IPC，retry 调 handleRun
+  // Cancel / retry are just two simple steps in the store model: cancel goes through IPC, retry calls handleRun
   const handleCancel = async (runId: string): Promise<void> => {
     try {
       await invoke('pragent:cancel', { runId });
@@ -253,8 +254,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
       setError(e instanceof Error ? e.message : String(e));
     }
   };
-  // 删除单条已结束的 run 记录（成功 / 失败 / 取消）：删远端记录后乐观从本地列表移除该条。
-  // 仅删该 run，不动 Agent 会话 / 台账 / 徽标（与「清空」区分）。
+  // Delete a single finished run record (success / failed / cancelled): after deleting the remote record, optimistically remove it from the local list.
+  // Deletes only that run, not touching the Agent session / ledger / badge (distinct from "clear").
   const handleDeleteRun = async (runId: string): Promise<void> => {
     if (!prLocalId) return;
     try {
@@ -264,36 +265,36 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
       setError(e instanceof Error ? e.message : String(e));
     }
   };
-  // 停止本 PR 会话内进行中的全部任务：逐条取消所有活动 run（Agent 并行多选时可能 >1），
-  // 并中止 Agent 编排（abort，阻止其在子任务取消后继续后续步骤）。
+  // Stop all in-progress tasks in this PR session: cancel every active run one by one (may be >1 with Agent parallel multi-select),
+  // and abort the Agent orchestration (abort, preventing it from continuing subsequent steps after sub-tasks are cancelled).
   const handleStopAll = (): void => {
     for (const r of myActiveRuns) void handleCancel(r.runId);
     if (agentRunningHere && prLocalId) void invoke('agent:stop', { localId: prLocalId });
   };
   const handleRetry = (run: ReviewRun): void => {
-    // 重试沿用原 run 的单 commit 范围（若有），保证复跑仍限定同一 commit。
+    // Retry reuses the original run's single-commit scope (if any), ensuring the rerun stays limited to the same commit.
     void handleRun(run.tool, run.question, undefined, undefined, run.scope);
   };
 
   /**
-   * 把 AI finding body 转成草稿初始 body：先 stripFindingMarker 去掉 [file:...]
-   * 末尾 marker，再把 pr-agent GFM 里的内联 HTML 标签归一成 markdown（草稿编辑器是
-   * 纯文本，裸 `<code>`/`<br>` 会露馅），最后加 `[AI 建议]` 前缀 — 让远端 reviewer
-   * 看到时知道这条评论来自 pr-agent
+   * Turns an AI finding body into the draft's initial body: first stripFindingMarker removes the
+   * trailing [file:...] marker, then normalizes inline HTML tags in pr-agent's GFM into markdown (the draft editor is
+   * plain text, so bare `<code>`/`<br>` would leak through), and finally adds the `[AI suggestion]` prefix — so the remote reviewer
+   * knows this comment came from pr-agent
    */
   const buildDraftBodyFromFinding = (body: string): string =>
     `${t('chatPane.aiSuggestionPrefix')} ${htmlInlineToMarkdown(stripFindingMarker(body))}`;
 
   /**
-   * ChatPane finding card 上点"编辑"按钮的处理：
-   * - 已有关联草稿 → 直接 onJumpToDraftEditor，DiffView 打开它
-   * - 没有关联草稿 → 懒创建一条 pending + onJumpToDraftEditor
-   * - 关联草稿是 rejected → update 回 pending (撤销拒绝) + 跳转
+   * Handler for clicking the "Edit" button on a ChatPane finding card:
+   * - Already has an associated draft → directly onJumpToDraftEditor, DiffView opens it
+   * - No associated draft → lazily create a pending one + onJumpToDraftEditor
+   * - Associated draft is rejected → update back to pending (undo rejection) + jump
    */
   const handleJumpToDraft = async (finding: Finding, run: ReviewRun): Promise<void> => {
     if (!pr) return;
     if (!finding.anchor || typeof finding.anchor.startLine !== 'number') {
-      return; // 没 anchor 行号 → 没法变 inline，按钮本不该出现，兜底
+      return; // No anchor line number → cannot become inline; the button should not appear, fallback
     }
     const startLine = finding.anchor.startLine;
     const endLine = finding.anchor.endLine ?? startLine;
@@ -303,7 +304,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     );
     try {
       if (!existing) {
-        // 懒创建：从 finding 拷贝 body 作初始内容；side 默认 'new' (head 侧 inline 评论惯例)
+        // Lazy create: copy the body from the finding as initial content; side defaults to 'new' (head-side inline comment convention)
         await invoke('drafts:create', {
           localId: pr.localId,
           draft: {
@@ -315,7 +316,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
           },
         });
       } else if (existing.status === 'rejected') {
-        // 撤销 reject 决断 → 回到 pending，让用户重新编辑
+        // Undo the reject decision → back to pending, letting the user edit again
         await invoke('drafts:update', {
           localId: pr.localId,
           draftId: existing.id,
@@ -333,7 +334,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActions {
     });
   };
 
-  // 点击 finding 锚点：仅导航到 Diff 对应行（不创建/打开草稿），便于快速核对上下文
+  // Click a finding anchor: only navigate to the corresponding Diff line (does not create/open a draft), for quickly checking context
   const handleNavigateToFinding = (finding: Finding): void => {
     if (!finding.anchor || typeof finding.anchor.startLine !== 'number') return;
     const startLine = finding.anchor.startLine;

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatInput.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatInput.ts
@@ -20,15 +20,15 @@ export interface UseChatInputParams {
   onAgentAsk: (question: string) => void;
   onCancel?: () => void;
   onSetReviewStatus?: (status: LocalPrStatus) => void;
-  /** PR 远端可直接合并（mergeStatus.canMerge）：false 时 /merge 不出现在补全/命令菜单，误输入也拒绝。 */
+  /** PR is directly mergeable on the remote (mergeStatus.canMerge): when false, /merge does not appear in autocomplete/command menu, and mistyped input is also rejected. */
   canMerge?: boolean;
-  /** /merge 触发：交由 ChatPane 弹二次确认后再实际合并。 */
+  /** /merge trigger: hand off to ChatPane to pop a second confirmation before actually merging. */
   onMerge?: () => void;
 }
 
 /**
- * 输入栏状态机：输入 / `/` 命令解析与提交 / 自动补全浮层 / 历史回放（shell 式 Up/Down）/ 停止请求。
- * 命令解析纯逻辑见 ../utils/parse-command；历史栈见 ../utils/chat-history。ChatInputBar 只消费返回值渲染。
+ * Input bar state machine: input / `/` command parsing and submission / autocomplete overlay / history replay (shell-style Up/Down) / stop request.
+ * Pure command-parsing logic in ../utils/parse-command; history stack in ../utils/chat-history. ChatInputBar only consumes the return value to render.
  */
 export function useChatInput({
   pr,
@@ -46,54 +46,54 @@ export function useChatInput({
   const { t } = useTranslation();
   const [input, setInput] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
-  // PR 切换时清掉异常提示 + 输入框残留 (避免跨 PR 显示陈旧的错误"未知命令" 等)
+  // On PR switch, clear the error hint + leftover input (to avoid showing a stale error "unknown command" etc. across PRs)
   useEffect(() => {
     setParseError(null);
     setInput('');
   }, [pr?.localId]);
   const [cmdMenuOpen, setCmdMenuOpen] = useState(false);
-  // 自动补全菜单选中项索引 (textarea 输入 / 时显示的浮层)
+  // Selected-item index of the autocomplete menu (the overlay shown when the textarea contains /)
   const [autocompleteIdx, setAutocompleteIdx] = useState(0);
-  // 已经为某个特定输入值关闭过菜单 (Esc / 选中后插入)。input 一变就失效
-  // → 用户继续打字时菜单会自然重新出现，但选中 / Esc 后不会立刻重弹
+  // Menu was already dismissed for a specific input value (Esc / inserted after selecting). Invalidated as soon as input changes
+  // → the menu naturally reappears as the user keeps typing, but does not immediately re-pop right after selecting / Esc
   const [dismissedFor, setDismissedFor] = useState<string | null>(null);
-  // 历史回放：从最新到最老的栈；historyIdx 表示当前正在浏览的位置 (-1 = 不在浏览态)
+  // History replay: stack from newest to oldest; historyIdx indicates the position currently being browsed (-1 = not in browsing state)
   const [history, setHistory] = useState<string[]>(() => loadChatHistory());
   const [historyIdx, setHistoryIdx] = useState(-1);
-  // 进入历史浏览前用户正在编辑的内容；按 Down 回到底端时还原回去，模仿 shell 行为
+  // The content the user was editing before entering history browsing; restored when pressing Down back to the bottom, mimicking shell behavior
   const draftBeforeHistoryRef = useRef<string>('');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const cmdMenuRef = useRef<HTMLDivElement | null>(null);
 
-  // 队列模型：仅 !pr / pr-agent 未就绪 时禁用 input。activeRun / busyOnOtherPr
-  // 不再阻塞新提交 (会排队 by main)。running 决定是否渲染 stop 按钮：除活动工具 run 外，
-  // Agent 自身执行阶段（思考 / 编排，无工具 run 占用）也算「运行中」，以便随时取消。
+  // Queue model: disable input only when !pr / pr-agent not ready. activeRun / busyOnOtherPr
+  // no longer block new submissions (queued by main). running decides whether to render the stop button: besides an active tool run,
+  // the Agent's own execution phase (thinking / orchestration, with no tool run occupied) also counts as "running", so it can be cancelled anytime.
   const running = runningTool !== null || agentRunningHere;
-  // LLM 未配置时一并禁用：即便 pr-agent 运行时就绪，没有模型也无法发起调用
+  // Also disable when the LLM is not configured: even if the pr-agent runtime is ready, without a model no call can be made
   const disabled = !pr || !prAgent.available || !llmConfigured;
-  // stop 按钮点过后等 main 回 queueChanged 才会改变状态；中间这段时间二次点击
-  // 应失效，避免反复 spam abort
+  // After the stop button is clicked, the state only changes once main returns queueChanged; a second click during this interval
+  // should be a no-op, to avoid repeatedly spamming abort
   const [stopRequested, setStopRequested] = useState(false);
-  // running → false 时 (run 结束了) 重置 stopRequested，下次起 run 又能取消
+  // When running → false (the run has finished), reset stopRequested so the next run can be cancelled again
   useEffect(() => {
     if (!running) setStopRequested(false);
   }, [running]);
   const trimmed = input.trim();
-  // 可见命令集合：PR 不可直接合并时隐去 /merge（不在补全 / 命令菜单提示不可用的动作）。
+  // Visible command set: hide /merge when the PR is not directly mergeable (don't hint an unavailable action in autocomplete / command menu).
   const visibleCommands = canMerge ? COMMANDS : COMMANDS.filter((c) => c.kind !== 'pr-action');
-  // `/` 开头 + 命令名还没敲完整 (没空格) → 显示候选；已为当前 input dismiss 过则隐藏
+  // Starts with `/` + command name not fully typed yet (no space) → show candidates; hidden if already dismissed for the current input
   const showAutocomplete =
     !disabled && dismissedFor !== input && input.startsWith('/') && !input.includes(' ');
   const filtered = showAutocomplete
     ? visibleCommands.filter((c) => c.label.startsWith(input.split(' ')[0] ?? ''))
     : [];
 
-  // 输入变化时重置选中项到首条 (候选集变了)
+  // Reset the selected item to the first when input changes (the candidate set changed)
   useEffect(() => {
     setAutocompleteIdx(0);
   }, [input]);
 
-  // `/` 命令按钮触发的弹出菜单：点击外部 / Esc / 选中命令时关闭
+  // Popup menu triggered by the `/` command button: closes on outside click / Esc / selecting a command
   useEffect(() => {
     if (!cmdMenuOpen) return;
     const onDown = (e: MouseEvent): void => {
@@ -122,8 +122,8 @@ export function useChatInput({
     setInput(cmd.insertAs);
     setParseError(null);
     setCmdMenuOpen(false);
-    // 选中后立即关掉补全菜单 (insertAs 可能 "/describe" 没空格，否则会一直撑着)。
-    // dismissedFor 绑当前 input 值，用户继续打字 input 变了菜单会重新打开
+    // Close the autocomplete menu immediately after selecting (insertAs may be "/describe" with no space, otherwise it would keep it propped open).
+    // dismissedFor is bound to the current input value; as the user keeps typing and input changes, the menu reopens
     setDismissedFor(cmd.insertAs);
     const el = textareaRef.current;
     if (el) {
@@ -134,7 +134,7 @@ export function useChatInput({
     }
   };
 
-  // 提交成功路径共用：写历史栈 + 退出浏览态 + 清空输入
+  // Shared by the successful-submit path: write the history stack + exit browsing state + clear input
   const pushHistoryAndReset = (): void => {
     setHistory(pushChatHistory(input));
     setHistoryIdx(-1);
@@ -162,19 +162,19 @@ export function useChatInput({
         setParseError(t('chatPane.askNeedsQuestion'));
         return;
       case 'reviewAction':
-        if (!onSetReviewStatus) return; // 没装回调直接忽略 (保护性)
+        if (!onSetReviewStatus) return; // No callback wired → just ignore (protective)
         pushHistoryAndReset();
         onSetReviewStatus(parsed.status);
         return;
       case 'mergeAction':
-        if (!onMerge) return; // 没装回调直接忽略 (保护性)
-        // canMerge 门控：不可直接合并时拒绝并提示（输入框已不补全 /merge，此处兜底手输）。
+        if (!onMerge) return; // No callback wired → just ignore (protective)
+        // canMerge gate: reject and hint when not directly mergeable (the input no longer autocompletes /merge; this is the fallback for manual typing).
         if (!canMerge) {
           setParseError(t('chatPane.notMergeable'));
           return;
         }
         pushHistoryAndReset();
-        onMerge(); // 交由 ChatPane 弹确认后实际合并
+        onMerge(); // Hand off to ChatPane to pop confirmation before actually merging
         return;
       case 'run':
         pushHistoryAndReset();
@@ -187,11 +187,11 @@ export function useChatInput({
     }
   };
 
-  // 历史回放工具：根据 idx 设 textarea 内容；idx = -1 表示退出浏览态，恢复 draft
+  // History replay helper: set textarea content by idx; idx = -1 means exit browsing state, restore draft
   const applyHistoryIdx = (nextIdx: number): void => {
     setHistoryIdx(nextIdx);
     setInput(nextIdx < 0 ? draftBeforeHistoryRef.current : (history[nextIdx] ?? ''));
-    // 光标移到末尾，下一次 Up/Down 行为可预期
+    // Move the cursor to the end so the next Up/Down behavior is predictable
     const el = textareaRef.current;
     if (el) {
       requestAnimationFrame(() => {
@@ -202,8 +202,8 @@ export function useChatInput({
     }
   };
 
-  // 判断是否应让 Up/Down 触发历史回放：textarea 光标必须在首行 / 末行边缘，
-  // 否则让 Up/Down 走原生光标移动 (多行编辑时还在行内导航不能被劫持)
+  // Decide whether Up/Down should trigger history replay: the textarea cursor must be at the first-line / last-line edge,
+  // otherwise let Up/Down do native cursor movement (in multi-line editing, in-line navigation must not be hijacked)
   const atFirstLine = (): boolean => {
     const el = textareaRef.current;
     if (!el) return false;
@@ -216,10 +216,10 @@ export function useChatInput({
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-    // 输入法 composing 中：所有快捷键都不拦截，交给 IME 处理
+    // During IME composing: intercept no shortcuts, hand off to the IME
     if (e.nativeEvent.isComposing) return;
 
-    // 自动补全菜单打开时：拦截 Up/Down/Enter/Tab/Esc 用于菜单导航，避免落到 textarea
+    // When the autocomplete menu is open: intercept Up/Down/Enter/Tab/Esc for menu navigation, to avoid falling through to the textarea
     if (showAutocomplete && filtered.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
@@ -244,11 +244,11 @@ export function useChatInput({
       }
     }
 
-    // 历史回放：菜单未打开时，Up/Down 在边缘行 → 翻历史。中间行让原生光标移动接管
+    // History replay: when the menu is closed, Up/Down on an edge line → page through history. Middle lines let native cursor movement take over
     if (e.key === 'ArrowUp' && history.length > 0 && atFirstLine()) {
       e.preventDefault();
       if (historyIdx < 0) {
-        // 首次进浏览态：把当前编辑内容存为 draft，方便 Down 回到底端时复原
+        // First entering browsing state: save the current editing content as draft, so Down can restore it back at the bottom
         draftBeforeHistoryRef.current = input;
       }
       applyHistoryIdx(Math.min(historyIdx + 1, history.length - 1));

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatSession.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatSession.ts
@@ -18,53 +18,53 @@ export interface ChatSession {
   setAgentSteps: React.Dispatch<React.SetStateAction<AgentStep[]>>;
   messages: AgentMessage[];
   setMessages: React.Dispatch<React.SetStateAction<AgentMessage[]>>;
-  /** 规划 Agent 的计划（todo）：随 agent:planUpdated 实时刷新，切 PR 经 getSession 水合。 */
+  /** The planning Agent's plan (todo): refreshed in real time with agent:planUpdated, hydrated via getSession on PR switch. */
   todo: AgentTodoItem[];
   setTodo: React.Dispatch<React.SetStateAction<AgentTodoItem[]>>;
   bodyRef: MutableRefObject<HTMLDivElement | null>;
-  /** 当前展示中的 PR id（每渲染同步）：异步任务 resolve 时据此判断是否仍停在发起 PR。 */
+  /** The PR id currently displayed (synced every render): used when an async task resolves to decide whether we're still on the initiating PR. */
   currentPrIdRef: MutableRefObject<string | undefined>;
-  /** 从 main 重载某 PR 的多轮对话（落盘版为准）；仅当仍停在该 PR 才落到当前视图。 */
+  /** Reload a PR's multi-turn conversation from main (persisted version is authoritative); only applied to the current view if still on that PR. */
   reloadConversation: (localId: string) => Promise<void>;
 }
 
 /**
- * ChatPane 的会话态与生命周期：切 PR 时重载 run 历史 / 规则 / 多轮对话 / 过程步骤，
- * 订阅流式步骤与对话变更，跑完的 run 逐条插入，向上滚动游标分页，新内容自动滚到底。
+ * ChatPane's session state and lifecycle: on PR switch, reload run history / rules / multi-turn conversation / process steps,
+ * subscribe to streaming steps and conversation changes, insert finished runs one by one, cursor-paginate on scroll up, auto-scroll to bottom on new content.
  *
- * 入参 `myActiveIds` 是本 PR 运行中 run 的 runId 列表（来源于全局 store），用于：
- * 检测「某条跑完了」→ 单独 fetch 插入；以及新 run / 活动集变化时滚到底。
+ * The `myActiveIds` param is the list of runIds of runs in progress for this PR (sourced from the global store), used for:
+ * detecting "one finished" → fetch and insert it individually; and scrolling to bottom when a new run / the active set changes.
  */
 export function useChatSession(
   prLocalId: string | undefined,
   myActiveIds: string[],
 ): ChatSession {
-  // runs 按 startedAt 升序保存 (chat 习惯：旧在上 / 新在下)。分页：进入 PR 默认拉
-  // 最新 RUNS_PAGE_SIZE 条，向上滚到顶端用 runs[0].id 当游标向 main 要更早一批
+  // runs kept in ascending startedAt order (chat convention: old on top / new at bottom). Pagination: entering a PR pulls
+  // the latest RUNS_PAGE_SIZE by default; scrolling up to the top uses runs[0].id as the cursor to request an earlier batch from main
   const [runs, setRuns] = useState<ReviewRun[]>([]);
   const [hasMoreOlder, setHasMoreOlder] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  // 切 PR 时初次拉取（runs / 规则 / 会话 / transcript）在飞标志：期间盖延迟 loading，
-  // 避免「清空 → 空白 → 内容 pop-in」的抖动。延迟显示让快路径（缓存命中）零闪烁。
+  // In-flight flag for the initial fetch on PR switch (runs / rules / session / transcript): during it, cover with delayed loading
+  // to avoid the "clear → blank → content pop-in" jitter. Delayed display gives the fast path (cache hit) zero flicker.
   const [loadingSession, setLoadingSession] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // 当前 PR 命中的全部规则 (针对 /review 工具；缺省 tools=[review] 是规则最常生效的场景)
+  // All rules matched for the current PR (for the /review tool; default tools=[review] is the scenario where rules most often apply)
   const [matchedRules, setMatchedRules] = useState<MatchedRules>([]);
   const [agentSteps, setAgentSteps] = useState<AgentStep[]>([]);
-  // 多轮对话消息（用户输入 + Agent 回答），跨回合保留、由 main 落盘 conversation.json，
-  // 切回该 PR 恢复。用户消息含临时 optimistic 项（提交即回显），收尾后整体以落盘版重载对齐。
+  // Multi-turn conversation messages (user input + Agent replies), kept across turns, persisted by main to conversation.json,
+  // restored when switching back to that PR. User messages include temporary optimistic items (echoed on submit), aligned wholesale against the persisted version on reload after completion.
   const [messages, setMessages] = useState<AgentMessage[]>([]);
-  // 规划 Agent 的计划（todo）：随 agent:planUpdated 实时刷新；切 PR 经 agent:getSession 水合。
+  // The planning Agent's plan (todo): refreshed in real time with agent:planUpdated; hydrated via agent:getSession on PR switch.
   const [todo, setTodo] = useState<AgentTodoItem[]>([]);
   const bodyRef = useRef<HTMLDivElement | null>(null);
-  // 当前展示中的 PR id（每渲染同步）：异步 Agent 任务 resolve 时据此判断是否仍停在发起 PR，
-  // 避免把收尾结果 / 错误串台到切换后打开的别的 PR 会话。
+  // The PR id currently displayed (synced every render): used when an async Agent task resolves to decide whether we're still on the initiating PR,
+  // to avoid crossing the conclusion result / error into a different PR session opened after switching.
   const currentPrIdRef = useRef<string | undefined>(undefined);
   currentPrIdRef.current = prLocalId;
 
-  // PR 切换：重置面板状态 + 拉该 PR 的 run 历史 (含切走前还在跑、现在已落盘的 run)。
-  // 依赖用 pr?.localId 而不是 pr 对象引用：App 在 poll tick / window focus 时会
-  // reloadPrs → 新 prs 数组 → selected 是新对象引用；localId 是稳定字符串，同 PR 刷新不触发。
+  // PR switch: reset panel state + pull this PR's run history (including runs still running before the switch, now persisted).
+  // Depend on pr?.localId rather than the pr object reference: App does reloadPrs on poll tick / window focus
+  // → new prs array → selected is a new object reference; localId is a stable string, so refreshing the same PR does not trigger.
   useEffect(() => {
     setRuns([]);
     setHasMoreOlder(false);
@@ -80,9 +80,9 @@ export function useChatSession(
     setLoadingSession(true);
     void (async () => {
       try {
-        // listRuns 默认返回 newest-first；这里只拉最新一页 (RUNS_PAGE_SIZE)。
-        // 同时拉已落盘的多轮对话 + 过程步骤（transcript）：把会话恢复到其 PR，跨切换 / 重启不丢失，
-        // 过程化跟踪的思考步骤也随之恢复（步骤随产生增量落盘）。
+        // listRuns returns newest-first by default; here we only pull the latest page (RUNS_PAGE_SIZE).
+        // Also pull the persisted multi-turn conversation + process steps (transcript): restore the session to its PR, not lost across switch / restart,
+        // and the process-tracked thinking steps are restored along with it (steps are persisted incrementally as produced).
         const [list, rules, conversation, transcript, session] = await Promise.all([
           invoke('pragent:listRuns', { localId: prLocalId, limit: RUNS_PAGE_SIZE }),
           invoke('rules:matchForPr', { localId: prLocalId, tool: 'review' }),
@@ -91,7 +91,7 @@ export function useChatSession(
           invoke('agent:getSession', { localId: prLocalId }),
         ]);
         if (cancelled) return;
-        // 反转为升序 (chat 习惯)，UI 直接读 runs 即可
+        // Reverse to ascending order (chat convention); the UI can read runs directly
         setRuns([...list].reverse());
         setHasMoreOlder(list.length === RUNS_PAGE_SIZE);
         setMatchedRules(rules);
@@ -109,28 +109,28 @@ export function useChatSession(
     };
   }, [prLocalId]);
 
-  // Agent 步骤流式：订阅 main 的 agent:stepProgress，按当前 PR 过滤实时追加。
+  // Agent step streaming: subscribe to main's agent:stepProgress, filter by current PR and append in real time.
   useEffect(() => {
     if (!prLocalId) return;
     return subscribe('agent:stepProgress', (ev) => {
-      // 流式步骤可能未带 at（编排器广播在落盘 stamp 之前）→ 到达即补一个时间戳，
-      // 供下方与 run 卡片按时间归并排序（自然时间顺序展示）。
+      // Streaming steps may arrive without at (the orchestrator broadcasts before the persist stamp) → stamp one on arrival,
+      // so the section below can merge-sort by time with run cards (displayed in natural time order).
       if (ev.prLocalId === prLocalId)
         setAgentSteps((s) => [...s, { ...ev.step, at: ev.step.at ?? new Date().toISOString() }]);
     });
   }, [prLocalId]);
 
-  // 从 main 重载某 PR 的多轮对话（落盘版为准）；仅当仍停在该 PR 才落到当前视图，避免串台。
+  // Reload a PR's multi-turn conversation from main (persisted version is authoritative); only applied to the current view if still on that PR, to avoid crossing.
   const reloadConversation = async (localId: string): Promise<void> => {
     try {
       const conversation = await invoke('agent:getConversation', { localId });
       if (currentPrIdRef.current === localId) setMessages(conversation);
     } catch {
-      /* 忽略：下次 PR 切换 effect 会重载 */
+      /* Ignore: the next PR-switch effect will reload */
     }
   };
 
-  // 后台评审（AutoPilot）收尾追加「评审总结」消息时，若正打开该 PR 则重载会话，让总结卡片即时出现。
+  // When background review (AutoPilot) appends a "review summary" message on conclusion, reload the session if that PR is open, so the summary card appears immediately.
   useEffect(() => {
     if (!prLocalId) return;
     return subscribe('agent:conversationChanged', (ev) => {
@@ -138,7 +138,7 @@ export function useChatSession(
     });
   }, [prLocalId]);
 
-  // 计划（todo）实时刷新：规划 Agent 每轮给出 / 更新 plan 即广播，按当前 PR 过滤更新计划面板。
+  // Plan (todo) real-time refresh: the planning Agent broadcasts each round when it gives / updates the plan; filter by current PR and update the plan panel.
   useEffect(() => {
     if (!prLocalId) return;
     return subscribe('agent:planUpdated', (ev) => {
@@ -146,9 +146,9 @@ export function useChatSession(
     });
   }, [prLocalId]);
 
-  // 本 PR 的运行中 run 集合发生「移除」→ 那条跑完了：单独 fetch 它 + 按 runId 升序
-  // 插入 runs（不重拉整页，避免毁掉用户已向上加载的更早历史）。lines 缓存的回收已
-  // 上移到 store 层（setQueue 全局处理），这里不再负责。多并发下逐条 diff 处理。
+  // When this PR's set of in-progress runs sees a "removal" → that one finished: fetch it individually + insert into runs
+  // in ascending runId order (don't refetch the whole page, to avoid destroying the earlier history the user loaded upward). Reclaiming the lines cache has
+  // moved up to the store layer (handled globally by setQueue) and is no longer done here. Diff processed one by one under concurrency.
   const myActiveIdsKey = myActiveIds.join(',');
   const prevMyActiveRef = useRef<string[]>(myActiveIds);
   const prevPrRef = useRef<string | undefined>(prLocalId);
@@ -157,7 +157,7 @@ export function useChatSession(
     prevPrRef.current = prLocalId;
     const prev = prevMyActiveRef.current;
     prevMyActiveRef.current = myActiveIds;
-    // PR 切换：prev 属于旧 PR，不能当本 PR 的「跑完」处理，仅同步 ref
+    // PR switch: prev belongs to the old PR, so it must not be treated as this PR's "finished"; only sync the ref
     if (prevPr !== prLocalId || !prLocalId) return;
     const current = new Set(myActiveIds);
     for (const runId of prev) {
@@ -169,14 +169,14 @@ export function useChatSession(
             setRuns((prevRuns) => {
               const idx = prevRuns.findIndex((r) => r.id === finished.id);
               if (idx >= 0) {
-                // 已在列表（重复事件 / 重连）→ 就地更新
+                // Already in the list (duplicate event / reconnect) → update in place
                 const next = prevRuns.slice();
                 next[idx] = finished;
                 return next;
               }
-              // 并发完成顺序 ≠ runId 顺序：按 runId 升序插入而非无条件 append，
-              // 维持 runs 始终有序（loadOlderRuns 以 runs[0].id 作游标拉更早历史，
-              // 依赖此不变量）。runId 字典序即时序，可直接字符串比较。
+              // Concurrent completion order ≠ runId order: insert in ascending runId order rather than unconditional append,
+              // keeping runs always ordered (loadOlderRuns uses runs[0].id as the cursor to pull earlier history,
+              // relying on this invariant). runId lexical order is the time order, so a direct string comparison works.
               const insertAt = prevRuns.findIndex((r) => r.id > finished.id);
               if (insertAt < 0) return [...prevRuns, finished];
               const next = prevRuns.slice();
@@ -192,9 +192,9 @@ export function useChatSession(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [myActiveIdsKey, prLocalId]);
 
-  // 向上滚到顶端 → 用 runs[0].id 当游标，向 main 要更早一批，prepend 到 runs。
-  // 保留视觉滚动位置：插入新内容后把 scrollTop 推到 (newHeight - prevHeight)
-  // 抵消，用户看上去像"接着原来位置"
+  // Scroll up to the top → use runs[0].id as the cursor, request an earlier batch from main, prepend to runs.
+  // Preserve the visual scroll position: after inserting new content, push scrollTop by (newHeight - prevHeight)
+  // to offset, so it looks to the user like "continuing from the original position"
   const loadOlderRuns = async (): Promise<void> => {
     if (loadingOlder || !hasMoreOlder || !prLocalId || runs.length === 0) return;
     setLoadingOlder(true);
@@ -207,10 +207,10 @@ export function useChatSession(
         limit: RUNS_PAGE_SIZE,
         beforeId: runs[0]!.id,
       });
-      // older 是 newest-first，反转后整段塞到 runs 前面
+      // older is newest-first; reverse and stuff the whole batch in front of runs
       setRuns((prev) => [...[...older].reverse(), ...prev]);
       setHasMoreOlder(older.length === RUNS_PAGE_SIZE);
-      // 下一帧补齐滚动位置
+      // Restore the scroll position on the next frame
       requestAnimationFrame(() => {
         if (!bodyRef.current) return;
         bodyRef.current.scrollTop = prevTop + (bodyRef.current.scrollHeight - prevHeight);
@@ -222,13 +222,13 @@ export function useChatSession(
     }
   };
 
-  // 新 run 完成 / 运行中 run 集合变化时自动滚到底，让最新消息浮上来
+  // Auto-scroll to bottom when a new run completes / the set of in-progress runs changes, so the latest message surfaces
   useEffect(() => {
     const el = bodyRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [runs.length, myActiveIdsKey]);
 
-  // 向上滚到顶端 → 触发 loadOlderRuns 拉更早一批 (cursor = runs[0].id)
+  // Scroll up to the top → trigger loadOlderRuns to pull an earlier batch (cursor = runs[0].id)
   useEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
@@ -238,7 +238,7 @@ export function useChatSession(
     };
     el.addEventListener('scroll', onScroll);
     return () => el.removeEventListener('scroll', onScroll);
-    // loadOlderRuns 是稳定的语义包装，依赖项放足够即可
+    // loadOlderRuns is a stable semantic wrapper; listing enough deps is sufficient
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasMoreOlder, loadingOlder, prLocalId, runs.length]);
 

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatTimeline.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useChatTimeline.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { PragentRunInfo } from '@meebox/ipc';
 import type { AgentMessage, AgentStep, ReviewRun } from '@meebox/shared';
 
-/** 时间线一项：四类内容（run 卡片 / 运行中 run / 思考步骤 / 对话消息）按启动时间归并后的承载体。 */
+/** One timeline entry: the carrier for the four content kinds (run card / in-progress run / thinking step / conversation message) merged by start time. */
 export interface TimelineEntry {
   key: string;
   sortTime: number;
@@ -18,8 +18,8 @@ function ms(iso: string | null | undefined): number {
 }
 
 /**
- * 用户直接发起的斜杠命令的回显文案：/ask 显示问题正文（更贴近对话；空问题回退 `/ask`），
- * describe/review/improve 显示 `/工具名`。仅用于命令回显气泡，不做 i18n（就是用户键入的命令）。
+ * Echo text for slash commands directly triggered by the user: /ask shows the question body (closer to conversation; empty question falls back to `/ask`),
+ * describe/review/improve show `/toolName`. Used only for the command echo bubble, no i18n (it's literally the command the user typed).
  */
 function echoContent(tool: string, question: string | undefined): string {
   if (tool === 'ask') {
@@ -30,16 +30,16 @@ function echoContent(tool: string, question: string | undefined): string {
 }
 
 /**
- * 历史时间线 + 实时「思考中」计时锚点。
+ * History timeline + real-time "thinking" timing anchor.
  *
- * timeline：把已完成 run、正在执行的 run、Agent 思考步骤、对话消息统一按**启动时间**归并排序，
- * 顺序固定——即便后启动的任务先完成，也排在先启动（仍在执行）的任务下方，不因完成先后跳序。
- * 类 Claude Code「先思考→定步骤→执行步骤」：思考步骤（plan/judge）是工具选择的前因，排在所选工具的
- * run 卡片之前；工具执行的进度 / 计时由 run 卡片承载，不重复。排队中（未启动）的任务不入此列，另置末尾。
+ * timeline: merge-sorts completed runs, in-progress runs, Agent thinking steps, and conversation messages uniformly by **start time**,
+ * with a fixed order — even if a later-started task finishes first, it still sits below the earlier-started (still-executing) task, never jumping order by completion.
+ * Like Claude Code's "think first → decide steps → execute steps": thinking steps (plan/judge) are the antecedent of tool selection, placed before the chosen tool's
+ * run card; the tool execution's progress / timing is carried by the run card, not duplicated. Queued (not-yet-started) tasks are not in this list, placed separately at the end.
  *
- * thinkingSince：「思考中」实时计时的锚点，取「最近一次活动结束」——{本 PR run 起点, 末个思考步 at,
- * 末个完成 run 的结束时刻} 三者最晚者。锚到持久数据（runningPrs 跨 PR 切换不清、run 历史会重载）而非
- * 组件挂载，故切走再切回不清零；用 run 结束而非步骤记录时刻，避免把工具执行时间算进当前思考。
+ * thinkingSince: the anchor for real-time "thinking" timing, taking "the most recent activity end" — the latest of {this PR's run start, last thinking step at,
+ * last completed run's finish time}. Anchored to persistent data (runningPrs is not cleared across PR switch, run history is reloaded) rather than
+ * component mount, so switching away and back does not reset it; uses run end rather than the step record time, to avoid counting tool execution time into the current thinking.
  */
 export function useChatTimeline(params: {
   visibleRuns: ReviewRun[];
@@ -82,10 +82,10 @@ export function useChatTimeline(params: {
       sortTime: ms(m.at),
       message: m as AgentMessage | null,
     }));
-    // 命令回显气泡：仅对**用户直接发起**（origin==='user'）的 run 补一条 user 消息，紧贴其卡片之上
-    // （sortTime 取起跑时刻 -1ms）。编排 / AutoPilot 子 run（origin==='agent'）不回显——其用户输入已由
-    // 编排会话的用户消息承载。历史 run 无 origin（undefined）→ 不回显。active 与完成态同一 runId 互斥，
-    // key 统一为 `echo-<runId>`，运行中→完成的切换平滑不重挂。
+    // Command echo bubble: only for runs **directly triggered by the user** (origin==='user'), add a user message right above its card
+    // (sortTime takes the start time -1ms). Orchestration / AutoPilot sub-runs (origin==='agent') are not echoed — their user input is already
+    // carried by the orchestration session's user message. Historical runs have no origin (undefined) → not echoed. active and completed states are mutually exclusive on the same runId,
+    // key uniformly `echo-<runId>`, so the running→completed switch is smooth without remounting.
     const echoOf = (
       runId: string,
       tool: string,

--- a/apps/desktop/src/renderer/src/components/features/chat/hooks/useTextareaAutosizeDrag.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/hooks/useTextareaAutosizeDrag.ts
@@ -1,9 +1,9 @@
 import { useState, type RefObject } from 'react';
 
 /**
- * textarea 顶边拖拽调高。不用 CSS `resize: vertical`（handle 在右下角、向下拖才放大，
- * 但 input 钉在面板底部、视觉是向上扩展，反直觉）；改顶边自绘 handle，向上拖 = 放大。
- * 边界跟 css min-height(2 行) / max-height(8 行) 一致；height 为 null 时不写 inline style。
+ * Drag the textarea's top edge to resize its height. Does not use CSS `resize: vertical` (its handle is at the bottom-right and only grows when dragged down,
+ * but the input is pinned to the panel bottom and visually expands upward, which is counterintuitive); instead draws a custom handle on the top edge, dragging up = grow.
+ * Bounds match css min-height (2 lines) / max-height (8 lines); when height is null, no inline style is written.
  */
 export function useTextareaAutosizeDrag(textareaRef: RefObject<HTMLTextAreaElement | null>): {
   textareaHeightPx: number | null;
@@ -16,11 +16,11 @@ export function useTextareaAutosizeDrag(textareaRef: RefObject<HTMLTextAreaEleme
     if (!el) return;
     const startY = e.clientY;
     const startHeight = el.getBoundingClientRect().height;
-    // 跟 css token: $fs-md=13 * $lh-normal=1.4 = 18.2 px/line；$space-3=6 px padding 上下 = 12 px
+    // Matches css tokens: $fs-md=13 * $lh-normal=1.4 = 18.2 px/line; $space-3=6 px padding top+bottom = 12 px
     const MIN = Math.round(13 * 1.4 * 2 + 12);
     const MAX = Math.round(13 * 1.4 * 8 + 12);
     const onMove = (ev: MouseEvent): void => {
-      // 上拖 dy < 0 → 高度增加；下拖反之
+      // Drag up dy < 0 → height increases; drag down is the reverse
       const dy = ev.clientY - startY;
       const next = Math.min(MAX, Math.max(MIN, startHeight - dy));
       setTextareaHeightPx(next);

--- a/apps/desktop/src/renderer/src/components/features/chat/statusbar/AutopilotChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/statusbar/AutopilotChip.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { RobotIcon, RobotOffIcon, StatusChip } from '../../../common';
 
 /**
- * AutoPilot 开关 chip：默认关，点击切换（持久化到 agent.autopilot.enabled，下次 poll 生效）。
+ * AutoPilot toggle chip: off by default, click to toggle (persisted to agent.autopilot.enabled, takes effect on next poll).
  */
 export function AutopilotChip({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/chat/statusbar/PrAgentActiveChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/chat/statusbar/PrAgentActiveChip.tsx
@@ -6,8 +6,8 @@ import { formatElapsed } from '../../../../utils/time';
 import { StatusChip } from '../../../common';
 
 /**
- * 队列弹出菜单：状态栏 chip 上方弹出。先列全部运行中（active）行，再列 waiting 行。
- * waiting 行右侧 × 按钮取消。最多 6 个 item 高度，超出内部滚动。
+ * Queue popover: pops up above the status bar chip. Lists all active rows first, then waiting rows.
+ * The × button on the right of a waiting row cancels it. Max 6 items tall, scrolls internally beyond that.
  */
 function QueuePopover({
   active,
@@ -88,32 +88,32 @@ function QueuePopover({
 }
 
 /**
- * pr-agent 活动状态 chip：active 时显示运行中工具 + elapsed (可点跳 PR)；idle 时
- * 显示"空闲"占位。PR 切换不会丢运行中状态，由 chatRunStore 跨实例维护。
+ * pr-agent activity chip: when active, shows the running tool + elapsed (clickable to jump to PR);
+ * when idle, shows an "idle" placeholder. Switching PRs won't lose running state, which chatRunStore maintains across instances.
  *
- * 调用方应在 pr-agent 实际可用 (PrAgentStatus.available) 时才挂这条。
+ * Callers should only mount this when pr-agent is actually available (PrAgentStatus.available).
  */
 export function PrAgentActiveChip({ onJumpToPr }: { onJumpToPr?: (localId: string) => void }) {
   const { t } = useTranslation();
   const { active, waiting } = useChatRunStore();
-  // 并发模型：active 是运行中 run 列表。chip 主体展示第一条（primary）的 tool + elapsed，
-  // 多于一条时用徽标显示并发总数；点开 popover 列出全部运行中 + 排队中。
+  // Concurrency model: active is the list of running runs. The chip body shows the first (primary) run's tool + elapsed,
+  // with a badge showing the concurrent total when there's more than one; opening the popover lists all running + queued.
   const primary = active[0] ?? null;
   const runningCount = active.length;
-  // 计时器：1s 粒度，跟 ChatPane 的 elapsed 同步。仅有 primary 时启
+  // Timer: 1s granularity, synced with ChatPane's elapsed. Only started when there's a primary.
   const [elapsedMs, setElapsedMs] = useState(0);
-  // startedAt 入队时为 null，executeRun 起跑时设值；fallback 到 enqueuedAt 即可
+  // startedAt is null while queued, set when executeRun starts; fallback to enqueuedAt is fine
   const startMs = primary ? new Date(primary.startedAt ?? primary.enqueuedAt).getTime() : 0;
   useEffect(() => {
     if (!primary) return;
     setElapsedMs(Date.now() - startMs);
     const id = setInterval(() => setElapsedMs(Date.now() - startMs), 1000);
     return () => clearInterval(id);
-    // 仅依赖 primary runId + startMs：其它字段变化不影响计时
+    // Only depend on primary runId + startMs: changes to other fields don't affect timing
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primary?.runId, startMs]);
 
-  // 队列弹出菜单：点开 (active chip + 队列 ≥1) 显示 waiting 列表 + × 取消
+  // Queue popover: opening it (active chip + queue ≥1) shows the waiting list + × to cancel
   const [queueOpen, setQueueOpen] = useState(false);
   const queueRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -131,7 +131,7 @@ export function PrAgentActiveChip({ onJumpToPr }: { onJumpToPr?: (localId: strin
       document.removeEventListener('keydown', onKey);
     };
   }, [queueOpen]);
-  // 无可展开内容（无排队 且 运行中 ≤1）→ 自动收起菜单
+  // Nothing to expand (no queue and running ≤1) → auto-collapse the menu
   useEffect(() => {
     if (queueOpen && waiting.length === 0 && active.length <= 1) setQueueOpen(false);
   }, [queueOpen, waiting.length, active.length]);
@@ -141,7 +141,7 @@ export function PrAgentActiveChip({ onJumpToPr }: { onJumpToPr?: (localId: strin
   };
 
   if (!primary) {
-    // Idle：静态灰点 + "空闲" 文案。让用户一眼看到"agent 可用 + 当前没活儿"
+    // Idle: static gray dot + "idle" text. Lets the user see at a glance "agent available + nothing running right now"
     return (
       <StatusChip
         className="statusbar-pragent-chip statusbar-pragent-chip-idle"
@@ -153,7 +153,7 @@ export function PrAgentActiveChip({ onJumpToPr }: { onJumpToPr?: (localId: strin
     );
   }
 
-  // 可展开（运行中 >1 或有排队）→ chip 变 button 点开 popover；否则按 onJumpToPr 跳 PR。
+  // Expandable (running >1 or has queue) → chip becomes a button that opens the popover; otherwise jumps to PR via onJumpToPr.
   const expandable = waiting.length > 0 || runningCount > 1;
   const clickable = expandable || Boolean(onJumpToPr);
   const handleClick = (): void => {
@@ -163,7 +163,7 @@ export function PrAgentActiveChip({ onJumpToPr }: { onJumpToPr?: (localId: strin
       onJumpToPr?.(primary.prLocalId);
     }
   };
-  // 徽标数 = 其它并发运行中(runningCount-1) + 排队中(waiting)
+  // Badge count = other concurrent running (runningCount-1) + queued (waiting)
   const extraCount = runningCount - 1 + waiting.length;
   const title = expandable
     ? t('statusBar.prAgentExpandableTitle', { running: runningCount, waiting: waiting.length })

--- a/apps/desktop/src/renderer/src/components/features/chat/types.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/types.ts
@@ -1,6 +1,6 @@
 import type { IpcChannels } from '@meebox/ipc';
 
-/** 当前 PR 命中的全部规则（针对 /review 工具）；空数组 = 未配置 / 无命中。 */
+/** All rules matched by the current PR (for the /review tool); empty array = unconfigured / no match. */
 export type MatchedRules = IpcChannels['rules:matchForPr']['response'];
-/** 单条命中规则。 */
+/** A single matched rule. */
 export type MatchedRule = MatchedRules[number];

--- a/apps/desktop/src/renderer/src/components/features/chat/utils/chat-history.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/utils/chat-history.ts
@@ -1,5 +1,5 @@
-// 输入历史：最近 5 次成功提交，localStorage 持久化。Up/Down 按键在 textarea 末尾
-// 输入位置时回放。命中 / dismissed 后焦点保持在 textarea 上
+// Input history: last 5 successful submissions, persisted to localStorage. Up/Down keys
+// replay it when the caret is at the end of the textarea. Focus stays on the textarea after a hit / dismiss
 const CHAT_HISTORY_KEY = 'meebox.chatHistory';
 export const CHAT_HISTORY_MAX = 5;
 
@@ -9,7 +9,7 @@ export function loadChatHistory(): string[] {
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    // 防御性筛掉非 string 项，并截到上限 (历史 schema 改过也不爆)
+    // Defensively filter out non-string items and cap to the limit (won't blow up if the history schema changed)
     return parsed.filter((v): v is string => typeof v === 'string').slice(0, CHAT_HISTORY_MAX);
   } catch {
     return [];
@@ -20,14 +20,14 @@ export function pushChatHistory(value: string): string[] {
   const trimmed = value.trim();
   if (!trimmed) return loadChatHistory();
   const prev = loadChatHistory();
-  // 去重：跟最近一条一样不重复入栈 (用户连续打同样命令很常见)。也清掉历史里
-  // 重复的旧条目，让最新的那条上移到顶
+  // Dedupe: don't push again if identical to the most recent entry (users typing the same command repeatedly is common). Also
+  // remove duplicate older entries from history so the latest one moves to the top
   const deduped = prev.filter((v) => v !== trimmed);
   const next = [trimmed, ...deduped].slice(0, CHAT_HISTORY_MAX);
   try {
     localStorage.setItem(CHAT_HISTORY_KEY, JSON.stringify(next));
   } catch {
-    /* quota / private mode → 内存里历史能继续工作就行 */
+    /* quota / private mode → fine as long as in-memory history keeps working */
   }
   return next;
 }

--- a/apps/desktop/src/renderer/src/components/features/chat/utils/findings.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/utils/findings.ts
@@ -3,13 +3,13 @@ import type { TFunction } from 'i18next';
 import type { Finding, PrDocSectionKey } from '@meebox/shared';
 
 /**
- * pr-agent /review 输出的 issue body 尾部含 `[file: <path>, lines: <s>-<e>]`
- * marker — 是我们注入的 prompt directive 让 parser 抽 anchor 的，对用户无意义。
- * FindingCard 渲染前 / 转 draft 时统一清洗
+ * The issue body from pr-agent /review has a trailing `[file: <path>, lines: <s>-<e>]`
+ * marker — injected by our prompt directive so the parser can extract the anchor, meaningless to users.
+ * Cleaned uniformly before FindingCard renders / when converting to draft
  */
 export function stripFindingMarker(body: string): string {
-  // 路径可能含 `[]`：带 lines 时用惰性 `.+?` + 必现 `, lines:` 后缀界定（`.` 匹配 `]`，不被
-  // 路径里的 `]` 误截）；无 lines 时回退到不含 `]` 的旧式。末尾锚定，只清尾部 marker。
+  // The path may contain `[]`: with lines, use lazy `.+?` + the required `, lines:` suffix to delimit (`.` matches `]`, so it isn't
+  // truncated by a `]` in the path); without lines, fall back to the old style that excludes `]`. Anchored at the end, only strips the trailing marker.
   return body
     .replace(
       /\s*\[\s*file\s*:\s*(?:.+?\s*,\s*lines?\s*:\s*\d+(?:\s*[-–—]\s*\d+)?|[^\]\n]*?)\s*\]\s*$/i,
@@ -19,11 +19,11 @@ export function stripFindingMarker(body: string): string {
 }
 
 /**
- * 把 pr-agent GFM 输出里的内联 HTML 标签归一成 markdown。finding 卡片走 ReactMarkdown
- * (允许 HTML) 能正常渲染这些标签，但转成草稿正文落进编辑器 textarea / 发布到远端后，
- * 裸 `<code>` `<br>` 不一定被渲染，会暴露成字面标签。这里把常见内联标签转成等价
- * markdown：`<code>x</code>`→`` `x` ``、`<br>`→换行、`<b>/<strong>`→`**`、`<i>/<em>`→`*`。
- * 空 `<code></code>` 直接丢弃，避免产出孤立的空反引号。
+ * Normalize inline HTML tags in pr-agent GFM output into markdown. Finding cards use ReactMarkdown
+ * (HTML allowed) which renders these tags fine, but once converted to draft body landing in the editor textarea / published to the remote,
+ * bare `<code>` `<br>` aren't necessarily rendered and get exposed as literal tags. Here we convert common inline tags to equivalent
+ * markdown: `<code>x</code>`→`` `x` ``, `<br>`→newline, `<b>/<strong>`→`**`, `<i>/<em>`→`*`.
+ * Empty `<code></code>` is simply dropped to avoid producing isolated empty backticks.
  */
 export function htmlInlineToMarkdown(text: string): string {
   return text
@@ -36,9 +36,9 @@ export function htmlInlineToMarkdown(text: string): string {
 }
 
 /**
- * sectionKey → 中文标签 + 渲染顺序。把 pr-agent 输出按已知段落排成标准文档骨架：
- *   建议标题 → 类型 → 总结 → 描述 → 走查 → 测试 → 安全 → 代码反馈 → 工作量 → 评分 → 其他
- * 未识别 (sectionKey === undefined 或 'general') 走兜底，按解析顺序放到末尾。
+ * sectionKey → label + render order. Arranges pr-agent output by known sections into a standard document skeleton:
+ *   suggested title → type → summary → description → walkthrough → tests → security → code feedback → effort → score → other
+ * Unrecognized (sectionKey === undefined or 'general') goes through the fallback, placed at the end in parse order.
  */
 const SECTION_ORDER: Record<PrDocSectionKey, number> = {
   title: 0,
@@ -46,16 +46,16 @@ const SECTION_ORDER: Record<PrDocSectionKey, number> = {
   summary: 2,
   description: 3,
   diagram: 4,
-  assessment: 5, // 思路建议紧随架构图（对齐 Qodo：Description → Diagram → Assessment）
+  assessment: 5, // assessment follows the diagram (aligned with Qodo: Description → Diagram → Assessment)
   walkthrough: 6,
   'relevant-tests': 7,
   security: 8,
   'code-feedback': 9,
-  'code-suggestion': 9, // 跟 code-feedback 一组，UI 顺序无优先关系
+  'code-suggestion': 9, // grouped with code-feedback, no ordering preference between them in the UI
   effort: 10,
   score: 11,
   general: 12,
-  // /ask 结构化分段（仅出现在 /ask run 内，彼此相对顺序：概述 → 分析 → 建议）
+  // /ask structured sections (only appear within an /ask run, relative order among them: summary → analysis → suggestions)
   'ask-summary': 13,
   'ask-analysis': 14,
   'ask-suggestions': 15,
@@ -74,7 +74,7 @@ const SECTION_LABEL_KEY: Record<PrDocSectionKey, string | null> = {
   'code-suggestion': 'chatPane.sectionCodeSuggestion',
   effort: 'chatPane.sectionEffort',
   score: 'chatPane.sectionScore',
-  general: null, // general / 未知段无 chip 标签
+  general: null, // general / unknown sections have no chip label
   'ask-summary': 'chatPane.sectionAskSummary',
   'ask-analysis': 'chatPane.sectionAskAnalysis',
   'ask-suggestions': 'chatPane.sectionAskSuggestions',
@@ -85,17 +85,17 @@ export function sectionLabel(key: PrDocSectionKey, t: TFunction): string {
 }
 
 /**
- * 工作量段已用 emoji 圆点（🔵🔵🔵⚪⚪）直观表示 1-5 分，去掉前面冗余的数字分数：
- *   "3 🔵🔵🔵⚪⚪" → "🔵🔵🔵⚪⚪"；"工作量: 3 🔵🔵" → "工作量: 🔵🔵"
- * 仅在数字后紧跟圆点 emoji 时才剥，避免误删正文里的普通数字。
+ * The effort section already uses emoji dots (🔵🔵🔵⚪⚪) to intuitively represent a 1-5 score, so drop the redundant leading numeric score:
+ *   "3 🔵🔵🔵⚪⚪" → "🔵🔵🔵⚪⚪"; "Effort: 3 🔵🔵" → "Effort: 🔵🔵"
+ * Only strips when the number is immediately followed by a dot emoji, to avoid removing ordinary numbers in the body.
  */
 export function stripEffortScoreNumber(s: string): string {
   return s.replace(/(^|[:：]\s*)\d+\s*(?=[🔵⚪⚫🟢🔴🟠🟡🟣🟤])/u, '$1');
 }
 
 /**
- * Stable sort by sectionKey 排序 + 同 key 保留原顺序 (兼容 Array.sort 非 stable JS 引擎)。
- * effort（评估工作量）段直接过滤掉：「Estimated effort to review」实用价值低，不展示。
+ * Stable sort by sectionKey + preserve original order within the same key (compatible with JS engines where Array.sort isn't stable).
+ * The effort section is filtered out entirely: "Estimated effort to review" has low practical value, not shown.
  */
 export function orderFindings(findings: Finding[]): Finding[] {
   return findings
@@ -109,7 +109,7 @@ export function orderFindings(findings: Finding[]): Finding[] {
     .map((x) => x.f);
 }
 
-/** 锚点短标签 `<basename>:<startLine>`（复评徽标 / 引用 chip 用），无锚点返回空串。 */
+/** Anchor short label `<basename>:<startLine>` (used by re-review badges / reference chips), returns empty string when there's no anchor. */
 export function anchorShortLabel(anchor?: {
   path: string;
   startLine?: number;
@@ -121,8 +121,8 @@ export function anchorShortLabel(anchor?: {
 }
 
 /**
- * 把一条待复评的 finding 拼成 /ask 的隐式引用上下文（referencedContext）：让模型看到原评论正文 + 位置，
- * 据此复评。与 diff 选区引用（formatReferencedContext）同走 EXTRA_INSTRUCTIONS 注入，不进问题位置参数。
+ * Assemble a finding pending re-review into /ask's implicit reference context (referencedContext): let the model see the original comment body + location,
+ * and re-review accordingly. Like the diff selection reference (formatReferencedContext), it's injected via EXTRA_INSTRUCTIONS, not into the question position args.
  */
 export function formatFindingReference(finding: Finding): string {
   const a = finding.anchor;
@@ -139,8 +139,8 @@ export function formatFindingReference(finding: Finding): string {
 }
 
 /**
- * 字符串 → HSL 色相。djb2 简化版，稳定 → 同一标签每次都同色。用于 PR Type 胶囊
- * 自动配色（"Bug fix" / "Enhancement" / "Tests" 各拿不同的色，不需要硬编码字典）。
+ * String → HSL hue. Simplified djb2, stable → the same label is always the same color. Used for PR Type pill
+ * auto-coloring ("Bug fix" / "Enhancement" / "Tests" each get a different color, no need for a hardcoded dictionary).
  */
 function labelHue(s: string): number {
   let h = 0;
@@ -148,14 +148,14 @@ function labelHue(s: string): number {
   return Math.abs(h) % 360;
 }
 export function pillStyle(s: string): CSSProperties {
-  // 仅注入标签 hue（--pill-hue）；明暗两套的饱和 / 明度由 CSS 按主题定（见 .pr-type-pill）——
-  // 避免在 JS 里写死暗色 HSL（底色 L=22%）导致浅色主题下胶囊过深、不协调。
+  // Only inject the label hue (--pill-hue); saturation / lightness for the light and dark sets are decided by CSS per theme (see .pr-type-pill) —
+  // avoids hardcoding a dark HSL in JS (background L=22%) that would make pills too dark and jarring in the light theme.
   return { ['--pill-hue']: labelHue(s) } as CSSProperties;
 }
 /**
- * 把 "Bug fix, Enhancement\nTests" 拆成 ["Bug fix", "Enhancement", "Tests"]。
- * parser 层已经剥过 HR，这里再加一层防御：纯标点 / 长度 ≤1 的项直接 filter 掉，
- * 避免 markdown 装饰符号溜进胶囊（"---" 这种实际遇到过）
+ * Split "Bug fix, Enhancement\nTests" into ["Bug fix", "Enhancement", "Tests"].
+ * The parser layer already stripped HRs; add another defensive layer here: filter out pure-punctuation / length ≤1 items
+ * to keep markdown decoration symbols out of the pills ("---" has actually been seen)
  */
 export function splitTypeLabels(body: string): string[] {
   return body

--- a/apps/desktop/src/renderer/src/components/features/chat/utils/format.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/utils/format.ts
@@ -1,10 +1,10 @@
 import type { TFunction } from 'i18next';
 import type { ReviewRun } from '@meebox/shared';
 
-// 时长格式化统一在 utils/time（状态栏紧凑版用 compact 选项）；此处再导出，chat 各组件就近引用。
+// Duration formatting lives in utils/time (status-bar compact version uses the compact option); re-exported here so chat components import it nearby.
 export { formatElapsed } from '../../../../utils/time';
 
-/** 1234 → "1.2k"；保留 1 位小数；< 1000 直接返回数字 */
+/** 1234 → "1.2k"; keeps 1 decimal place; < 1000 returns the number as-is */
 export function formatTokens(n: number): string {
   if (n < 1000) return String(n);
   return `${(n / 1000).toFixed(1)}k`;
@@ -24,10 +24,12 @@ export function runStatusLabel(status: ReviewRun['status'], t: TFunction): strin
 }
 
 /**
- * 把时间戳格式化为 "HH:MM:SS" (当天) 或 "MM-DD HH:MM" (跨日)。用户主要看"哪一次
- * 跑的"，秒粒度足够区分相邻 run；隔天的 run 加日期标识让历史 run 列表里能立刻
- * 分组。接受 ISO 字符串 (持久化 ReviewRun.startedAt) 或毫秒时间戳 (RunningView
- * 端把 ISO 转过的 Date.getTime())
+ * Format a timestamp as "HH:MM:SS" (same day) or "MM-DD HH:MM" (crossing days).
+ * The user mainly cares about "which run"; second granularity is enough to tell
+ * adjacent runs apart; runs from another day get a date marker so the history run
+ * list groups them at a glance. Accepts an ISO string (persisted
+ * ReviewRun.startedAt) or a millisecond timestamp (RunningView side passes the
+ * Date.getTime() of the parsed ISO)
  */
 export function formatStartTime(input: string | number): string {
   const d = new Date(input);
@@ -48,15 +50,17 @@ export function formatStartTime(input: string | number): string {
 }
 
 /**
- * 从 stdout 已收到的行里推断 pr-agent 当前在哪个阶段。pr-agent 在 LLM 调用前会
- * 打几条 INFO 标志位 ("Reviewing PR..." / "Tokens: ... returning full diff"
- * / ...)，LLM 调用本身是几分钟静默；从最近行命中已知模式来给用户更准的状态提示。
+ * Infer which phase pr-agent is currently in from the stdout lines received so
+ * far. Before an LLM call pr-agent prints a few INFO markers ("Reviewing PR..." /
+ * "Tokens: ... returning full diff" / ...), while the LLM call itself is minutes
+ * of silence; matching known patterns against recent lines gives the user a more
+ * accurate status hint.
  *
- * 大仓库 /review 总时长可能 5min+，没有这个推断只看到 spinner + elapsed 容易
- * 误以为卡住。
+ * A /review on a large repo can total 5min+, and without this inference seeing
+ * only spinner + elapsed makes it easy to think it is stuck.
  */
 export function inferPhase(lines: ReadonlyArray<string>, t: TFunction): string {
-  // 从后往前找最近的命中标志，越靠后的标志代表更"晚"的阶段
+  // Scan from the end backward for the most recent matching marker; a later marker means a "later" phase
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i]!;
     if (/returning full diff|tokens?\s*[:：]\s*\d+/i.test(line))

--- a/apps/desktop/src/renderer/src/components/features/chat/utils/parse-command.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/utils/parse-command.ts
@@ -2,14 +2,14 @@ import type { LocalPrStatus, ReviewRunTool } from '@meebox/shared';
 import { COMMANDS } from '../commands';
 
 /**
- * 解析输入栏提交内容的判别式结果（纯函数，不做 i18n / 副作用）：
- * - `unknown` —— `/` 起手但命令名未知（head 用于错误提示）
- * - `commandNoArgs` —— review 决断命令带了多余参数
- * - `askNeedsQuestion` —— `/ask` 未带问题
- * - `reviewAction` —— `/approve` `/needswork` → 写 reviewer status
- * - `mergeAction` —— `/merge` → 合并 PR（输入栏弹确认 + canMerge 门控）
- * - `run` —— pr-agent 工具（review / describe / improve / ask）
- * - `agentAsk` —— 无 `/` 前缀，自然语言「对话即委派」交给自由规划 Agent
+ * Discriminated result of parsing the input-bar submission (pure function, no i18n / side effects):
+ * - `unknown` —— starts with `/` but the command name is unknown (head used for the error hint)
+ * - `commandNoArgs` —— a review-decision command was given extra arguments
+ * - `askNeedsQuestion` —— `/ask` without a question
+ * - `reviewAction` —— `/approve` `/needswork` → write reviewer status
+ * - `mergeAction` —— `/merge` → merge the PR (input bar pops a confirm + canMerge gating)
+ * - `run` —— pr-agent tool (review / describe / improve / ask)
+ * - `agentAsk` —— no `/` prefix, natural-language "conversation as delegation" handed to the free-planning Agent
  */
 export type ParsedCommand =
   | { kind: 'unknown'; head: string }
@@ -21,30 +21,30 @@ export type ParsedCommand =
   | { kind: 'agentAsk'; question: string };
 
 export function parseChatCommand(trimmed: string): ParsedCommand {
-  // 解析命令头：'/' 起手 → COMMANDS 表里找；无 '/' → 等价自然语言委派
+  // Parse the command head: starts with '/' → look it up in the COMMANDS table; no '/' → equivalent to natural-language delegation
   if (trimmed.startsWith('/')) {
     const spaceIdx = trimmed.indexOf(' ');
     const head = spaceIdx < 0 ? trimmed : trimmed.slice(0, spaceIdx);
     const rest = spaceIdx < 0 ? '' : trimmed.slice(spaceIdx + 1).trim();
     const found = COMMANDS.find((c) => c.label === head);
     if (!found) return { kind: 'unknown', head };
-    // review-action：/approve /needswork 没有参数，多余文本拒绝以免误用
+    // review-action: /approve /needswork take no arguments; extra text is rejected to avoid misuse
     if (found.kind === 'review-action') {
       if (rest) return { kind: 'commandNoArgs', cmd: found.label };
       return { kind: 'reviewAction', status: found.reviewStatus };
     }
-    // pr-action：/merge 无参数；canMerge 门控与二次确认在输入栏层（useChatInput）处理
+    // pr-action: /merge takes no arguments; canMerge gating and the confirmation are handled at the input-bar layer (useChatInput)
     if (found.kind === 'pr-action') {
       if (rest) return { kind: 'commandNoArgs', cmd: found.label };
       return { kind: 'mergeAction' };
     }
-    // pragent：/ask 必须带问题，其他工具空 question
+    // pragent: /ask must carry a question, other tools have an empty question
     if (found.name === 'ask') {
       if (!rest) return { kind: 'askNeedsQuestion' };
       return { kind: 'run', name: found.name, question: rest };
     }
     return { kind: 'run', name: found.name };
   }
-  // 无 '/' → 自然语言「对话即委派」：交给自由规划 Agent（而非 /ask）。
+  // No '/' → natural-language "conversation as delegation": handed to the free-planning Agent (not /ask).
   return { kind: 'agentAsk', question: trimmed };
 }

--- a/apps/desktop/src/renderer/src/components/features/chat/utils/tokens.ts
+++ b/apps/desktop/src/renderer/src/components/features/chat/utils/tokens.ts
@@ -1,36 +1,36 @@
 export interface TokenUsage {
-  /** 输入侧 (prompt) token 数。LITELLM_LOG=INFO 时来自 litellm；fallback 用 pr-agent
-      自己打的 "Tokens: N" (tiktoken 预估) */
+  /** Input-side (prompt) token count. Comes from litellm when LITELLM_LOG=INFO; fallback uses
+      pr-agent's own "Tokens: N" (tiktoken estimate) */
   prompt?: number;
-  /** 输出侧 (completion) token 数。仅 LITELLM_LOG=INFO 时可拿到 */
+  /** Output-side (completion) token count. Only available when LITELLM_LOG=INFO */
   completion?: number;
-  /** 总 token；优先用 litellm 给的，缺时算 prompt+completion */
+  /** Total tokens; prefers what litellm gives, computes prompt+completion when missing */
   total?: number;
-  /** 提示缓存读取量（cache_read），是 prompt 的一部分；缺/0 时不展示「(cache N)」括号 */
+  /** Prompt-cache read amount (cache_read), part of prompt; when missing/0 the "(cache N)" parenthesis is not shown */
   cacheRead?: number;
-  /** 模型交互轮次；≤1 时不单独展示 */
+  /** Model interaction turns; not shown separately when ≤1 */
   turns?: number;
 }
 
 /**
- * 从 pr-agent stdout 解析 token 用量。多源累加：
+ * Parse token usage from pr-agent stdout. Multi-source accumulation:
  *
- * 1. litellm INFO 模式 (我们默认开)：每次 LLM 调用后会打类似
+ * 1. litellm INFO mode (on by default for us): after each LLM call it prints something like
  *    `usage={'prompt_tokens': 8423, 'completion_tokens': 1234, 'total_tokens': 9657}`
- *    多轮调用 → 各项累加；这条最准
+ *    multiple call rounds → each field accumulates; this one is the most accurate
  *
- * 2. pr-agent 自己的 prompt 预估：`Tokens: 8423, total tokens under limit: ...`
- *    没 litellm 日志兜底；只反映输入侧，按最大值取代表
+ * 2. pr-agent's own prompt estimate: `Tokens: 8423, total tokens under limit: ...`
+ *    fallback when there is no litellm log; only reflects the input side, taking the max as representative
  *
- * 优先用 (1)；(1) 没命中再退到 (2)。
+ * Prefers (1); falls back to (2) when (1) does not match.
  */
 export function extractTokenUsage(stdout: string): TokenUsage {
   let prompt = 0;
   let completion = 0;
   let total = 0;
   let hasLitellm = false;
-  // litellm 的 usage dict 在 stdout 里以 Python repr 形式出现，单引号字符串
-  // (兼容 JSON 双引号也匹配)。一次 run 多轮 LLM 调用全部累加
+  // litellm's usage dict appears in stdout as a Python repr, single-quoted strings
+  // (also matches JSON double quotes for compatibility). All LLM call rounds in one run accumulate
   const usageRe =
     /['"]prompt_tokens['"]\s*:\s*(\d+)[\s,]*['"]completion_tokens['"]\s*:\s*(\d+)[\s,]*['"]total_tokens['"]\s*:\s*(\d+)/g;
   let m: RegExpExecArray | null;
@@ -43,7 +43,7 @@ export function extractTokenUsage(stdout: string): TokenUsage {
   if (hasLitellm) {
     return { prompt, completion, total: total || prompt + completion };
   }
-  // Fallback: pr-agent 的 prompt 预估
+  // Fallback: pr-agent's prompt estimate
   const fallbackRe = /Tokens:\s*(\d+)/gi;
   let maxPrompt: number | undefined;
   while ((m = fallbackRe.exec(stdout)) !== null) {

--- a/apps/desktop/src/renderer/src/components/features/command-palette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/CommandPalette.tsx
@@ -8,46 +8,46 @@ import type { FilterKey } from '../../layout/Sidebar';
 import type { SettingsCategory } from '../settings';
 
 interface CommandPaletteProps {
-  /** 运行平台：决定打开快捷键修饰键（mac = Cmd+Shift+P，其余 = Ctrl+Shift+P）。 */
+  /** Running platform: decides the open shortcut modifier (mac = Cmd+Shift+P, others = Ctrl+Shift+P). */
   platform: Platform;
   config: Config;
-  /** 当前选中 PR 的 localId（上下文相关命令用，如运行自动评审）。 */
+  /** localId of the currently selected PR (for context-relevant commands, e.g. run auto review). */
   selectedPrId: string | null;
   patchConfig: (updater: (c: Config) => Config) => void;
   openSettings: (category?: SettingsCategory) => void;
-  /** 切换对话面板折叠（评审域命令用）。 */
+  /** Toggle the chat panel collapse (used by review-domain command). */
   toggleChatPanel: () => void;
-  /** 切换 PR 列表（侧栏）折叠（PR 域命令用）。 */
+  /** Toggle the PR list (sidebar) collapse (used by PR-domain command). */
   togglePrList: () => void;
-  /** 当前平台支持的发现分类（PR 域「一级分类」命令门控用）。 */
+  /** Discovery filters supported by the current platform (gates the PR-domain "top-level filter" commands). */
   discoveryFilters: readonly PrDiscoveryFilter[];
   setDiscoveryFilter: (filter: PrDiscoveryFilter) => void;
-  /** 切到「已关闭」（归档）范围（PR 域「查看已关闭」命令用）。 */
+  /** Switch to the "closed" (archived) scope (used by the PR-domain "view closed" command). */
   viewArchived: () => void;
-  /** 按 URL 打开当前平台 PR（PR 域「打开 URL」自由文本命令用）。 */
+  /** Open a PR of the current platform by URL (used by the PR-domain "open URL" free-text command). */
   openPrByUrl: (url: string) => void | Promise<void>;
-  /** 可选的 PR 状态筛选项（PR 域「分类筛选」二级选项用）。 */
+  /** Selectable PR status filters (used by the PR-domain "filter by category" second-level options). */
   prStatusFilters: ReadonlyArray<{ value: FilterKey; labelKey: string }>;
   setPrStatusFilter: (filter: FilterKey) => void;
 }
 
-/** 当前层（顶层 / 二级）展开后用于渲染的扁平项。 */
+/** Flat item used for rendering after the current level (top / second) is expanded. */
 interface FlatItem {
   id: string;
   title: string;
-  /** 英文标题（缺省=title）：非英语界面作次行展示，并恒参与检索 */
+  /** English title (defaults to title): shown as a secondary line in non-English UI, and always searchable */
   titleEn: string;
   category?: string;
   categoryEn?: string;
   active?: boolean;
-  /** 快捷键按键 token（一键一框，如 ['⌘','B']），右侧展示 */
+  /** Shortcut key tokens (one key per box, e.g. ['⌘','B']), shown on the right */
   shortcut?: string[];
   onSelect: () => void;
 }
 
 /**
- * 把文本里匹配查询的（连续）子串包成高亮 `<mark>`，与列表的 `includes` 子串过滤一致。
- * 空查询原样返回；大小写不敏感；同一文本里多处命中都高亮。
+ * Wraps the (contiguous) substring of the text matching the query in a highlight `<mark>`, matching the list's `includes` substring filter.
+ * Empty query returns as-is; case-insensitive; all hits within the same text are highlighted.
  */
 function highlight(text: string, query: string): React.ReactNode {
   const q = query.trim();
@@ -73,9 +73,9 @@ function highlight(text: string, query: string): React.ReactNode {
 }
 
 /**
- * 标题栏命令面板（VS Code 风）：标题栏内嵌输入框 + 下拉结果。快捷键 mac Cmd+Shift+P /
- * 其余 Ctrl+Shift+P 打开聚焦。**最多两级**——顶层命令选中后若有二级选项则原地替换为选项列表，
- * 不支持返回上级（Esc 退出后重进）。搜索按当前界面语言匹配命令文案。设计见 docs/arch/03-gui/02-command-palette。
+ * Title-bar command palette (VS Code style): input box embedded in the title bar + dropdown results. Shortcut mac Cmd+Shift+P /
+ * others Ctrl+Shift+P to open and focus. **At most two levels** — after a top-level command is selected, if it has second-level options they replace the list in place,
+ * with no going back up (Esc to exit then re-enter). Search matches command text by the current UI language. Design: docs/arch/03-gui/02-command-palette.
  */
 export function CommandPalette({
   platform,
@@ -93,7 +93,7 @@ export function CommandPalette({
   setPrStatusFilter,
 }: CommandPaletteProps) {
   const { t, i18n } = useTranslation();
-  // 重入保护：调用时取实时运行中 PR 集合（编排 Agent），稳定引用避免命令清单频繁重建
+  // Reentrancy guard: read the live set of running PRs (orchestration Agent) on call; stable reference avoids frequent command-list rebuilds
   const isPrRunning = useCallback(
     (id: string) => chatRunStore.getSnapshot().agentPrs.includes(id),
     [],
@@ -104,17 +104,17 @@ export function CommandPalette({
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const activeItemRef = useRef<HTMLButtonElement>(null);
-  // 上次指针坐标：用于区分「真实鼠标移动」与「面板在静止光标下出现 / 滚动产生的合成 hover」。
+  // Last pointer coordinates: used to distinguish "real mouse movement" from "panel appearing under a stationary cursor / synthetic hover from scrolling".
   const pointerRef = useRef({ x: -1, y: -1 });
   const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  // 固定英文翻译器（en-US 静态打包、恒可用）：非英语界面作次行 + 恒按英文检索
+  // Fixed English translator (en-US statically bundled, always available): secondary line in non-English UI + always searchable in English
   const tEn = useMemo(() => i18n.getFixedT('en-US'), [i18n]);
   const isEnglish = i18n.language === 'en-US';
 
   const roots = useMemo(
     () => {
-      // 显式引用 i18n.language：t 引用在切语言后不变，需以语言为 key 重建命令文案（搜索按当前语言匹配）
+      // Explicitly reference i18n.language: the t reference stays unchanged after a language switch, so command text must be rebuilt keyed by language (search matches the current language)
       void i18n.language;
       return buildRootCommands({
         platform,
@@ -164,11 +164,11 @@ export function CommandPalette({
     inputRef.current?.blur();
   };
 
-  // 经 ref 取最新 roots，让 mruActiveIndex / openPalette 保持稳定引用（供快捷键 effect 依赖、不反复重订阅）
+  // Get the latest roots via ref so mruActiveIndex / openPalette keep stable references (for the shortcut effect's deps, avoiding repeated re-subscription)
   const rootsRef = useRef(roots);
   rootsRef.current = roots;
 
-  // 打开（空查询、顶层）时默认选中「最近用过且当前仍存在」的命令，回车即重复上次；查无回落第一条。
+  // On open (empty query, top level) default-select the "most recently used and still present" command, so Enter repeats last; fall back to the first if none found.
   const mruActiveIndex = useCallback((): number => {
     for (const id of readMru()) {
       const i = rootsRef.current.findIndex((r) => r.id === id);
@@ -185,7 +185,7 @@ export function CommandPalette({
     inputRef.current?.focus();
   }, [mruActiveIndex]);
 
-  // 直接打开并进入某条「自由文本输入」命令的输入层（供「打开 URL」快捷键直达，省去先开面板再选）。
+  // Open directly into a "free-text input" command's input level (for the "open URL" shortcut to jump straight in, skipping open-palette-then-select).
   const openInputCommand = useCallback((id: string): void => {
     const cmd = rootsRef.current.find((r) => r.id === id);
     if (!cmd?.input) return;
@@ -198,10 +198,10 @@ export function CommandPalette({
 
   const items: FlatItem[] = useMemo(() => {
     const q = query.trim().toLowerCase();
-    // haystack 恒含英文（本地化 + 英文一起匹配）：非英语界面下也始终支持英文检索
+    // haystack always includes English (localized + English matched together): English search stays available even in non-English UI
     const has = (hay: string): boolean => !q || hay.toLowerCase().includes(q);
     if (level) {
-      // 自由文本输入模式（如「打开 URL」）：二级无选项列表，输入框接受任意文本、回车提交。
+      // Free-text input mode (e.g. "open URL"): second level has no options list; input box accepts arbitrary text, submitted on Enter.
       if (!level.options) return [];
       return level
         .options()
@@ -226,9 +226,9 @@ export function CommandPalette({
         categoryEn: r.categoryEn,
         shortcut: r.shortcut,
         onSelect: () => {
-          pushMru(r.id); // 记最近使用（顶层命令；进容器 / 叶子执行都记）
+          pushMru(r.id); // record MRU (top-level command; recorded whether entering a container or executing a leaf)
           if (r.options || r.input) {
-            // 容器（二级选项）或自由文本输入：原地进入二级层
+            // Container (second-level options) or free-text input: enter the second level in place
             setLevel(r);
             setQuery('');
             setActiveIndex(0);
@@ -239,21 +239,21 @@ export function CommandPalette({
           }
         },
       }))
-      // 顶层按「领域前缀 + 命令名」（中英一起）匹配：搜领域名（如「设置」/「Settings」）可归类筛出该域全部命令
+      // Top level matches by "domain prefix + command name" (Chinese and English together): searching a domain name (e.g. "设置" / "Settings") filters out all commands in that domain
       .filter((it) => has(`${it.category} ${it.title} ${it.categoryEn} ${it.titleEn}`));
   }, [level, query, roots]);
 
-  // 列表变化后把高亮项夹在范围内
+  // After the list changes, clamp the highlighted item within range
   useEffect(() => {
     setActiveIndex((i) => Math.min(Math.max(0, i), Math.max(0, items.length - 1)));
   }, [items.length]);
 
-  // 高亮项滚入可视区：打开时默认选中的是 MRU 项（可能在列表中段），需自动滚到；方向键导航同理。
+  // Scroll the highlighted item into view: on open the default selection is the MRU item (may be mid-list) and needs auto-scroll; same for arrow-key navigation.
   useEffect(() => {
     if (open) activeItemRef.current?.scrollIntoView({ block: 'nearest' });
   }, [open, activeIndex, items.length]);
 
-  // 全局快捷键：mac Cmd+Shift+P / 其余 Ctrl+Shift+P 打开
+  // Global shortcut: mac Cmd+Shift+P / others Ctrl+Shift+P to open
   useEffect(() => {
     const isMac = platform === 'darwin';
     const onKey = (e: KeyboardEvent): void => {
@@ -264,7 +264,7 @@ export function CommandPalette({
         e.preventDefault();
         openPalette();
       } else if (k === 'u') {
-        // ⌘⇧U / Ctrl+Shift+U：直达「打开 URL」输入层（U = URL）
+        // ⌘⇧U / Ctrl+Shift+U: jump straight to the "open URL" input level (U = URL)
         e.preventDefault();
         openInputCommand('open-pr-url');
       }
@@ -274,15 +274,15 @@ export function CommandPalette({
   }, [platform, openPalette, openInputCommand]);
 
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    // 输入法合成中（IME 候选未确认）：该次按键（尤其 Enter）只用于确认候选词，不触发命令选择 / 导航。
-    // 否则中文等输入时，确认候选的 Enter 会同时选中命令进二级层，而 compositionend 的 onChange 又把候选词
-    // 写回 query → 二级层被残留词过滤（预期外的筛选）。确认后用户再按一次才动作，与各通用搜索框一致。
+    // During IME composition (candidate not yet confirmed): this keypress (especially Enter) is only for confirming the candidate, not triggering command selection / navigation.
+    // Otherwise, when typing Chinese etc., the Enter that confirms the candidate would also select the command and enter the second level, while compositionend's onChange writes the candidate
+    // back into query → the second level gets filtered by leftover text (unexpected filtering). The user presses once more after confirming to act, consistent with common search boxes.
     if (e.nativeEvent.isComposing) return;
     if (e.key === 'Escape') {
       e.preventDefault();
       close();
     } else if (e.key === 'Backspace' && level && query === '') {
-      // 二级层（提示符状态）下空查询按 Backspace 回退到上一级（顶层命令列表）
+      // At the second level (prompt state) with an empty query, Backspace goes back up one level (top-level command list)
       e.preventDefault();
       setLevel(null);
       setQuery('');
@@ -295,7 +295,7 @@ export function CommandPalette({
       setActiveIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      // 自由文本输入模式：回车把当前文本提交给命令（非空才提交）。
+      // Free-text input mode: Enter submits the current text to the command (only if non-empty).
       if (level?.input) {
         const text = query.trim();
         if (text) {
@@ -311,7 +311,7 @@ export function CommandPalette({
   return (
     <div className="cmdk">
       <div className="cmdk-field">
-        {/* 二级层前缀提示符：进入子层后显示简短前缀（prefixLabel，如「URL」）或回退命令名，稳住语境 */}
+        {/* Second-level prefix prompt: after entering a sub-level, show a short prefix (prefixLabel, e.g. "URL") or fall back to the command name, to anchor context */}
         {level && <span className="cmdk-field-prefix">{level.prefixLabel ?? level.title}</span>}
         <input
           ref={inputRef}
@@ -330,26 +330,26 @@ export function CommandPalette({
           }}
           onFocus={() => {
             if (blurTimer.current) clearTimeout(blurTimer.current);
-            // 点击聚焦打开（空查询、顶层）时同样预选最近用过的命令
+            // On click-focus open (empty query, top level), likewise pre-select the most recently used command
             if (query === '' && level === null) setActiveIndex(mruActiveIndex());
             setOpen(true);
           }}
           onBlur={() => {
-            // 延迟关闭：让下拉项的 click 先于 blur 生效（项的 onMouseDown 已 preventDefault 保住焦点）
+            // Delayed close: let a dropdown item's click take effect before blur (the item's onMouseDown already preventDefault to keep focus)
             blurTimer.current = setTimeout(close, 120);
           }}
           onKeyDown={onInputKeyDown}
           aria-label={t('commandPalette.placeholder')}
         />
       </div>
-      {/* 自由文本输入模式（如「打开 URL」）不出下拉层——没有可选项，纯输入 + 回车（占位已说明） */}
+      {/* Free-text input mode (e.g. "open URL") shows no dropdown — no options, pure input + Enter (the placeholder explains) */}
       {open && !level?.input && (
         <div className="cmdk-panel" role="listbox">
           {items.length === 0 ? (
             <div className="cmdk-empty">{t('commandPalette.empty')}</div>
           ) : (
             items.map((it, i) => {
-              // 非英语界面且英文与本地化不同 → 次行显示英文（对齐 VS Code 显示语言）
+              // Non-English UI and English differs from localized → show English on a secondary line (aligns with VS Code display language)
               const showEn =
                 !isEnglish &&
                 (it.titleEn !== it.title || (it.categoryEn ?? '') !== (it.category ?? ''));
@@ -362,8 +362,8 @@ export function CommandPalette({
                   aria-selected={i === activeIndex}
                   className={`cmdk-item${i === activeIndex ? ' is-active' : ''}`}
                   onMouseDown={(e) => e.preventDefault()}
-                  // 只认真实的鼠标移动来改高亮：面板在静止光标下弹出（mouseenter）、或键盘导航滚动把项
-                  // 移到光标下（合成事件、坐标不变），都不应抢走 MRU 默认选中 / 键盘选中。坐标真正变了才接管。
+                  // Only real mouse movement changes the highlight: the panel popping up under a stationary cursor (mouseenter), or keyboard-navigation scrolling moving an item
+                  // under the cursor (synthetic event, coordinates unchanged), must not steal the MRU default / keyboard selection. Only take over when coordinates truly change.
                   onMouseMove={(e) => {
                     if (e.clientX === pointerRef.current.x && e.clientY === pointerRef.current.y) {
                       return;

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/index.ts
@@ -6,9 +6,9 @@ import { buildSettingsCommands } from './settings';
 export * from './types';
 
 /**
- * 命令注册表：聚合各领域命令构建器。**新增领域 = 加一个 `<domain>.ts` 文件 + 在此登记**，
- * 上层（CommandPalette）只认 `buildRootCommands`。命令在面板里按此数组顺序、各自的 category 前缀分组；
- * 领域按**英文名字典序**固定排列（PR < Review < Settings），新增领域按此序插入对应位置。
+ * Command registry: aggregates each domain's command builder. **Adding a domain = add one `<domain>.ts` file + register it here**;
+ * the upper layer (CommandPalette) only knows `buildRootCommands`. Commands are grouped in the palette by this array's order, each under its own category prefix;
+ * domains are fixed in **English-name lexicographic order** (PR < Review < Settings), and new domains are inserted at the corresponding position by this order.
  */
 const DOMAIN_BUILDERS: ReadonlyArray<(ctx: CommandContext) => RootCommand[]> = [
   buildPrCommands,
@@ -17,9 +17,9 @@ const DOMAIN_BUILDERS: ReadonlyArray<(ctx: CommandContext) => RootCommand[]> = [
 ];
 
 export function buildRootCommands(ctx: CommandContext): RootCommand[] {
-  // 领域按 DOMAIN_BUILDERS 固定顺序（PR < Review < Settings）；**域内统一按英文标题字典序**排序，
-  // 使「查看 X / 分类筛选 / 切换…」等不依赖各域手工排列、动态生成的命令（如随平台能力的发现分类）也自动归位。
-  // 统一门控：命令声明 when 谓词，注册表在此统一过滤（各领域不再各写 if）。
+  // Domains follow DOMAIN_BUILDERS' fixed order (PR < Review < Settings); **within a domain, sort uniformly by English-title lexicographic order**,
+  // so dynamically generated commands (like discovery filters that vary by platform capability) such as "view X / filter by category / toggle…" also fall into place without per-domain manual ordering.
+  // Unified gating: commands declare a when predicate, and the registry filters here uniformly (domains no longer each write their own if).
   return DOMAIN_BUILDERS.flatMap((build) =>
     build(ctx)
       .filter((c) => !c.when || c.when())

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/pr.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/pr.ts
@@ -2,7 +2,7 @@ import type { PrDiscoveryFilter } from '@meebox/shared';
 import type { CommandContext, RootCommand } from './types';
 import { formatChord } from './shortcuts';
 
-/** 发现分类标签 i18n key（与 Sidebar 发现 tabs 同源；具体可用哪几类由 platform 能力决定）。 */
+/** i18n keys for discovery filter labels (same source as the Sidebar discovery tabs; which ones are available is decided by platform capability). */
 const DISCOVERY_LABEL_KEYS: Record<PrDiscoveryFilter, string> = {
   'review-requested': 'sidebar.discoveryReviewRequested',
   created: 'sidebar.discoveryCreated',
@@ -11,11 +11,11 @@ const DISCOVERY_LABEL_KEYS: Record<PrDiscoveryFilter, string> = {
 };
 
 /**
- * 「PR」领域命令：
- * - **一级分类**：每个发现分类（待我评审 / 我创建 / 指派我 / 提及我）各成一条一级命令，直接跳转；选项随
- *   当前 platform 能力门控，无分类的平台不提供。不显示当前选中态。
- * - **分类筛选（二级）**：筛选 PR 状态（待处理 / 全部 / 冲突 / 可合并等，与侧栏一致、随平台门控）。
- * - **切换 PR 列表**：折叠 / 展开侧栏。
+ * "PR" domain commands:
+ * - **Top-level filters**: each discovery filter (review requested / created / assigned / mentioned) becomes one top-level command that jumps directly; options are
+ *   gated by the current platform's capability, and platforms without a filter don't offer it. No current-selection state shown.
+ * - **Filter by category (second level)**: filter PR status (pending / all / conflict / mergeable etc., consistent with the sidebar, gated by platform).
+ * - **Toggle PR list**: collapse / expand the sidebar.
  */
 export function buildPrCommands(ctx: CommandContext): RootCommand[] {
   const { t, tEn, discoveryFilters, setDiscoveryFilter, prStatusFilters, setPrStatusFilter } = ctx;
@@ -23,7 +23,7 @@ export function buildPrCommands(ctx: CommandContext): RootCommand[] {
   const categoryEn = tEn('commandPalette.categoryPr');
   const out: RootCommand[] = [];
 
-  // 一级分类：按平台能力提供的顺序各成一条「查看「XXX」」命令（与 Sidebar 发现 tabs 同序），不显示选中态
+  // Top-level filters: in the order the platform capability provides, each becomes a "view «XXX»" command (same order as the Sidebar discovery tabs), no selection state shown
   for (const f of discoveryFilters) {
     const label = t(DISCOVERY_LABEL_KEYS[f]);
     const labelEn = tEn(DISCOVERY_LABEL_KEYS[f]);
@@ -37,8 +37,8 @@ export function buildPrCommands(ctx: CommandContext): RootCommand[] {
     });
   }
 
-  // 查看已关闭：切到归档（已关闭）范围浏览。快捷键取 H（history）；mac 用 ⌘⇧H 避开系统「隐藏应用」(⌘H)，
-  // 其余平台 Ctrl+H（浏览器历史惯例）。见 App 窗口级快捷键。
+  // View closed: switch to the archived (closed) scope to browse. Shortcut uses H (history); mac uses ⌘⇧H to avoid the system "Hide App" (⌘H),
+  // other platforms Ctrl+H (browser history convention). See App window-level shortcuts.
   out.push({
     id: 'view-archived',
     category,
@@ -49,7 +49,7 @@ export function buildPrCommands(ctx: CommandContext): RootCommand[] {
     run: () => ctx.viewArchived(),
   });
 
-  // 分类筛选：二级选择 PR 状态
+  // Filter by category: second level selects PR status
   out.push({
     id: 'filter-pr',
     category,
@@ -66,16 +66,16 @@ export function buildPrCommands(ctx: CommandContext): RootCommand[] {
       })),
   });
 
-  // 打开 URL（当前平台）：自由文本二级层，粘贴 / 输入 PR 链接回车打开（审查未正式被请求参与的他人 PR）
+  // Open URL (current platform): free-text second level, paste / type a PR link and Enter to open (review others' PRs you weren't formally requested on)
   out.push({
     id: 'open-pr-url',
     category,
     categoryEn,
     title: t('commandPalette.cmdOpenPrUrl'),
     titleEn: tEn('commandPalette.cmdOpenPrUrl'),
-    // 快捷键直达输入层（U = URL）；mac ⌘⇧U / 其余 Ctrl+Shift+U，见 CommandPalette 窗口级监听
+    // Shortcut jumps straight to the input level (U = URL); mac ⌘⇧U / others Ctrl+Shift+U, see CommandPalette window-level listener
     shortcut: formatChord(ctx.platform, 'U', { shift: true }),
-    // 输入层前缀只用简短「URL」（通用、免 i18n），不占整条命令标题
+    // The input-level prefix uses just a short "URL" (generic, no i18n), not the full command title
     prefixLabel: 'URL',
     input: {
       placeholder: t('commandPalette.openPrUrlPlaceholder'),

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/review.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/review.ts
@@ -12,9 +12,9 @@ function toggleAutopilot(ctx: CommandContext): void {
 }
 
 /**
- * 「评审」领域命令：开关 AutoPilot、对当前 PR 运行自动评审。运行自动评审走与 ChatPane「一键自动评审」
- * 同一通道（`agent:run`），运行态与会话经事件 / store 反映；需当前选中 PR 且 LLM 已配置才列出
- * （无 `when` 机制前先按上下文裁剪）。
+ * "Review" domain commands: toggle AutoPilot, run auto review on the current PR. Running auto review goes through the same channel
+ * (`agent:run`) as ChatPane's "one-click auto review"; run state and session are reflected via events / store; listed only when a PR is selected and the LLM is configured
+ * (trimmed by context until a `when` mechanism exists).
  */
 export function buildReviewCommands(ctx: CommandContext): RootCommand[] {
   const { t, tEn, selectedPrId, isPrRunning } = ctx;
@@ -26,15 +26,15 @@ export function buildReviewCommands(ctx: CommandContext): RootCommand[] {
     title: t(key),
     titleEn: tEn(key),
   });
-  // 域内按英文名字典序：Run Auto Review < Toggle AutoPilot < Toggle Chat Panel
+  // Within-domain English-name lexicographic order: Run Auto Review < Toggle AutoPilot < Toggle Chat Panel
   return [
     {
       id: 'run-auto-review',
       ...cmd('commandPalette.cmdRunAutoReview'),
-      // 门控：有选中 PR 才出现（无 PR 无意义）。执行时再做重入保护：同一 PR 已在跑则忽略。走与 ChatPane
-      // 一键评审同通道，运行态 / 会话经事件 + store 反映；LLM 未配置 / pr-agent 未就绪由后端按失败回流到会话。
+      // Gating: only appears when a PR is selected (meaningless without one). Reentrancy guard at execution: ignore if the same PR is already running. Uses the same channel as ChatPane's
+      // one-click review; run state / session reflected via events + store; LLM not configured / pr-agent not ready flow back into the session as a failure from the backend.
       when: () => Boolean(selectedPrId),
-      shortcut: ['F5'], // 运行（IDE 惯例）；单键避开组合冲突，见 App 窗口级快捷键
+      shortcut: ['F5'], // Run (IDE convention); single key avoids combo conflicts, see App window-level shortcuts
       run: () => {
         if (selectedPrId && !isPrRunning(selectedPrId)) {
           void invoke('agent:run', { localId: selectedPrId });

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/settings.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/settings.ts
@@ -7,15 +7,15 @@ import type { CommandContext, CommandOption, RootCommand } from './types';
 import { formatChord } from './shortcuts';
 
 function switchLanguage(ctx: CommandContext, next: SupportedLanguage): void {
-  void i18n.changeLanguage(next); // 渲染层实时切换
-  persistLanguage(next); // localStorage 缓存，下次启动命中
-  ctx.patchConfig((c) => ({ ...c, language: next })); // 同步 boot.config
-  void invoke('config:setLanguage', { language: next }); // 写盘 + 主进程 i18n
+  void i18n.changeLanguage(next); // live switch in the render layer
+  persistLanguage(next); // localStorage cache, hit on next launch
+  ctx.patchConfig((c) => ({ ...c, language: next })); // sync boot.config
+  void invoke('config:setLanguage', { language: next }); // write to disk + main-process i18n
 }
 
 function switchTheme(ctx: CommandContext, next: EditorTheme): void {
   const ap = ctx.config.appearance;
-  // 实时应用：写共享 store → App 的 useGlobalTheme 派生 data-theme / chrome / 持久化；字体不变沿用现值。
+  // Apply live: write the shared store → App's useGlobalTheme derives data-theme / chrome / persistence; font unchanged, keeps current value.
   setEditorAppearance({
     editorTheme: next,
     fontFamily: ap.editor_font_family,
@@ -42,15 +42,15 @@ function toggleProxy(ctx: CommandContext): void {
 }
 
 /**
- * 「设置」领域命令（P1）：切换语言 / 主题 / 模型、开关代理、打开设置 / 关于 / DevTools。
- * title 经当前语言本地化（搜索按当前语言匹配）；二级选项惰性求值、读当前 config 标注生效项。
+ * "Settings" domain commands (P1): switch language / theme / model, toggle proxy, open settings / about / DevTools.
+ * title is localized in the current language (search matches the current language); second-level options are lazily evaluated, reading the current config to mark the active item.
  */
 export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
   const { t, tEn, config } = ctx;
   const category = t('commandPalette.categorySettings');
   const categoryEn = tEn('commandPalette.categorySettings');
   const currentLang = resolveUiLanguage(config.language);
-  // 本地化 + 英文双标题（含领域前缀），供两行展示 + 恒按英文检索
+  // Dual title, localized + English (including domain prefix), for two-line display + always searchable in English
   const cmd = (key: string): Pick<RootCommand, 'title' | 'titleEn' | 'category' | 'categoryEn'> => ({
     category,
     categoryEn,
@@ -62,7 +62,7 @@ export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
       id: 'switch-language',
       ...cmd('commandPalette.cmdSwitchLanguage'),
       optionsPlaceholder: t('commandPalette.pickLanguage'),
-      // 语言展示用 endonym（各 UI 语言下一致、不翻译）→ 无需 titleEn
+      // Languages display by endonym (consistent across all UI languages, not translated) → no titleEn needed
       options: () =>
         LANGUAGE_OPTIONS.map((o) => ({
           id: o.code,
@@ -75,7 +75,7 @@ export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
       id: 'switch-theme',
       ...cmd('commandPalette.cmdSwitchTheme'),
       optionsPlaceholder: t('commandPalette.pickTheme'),
-      // 主题用专名（GitHub Dark / Monokai…，不翻译）；仅 'auto' 走 i18n（与设置页一致）
+      // Themes use proper names (GitHub Dark / Monokai…, not translated); only 'auto' goes through i18n (consistent with the settings page)
       options: () =>
         EDITOR_THEME_OPTIONS.map((o) => ({
           id: o.id,
@@ -96,7 +96,7 @@ export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
           active: p.id === config.llm.active_id,
           run: () => switchModel(ctx, p.id),
         }));
-        // 末尾固定「添加模型…」入口：打开设置的「模型」分区新建预设（无预设时即唯一项）
+        // Fixed "add model…" entry at the end: opens the settings "model" section to create a new profile (the only item when there are no profiles)
         items.push({
           id: '__add_model__',
           title: t('commandPalette.addModel'),
@@ -108,7 +108,7 @@ export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
     },
     {
       id: 'toggle-proxy',
-      // 切换型命令用单一文案（不随状态翻转）；当前开关状态在设置页查看
+      // Toggle commands use a single label (not flipped by state); check the current toggle state on the settings page
       ...cmd('commandPalette.cmdToggleProxy'),
       run: () => toggleProxy(ctx),
     },
@@ -125,7 +125,7 @@ export function buildSettingsCommands(ctx: CommandContext): RootCommand[] {
     {
       id: 'open-devtools',
       ...cmd('commandPalette.cmdOpenDevtools'),
-      // DevTools 惯例：mac ⌥⌘I / 其余 Ctrl+Shift+I（见 App 窗口级快捷键）
+      // DevTools convention: mac ⌥⌘I / others Ctrl+Shift+I (see App window-level shortcuts)
       shortcut: formatChord(ctx.platform, 'I', ctx.platform === 'darwin' ? { alt: true } : { shift: true }),
       run: () => {
         void invoke('app:openDevTools', undefined);

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/shortcuts.ts
@@ -1,9 +1,9 @@
 import type { Platform } from '@meebox/shared';
 
 /**
- * 把快捷键拆成**按键 token 数组**（一键一框、VS Code 风）：macOS 用符号（`⌥`/`⇧`/`⌘`/`B`），
- * 其余平台用文字（`Ctrl`/`Shift`/`Alt`/`B`）。仅用于命令面板右侧的提示展示；实际按键匹配在窗口级
- * 监听里另行判定（见 App 的快捷键 effect）。
+ * Split a shortcut into a **key token array** (one box per key, VS Code style): macOS uses symbols (`⌥`/`⇧`/`⌘`/`B`),
+ * other platforms use text (`Ctrl`/`Shift`/`Alt`/`B`). Only for the hint display on the right side of the command palette; the actual key matching
+ * is judged separately in the window-level listener (see App's shortcut effect).
  */
 export function formatChord(
   platform: Platform,

--- a/apps/desktop/src/renderer/src/components/features/command-palette/commands/types.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/commands/types.ts
@@ -4,79 +4,79 @@ import type { SettingsCategory } from '../../settings';
 import type { FilterKey } from '../../../layout/Sidebar';
 
 /**
- * 命令面板的执行上下文：当前配置 + 同步父级状态的钩子 + 打开设置面板 + 当前语言的 t。
- * 命令的「即时生效」复用设置页同一套原语（i18n.changeLanguage / editor-appearance store / config:* IPC），
- * 不另起一套，保证与设置页行为一致。各领域命令构建器都接收它。
+ * The command palette's execution context: current config + hooks to sync parent state + open settings panel + current-language t.
+ * The command's "instant effect" reuses the same primitives as the settings page (i18n.changeLanguage / editor-appearance store / config:* IPC),
+ * without spinning up a separate set, ensuring behavior consistent with the settings page. Every domain's command builder receives it.
  */
 export interface CommandContext {
-  /** 运行平台：命令格式化快捷键提示（mac ⌘ / 其余 Ctrl）等用。 */
+  /** Running platform: used by commands to format shortcut hints (mac ⌘ / others Ctrl), etc. */
   platform: Platform;
   config: Config;
-  /** 当前选中 PR 的 localId（无选中为 null）；上下文相关命令（如运行自动评审）据此裁剪 / 取目标。 */
+  /** localId of the currently selected PR (null if none selected); context-relevant commands (such as running auto review) use it to trim / pick the target. */
   selectedPrId: string | null;
-  /** 某 PR 是否有编排 Agent 运行中（重入保护用，调用时取实时态）。 */
+  /** Whether a PR has an orchestration Agent running (for re-entry protection; reads the live state at call time). */
   isPrRunning: (localId: string) => boolean;
-  /** 切换对话面板折叠（命令面板的「切换对话面板」用）。 */
+  /** Toggle chat panel collapse (used by the command palette's "toggle chat panel"). */
   toggleChatPanel: () => void;
-  /** 切换 PR 列表（侧栏）折叠（命令面板的「切换 PR 列表」用）。 */
+  /** Toggle PR list (sidebar) collapse (used by the command palette's "toggle PR list"). */
   togglePrList: () => void;
-  /** 当前 platform 能力支持的 PR 发现分类（空=该平台无分类，对应一级命令不提供）。 */
+  /** PR discovery categories supported by the current platform's capabilities (empty = the platform has no categories, the corresponding top-level command is not provided). */
   discoveryFilters: readonly PrDiscoveryFilter[];
-  /** 跳到某发现分类（PR 域「查看 X」命令用，如「待我评审」）；隐含切回「进行中」范围。 */
+  /** Jump to a discovery category (used by PR-domain "view X" commands, such as "awaiting my review"); implicitly switches back to the "in progress" scope. */
   setDiscoveryFilter: (filter: PrDiscoveryFilter) => void;
-  /** 切到「已关闭」（归档）范围（PR 域「查看已关闭」命令用）。 */
+  /** Switch to the "closed" (archived) scope (used by the PR-domain "view closed" command). */
   viewArchived: () => void;
-  /** 按 URL 打开当前平台的 PR（PR 域「打开 URL」自由文本命令用）：定位本地或拉取存档后跳转，失败弹 toast。 */
+  /** Open a PR of the current platform by URL (used by the PR-domain "open URL" free-text command): locate locally or fetch the archive then jump, popping a toast on failure. */
   openPrByUrl: (url: string) => void | Promise<void>;
-  /** 可选的 PR 状态筛选项（待处理 / 全部 / 冲突 / 可合并等，已按平台门控）。 */
+  /** Optional PR status filter items (pending / all / conflict / mergeable, etc., already gated by platform). */
   prStatusFilters: ReadonlyArray<{ value: FilterKey; labelKey: string }>;
-  /** 设置 PR 状态筛选（PR 域「分类筛选」二级选项用）。 */
+  /** Set the PR status filter (used by the PR-domain "category filter" second-level options). */
   setPrStatusFilter: (filter: FilterKey) => void;
   patchConfig: (updater: (c: Config) => Config) => void;
   openSettings: (category?: SettingsCategory) => void;
-  /** 当前界面语言的翻译函数 */
+  /** Translation function for the current UI language */
   t: TFunction;
-  /** 固定英文（en-US）翻译函数：非英语界面下作次行展示，并恒参与检索（对齐 VS Code） */
+  /** Fixed English (en-US) translation function: shown as a secondary line under a non-English UI, and always participates in search (aligning with VS Code) */
   tEn: TFunction;
 }
 
-/** 二级选项（叶子，直接执行）。`active` 标注当前生效项（打勾）。 */
+/** Second-level option (leaf, executes directly). `active` marks the currently effective item (checked). */
 export interface CommandOption {
   id: string;
   title: string;
-  /** 英文名（缺省=title，即各语言一致的专名/数据项）；非英语界面作次行 + 恒参与检索 */
+  /** English name (default = title, i.e. a proper name / data item consistent across languages); shown as a secondary line under a non-English UI + always participates in search */
   titleEn?: string;
   active?: boolean;
   run: () => void;
 }
 
 /**
- * 顶层命令：要么直接执行（`run`），要么进入二级选项（`options`）。**最多两级**、不支持返回上级
- * （Esc 退出后重进，见 docs/arch/03-gui/02-command-palette）。`title` / `category` 已按当前界面语言本地化，供按当前语言搜索。
+ * Top-level command: either executes directly (`run`), or enters second-level options (`options`). **At most two levels**, going back up is not supported
+ * (exit with Esc then re-enter, see docs/arch/03-gui/02-command-palette). `title` / `category` are already localized to the current UI language, for searching in the current language.
  */
 export interface RootCommand {
   id: string;
-  /** 上下文门控（可选）：返回 false 则该命令不出现在列表。缺省=恒可见。由注册表统一过滤，各领域只需声明。 */
+  /** Context gating (optional): returning false hides this command from the list. Default = always visible. Filtered uniformly by the registry; each domain only needs to declare it. */
   when?: () => boolean;
   title: string;
-  /** 英文标题：非英语界面作次行展示，并恒参与检索（对齐 VS Code 显示语言 + 英文检索） */
+  /** English title: shown as a secondary line under a non-English UI, and always participates in search (aligning with VS Code display language + English search) */
   titleEn: string;
   category: string;
-  /** 英文领域前缀：同 titleEn，用于次行展示与英文检索 */
+  /** English domain prefix: same as titleEn, used for secondary-line display and English search */
   categoryEn: string;
-  /** 快捷键按键 token 列表（一键一框，如 `['⌘','B']` / `['Ctrl','B']`），在命令项右侧展示；缺省=无 */
+  /** Shortcut key token list (one box per key, e.g. `['⌘','B']` / `['Ctrl','B']`), shown on the right side of the command item; default = none */
   shortcut?: string[];
-  /** 进入二级后的输入框占位提示 */
+  /** Input placeholder hint after entering the second level */
   optionsPlaceholder?: string;
-  /** 进入二级后输入框左侧的简短前缀提示符（如「URL」）；缺省回退到命令标题。 */
+  /** Short prefix indicator to the left of the input after entering the second level (e.g. "URL"); default falls back to the command title. */
   prefixLabel?: string;
-  /** 二级选项（惰性求值，读当前 config 标注 active）；与 run / input 三选一 */
+  /** Second-level options (lazily evaluated, reads current config to mark active); one of run / input / this three */
   options?: () => CommandOption[];
   /**
-   * 自由文本输入（二级）：选中后二级层不是选项列表，而是把输入框转为接受任意文本，回车提交给 `run`。
-   * 用于「按 URL 打开 PR」这类需用户粘贴 / 输入的命令。与 options / 顶层 run 互斥。
+   * Free-text input (second level): once selected, the second level is not an option list but turns the input box into one that accepts arbitrary text, submitting to `run` on Enter.
+   * Used for commands like "open PR by URL" that require the user to paste / type. Mutually exclusive with options / top-level run.
    */
   input?: { placeholder: string; run: (text: string) => void | Promise<void> };
-  /** 叶子命令的执行；与 options / input 二选一 */
+  /** Execution of a leaf command; one of options / input two */
   run?: () => void;
 }

--- a/apps/desktop/src/renderer/src/components/features/command-palette/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/index.ts
@@ -1,3 +1,3 @@
-// features/command-palette 对外公共 API：标题栏命令面板组件。
+// features/command-palette public API: title-bar command palette component.
 export { CommandPalette } from './CommandPalette';
 export type { CommandContext, RootCommand, CommandOption } from './commands';

--- a/apps/desktop/src/renderer/src/components/features/command-palette/mru.ts
+++ b/apps/desktop/src/renderer/src/components/features/command-palette/mru.ts
@@ -1,11 +1,11 @@
-// 命令面板 MRU（最近使用）：仅存顶层命令 id 的小列表，用于「打开即预选上次用的命令」。
-// 纯本机 UI 顺手优化，存 localStorage（与主题 / 语言持久化同套，无 IPC）；丢失无碍（下次重新积累）。
-// 存成小列表（非单值）以便将来升级到「最近使用置顶分组」时不必改存储格式。
+// Command palette MRU (most recently used): stores only a small list of top-level command ids, used to "preselect the last-used command on open".
+// A purely local UI convenience optimization, stored in localStorage (same setup as theme / language persistence, no IPC); losing it is harmless (re-accumulated next time).
+// Stored as a small list (not a single value) so that a future upgrade to "MRU pinned group" won't require changing the storage format.
 
 const KEY = 'meebox.commandPalette.mru';
 const CAP = 8;
 
-/** 读 MRU（最近在前）；缺失 / 损坏 / localStorage 不可用一律当空。 */
+/** Read the MRU (most recent first); missing / corrupt / localStorage unavailable are all treated as empty. */
 export function readMru(): string[] {
   try {
     const raw = localStorage.getItem(KEY);
@@ -17,12 +17,12 @@ export function readMru(): string[] {
   }
 }
 
-/** 记一次使用：把 id 提到最前、去重、封顶后写回。localStorage 不可用时静默跳过。 */
+/** Record a use: move the id to the front, dedupe, cap, then write back. Silently skips when localStorage is unavailable. */
 export function pushMru(id: string): void {
   try {
     const next = [id, ...readMru().filter((x) => x !== id)].slice(0, CAP);
     localStorage.setItem(KEY, JSON.stringify(next));
   } catch {
-    // 仅为顺手优化，写失败忽略
+    // Just a convenience optimization; ignore write failures
   }
 }

--- a/apps/desktop/src/renderer/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/OnboardingWizard.tsx
@@ -15,27 +15,27 @@ import { PlatformStep } from './steps/PlatformStep';
 import { LlmStep } from './steps/LlmStep';
 import { DoneStep } from './steps/DoneStep';
 
-/** 向导收集到的配置，交由 App 落盘（config:setConnections 等）后切入主界面 */
+/** Config collected by the wizard, handed to App to persist (config:setConnections etc.) before switching into the main UI */
 export interface OnboardingResult {
   connection: ConnEntry;
-  /** 用户填了并通过校验的 LLM 预设；跳过时为 null */
+  /** LLM profile the user filled in and that passed validation; null when skipped */
   llm: LlmProfile | null;
-  /** 缓存目录原始输入（含 `~`）；App 与初值比较后决定是否 config:setReposDir */
+  /** Raw cache directory input (may contain `~`); App compares against the initial value to decide whether to config:setReposDir */
   reposDir: string;
 }
 
 interface OnboardingWizardProps {
-  /** 唯一性校验用（首启通常为空） */
+  /** For uniqueness validation (usually empty on first launch) */
   existingLlmProfiles: LlmProfile[];
-  /** 缓存目录初值（config.workspace.repos_dir，未展开的 `~/...` 形态） */
+  /** Initial cache directory (config.workspace.repos_dir, unexpanded `~/...` form) */
   initialReposDir: string;
-  /** UI 语言初值（config.language 原始值，空串=自动）；欢迎页据此回显，空则按 OS 偏好 */
+  /** Initial UI language (config.language raw value, empty string = auto); the welcome page echoes it back, falling back to OS preference when empty */
   initialLanguage: string;
-  /** 全部配置完成 → App 落盘 + 切主界面。reject 时向导展示错误允许重试 */
+  /** All config done → App persists + switches to main UI. On reject the wizard shows the error and allows a retry */
   onComplete: (result: OnboardingResult) => Promise<void>;
 }
 
-// 步骤：欢迎 → 平台（必填）→ LLM（可跳过）→ 完成
+// Steps: welcome → platform (required) → LLM (skippable) → done
 const STEP_KEYS = [
   'onboarding.stepWelcome',
   'onboarding.stepPlatform',
@@ -52,8 +52,8 @@ export function OnboardingWizard({
   const { t } = useTranslation();
   const [step, setStep] = useState(0);
 
-  // 界面语言：即时生效（写盘 + 渲染层切换）。初值取当前生效语言——无配置时按 OS 偏好匹配。
-  // 选择项放在欢迎页底部 nav（复用其分割线），仅 step 0 显示。
+  // UI language: takes effect immediately (persist + renderer switch). Initial value is the currently effective language — falls back to matching OS preference when unconfigured.
+  // The picker sits in the welcome page's bottom nav (reusing its divider), shown only on step 0.
   const [language, setLanguage] = useState<SupportedLanguage>(() =>
     resolveUiLanguage(initialLanguage),
   );
@@ -63,7 +63,7 @@ export function OnboardingWizard({
     void i18n.changeLanguage(next);
     persistLanguage(next);
     void invoke('config:setLanguage', { language: next }).catch(() => {
-      /* 写盘失败不阻断向导：渲染层已切、localStorage 已存，完成向导后随整体落盘兜底 */
+      /* A persist failure does not block the wizard: the renderer already switched, localStorage is already stored, and the overall persist on wizard completion is the fallback */
     });
   };
 
@@ -87,7 +87,7 @@ export function OnboardingWizard({
     api_key: '',
   }));
   const [llmValid, setLlmValid] = useState(false);
-  // null = 还没决定；true = 带 LLM 进入；false = 跳过。Done 页据此显示摘要
+  // null = not yet decided; true = enter with LLM; false = skip. The Done page shows the summary based on this
   const [includeLlm, setIncludeLlm] = useState<boolean | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
@@ -105,7 +105,7 @@ export function OnboardingWizard({
         llm: includeLlm ? llmDraft : null,
         reposDir,
       });
-      // 成功后由 App 卸载本组件，无需复位本地状态
+      // On success App unmounts this component, so no need to reset local state
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : String(e));
       setSubmitting(false);
@@ -161,8 +161,8 @@ export function OnboardingWizard({
               </button>
             )}
           </div>
-          {/* 欢迎页：语言选择放在底部 nav（复用其分割线），居于两端（空）之间 → 居中显示。
-              选项用各语言自身 endonym，不随 UI 翻译；选择即时生效。 */}
+          {/* Welcome page: the language picker sits in the bottom nav (reusing its divider), between the two (empty) ends → centered.
+              Options use each language's own endonym, not the UI translation; selection takes effect immediately. */}
           {step === 0 && (
             <div className="onboarding-nav-language">
               <span className="muted">{t('onboarding.languageLabel')}</span>

--- a/apps/desktop/src/renderer/src/components/features/onboarding/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/index.ts
@@ -1,3 +1,3 @@
-// features/onboarding 对外公共 API：首启向导组件 + 其收集结果类型。
+// features/onboarding public API: onboarding wizard component + its collected result type.
 export { OnboardingWizard } from './OnboardingWizard';
 export type { OnboardingResult } from './OnboardingWizard';

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/LlmStep.tsx
@@ -16,7 +16,7 @@ export function LlmStep({
   onValidityChange: (valid: boolean) => void;
 }) {
   const { t } = useTranslation();
-  // 两阶段：先选 provider（居中滚动列表）→ 选定后列表收到左侧、右侧展开配置
+  // Two phases: first pick a provider (centered scrolling list) → once chosen the list collapses to the left and the config expands on the right
   const [chosen, setChosen] = useState(false);
   const pick = (provider: LlmProfile['provider']): void => {
     onChange({ ...draft, provider });
@@ -28,9 +28,9 @@ export function LlmStep({
       <p className="muted onboarding-step-sub">{t('onboarding.llmSub')}</p>
 
       {!chosen ? (
-        // 阶段一：居中的 provider 选择列表（滚动）
+        // Phase one: centered provider pick list (scrolling)
         <div className="onboarding-provider-pick">
-          {/* 阶段一沿用中性配置选择器视觉，但每项尾随「›」提示可进入、且不预选高亮 */}
+          {/* Phase one reuses the neutral config picker visuals, but each item trails a "›" hinting it's enterable and has no pre-selected highlight */}
           <div
             className="config-pick-list"
             role="radiogroup"
@@ -58,7 +58,7 @@ export function LlmStep({
           </div>
         </div>
       ) : (
-        // 阶段二：左侧列表（图标左移）+ 右侧配置
+        // Phase two: left list (icons shifted left) + right config
         <div className="onboarding-llm-grid">
           <LlmProviderPicker
             value={draft.provider}

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/PlatformStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/PlatformStep.tsx
@@ -24,14 +24,14 @@ export function PlatformStep({
       <h2 className="onboarding-step-title">{t('onboarding.platformTitle')}</h2>
       <p className="muted onboarding-step-sub">{t('onboarding.platformSub')}</p>
       <div className="config-pick-grid">
-        {/* 左：平台方案选择 */}
+        {/* Left: platform choice */}
         <PlatformPicker
           value={connDraft.kind}
           onChange={(kind) => onConnChange({ ...connDraft, kind })}
           ariaLabel={t('onboarding.platformGroupAria')}
         />
 
-        {/* 右：连接表单 + 折叠缓存目录 */}
+        {/* Right: connection form + collapsible cache directory */}
         <div className="config-pick-form">
           <ConnectionForm draft={connDraft} onChange={onConnChange} autoFocus={false} />
 

--- a/apps/desktop/src/renderer/src/components/features/onboarding/steps/WelcomeStep.tsx
+++ b/apps/desktop/src/renderer/src/components/features/onboarding/steps/WelcomeStep.tsx
@@ -5,8 +5,8 @@ import { PullRequestIcon } from '../../../common';
 
 export function WelcomeStep({ onStart }: { onStart: () => void }) {
   const { t } = useTranslation();
-  // 隐藏后门：连续快速点击 logo 7 次打开 DevTools（每次间隔 > 800ms 则计数清零）。
-  // 首启向导下没有菜单 / 状态栏入口，给开发排障留一个不显眼的手势。
+  // Hidden backdoor: 7 rapid clicks on the logo open DevTools (an interval > 800ms between clicks resets the count).
+  // The onboarding wizard has no menu / status bar entry, so this leaves an unobtrusive gesture for dev troubleshooting.
   const tapRef = useRef<{ count: number; last: number }>({ count: 0, last: 0 });
   const onLogoTap = (): void => {
     const now = performance.now();

--- a/apps/desktop/src/renderer/src/components/features/pr/PrEmpty.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/PrEmpty.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
 
 /**
- * PR 工作区空态：未选中 PR 时的主区占位。按是否已配置连接给不同引导
- * （有连接 → 提示去左侧选 PR；无连接 → 提示去设置加连接）。
+ * PR workspace empty state: main-area placeholder when no PR is selected. Shows
+ * different guidance based on whether a connection is configured (has connection →
+ * prompt to pick a PR on the left; no connection → prompt to add one in settings).
  */
 export function PrEmpty({ hasConnections }: { hasConnections: boolean }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/pr/PrHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/PrHeader.tsx
@@ -10,8 +10,8 @@ import { ApproveIcon, GlobeIcon, NeedsWorkIcon, PullRequestIcon } from '../../co
 import { ReviewerStack } from './ReviewerStack';
 
 /**
- * PR 详情头：标题 / 元信息 + 动作区（浏览器打开 · 提交评论 N · 合并 · 通过 / 需修改）。
- * 审批按钮按平台能力位降级；自己作者的 PR 不能审批（灰显 + 原因）。
+ * PR detail header: title / meta + action area (open in browser · publish comments N · merge · approve / needs work).
+ * Approval buttons degrade by platform capability bits; you cannot approve your own PR (disabled + reason).
  */
 export function PrHeader({
   pr,
@@ -31,21 +31,21 @@ export function PrHeader({
   merging: boolean;
   onMerge: () => void;
   onSetStatus: (status: LocalPrStatus) => void;
-  /** 隐藏 PR 生命周期操作（合并 + 评审决断）：已关闭范围恒置。 */
+  /** Hide PR lifecycle actions (merge + review decision): always set for the closed scope. */
   hideLifecycle?: boolean;
-  /** 内容只读（decline / 不可参与）：隐藏「提交评论 (N)」发布入口。 */
+  /** Content read-only (declined / cannot participate): hides the "publish comments (N)" entry. */
   readOnly?: boolean;
   publishableCount: number;
   onPublish: () => void;
 }) {
   const { t } = useTranslation();
-  // 能力位降级：reviewStatuses 决定审批按钮显隐；capabilities undefined（旧数据/无连接）时不降级。
+  // Capability-bit degradation: reviewStatuses drives approval-button visibility; no degradation when capabilities is undefined (old data / no connection).
   const reviewAllowed = (s: ReviewerStatus): boolean =>
     !capabilities || capabilities.reviewStatuses.includes(s);
   const isOwnPr = !!currentUserName && pr.author.name === currentUserName;
   const ownPrReason = isOwnPr ? t('mainPane.ownPrReason') : undefined;
-  // 「我的评审」：取当前用户的 reviewer 条目（头像），角标状态用本地决断 localStatus（审批按钮即时更新，
-  // 比远端 reviewer.status 更跟手）。自己作者的 PR 不可评审 → 不展示。
+  // "My review": take the current user's reviewer entry (avatar); the badge status uses the local decision localStatus
+  // (approval buttons update instantly, more responsive than the remote reviewer.status). Your own PR is not reviewable → not shown.
   const selfReviewer =
     !isOwnPr && currentUserName ? pr.reviewers.find((r) => r.name === currentUserName) : undefined;
   const selfReviewStatus: ReviewerStatus =
@@ -88,7 +88,7 @@ export function PrHeader({
             </span>
           </div>
         </div>
-        {/* reviewer 头像栈：标题 + 元信息 band 右侧、按钮行之上，垂直居中 */}
+        {/* reviewer avatar stack: right of the title + meta band, above the button row, vertically centered */}
         <ReviewerStack
           reviewers={pr.reviewers}
           connectionId={pr.connectionId}
@@ -106,10 +106,10 @@ export function PrHeader({
         >
           <GlobeIcon /> {t('mainPane.openInBrowser')}
         </a>
-        {/* approve / needs work：当前状态 = 高亮；点已高亮的回退到 pending（撤销远端标记）。
-            「提交评论 (N)」放在决断按钮左边 — 评审动作分两步：先发评论 (左)，再下决断 (右)。 */}
+        {/* approve / needs work: current status = highlighted; clicking an already-highlighted one falls back to pending (revokes the remote mark).
+            "Publish comments (N)" sits to the left of the decision buttons — reviewing is two steps: post comments first (left), then make the decision (right). */}
         <div className="pr-header-actions-right">
-          {/* "提交评论" 仅在有待发布草稿时渲染：N=0 时整按钮隐藏，减少 header 视觉噪音。 */}
+          {/* "Publish comments" renders only when there are drafts pending publish: at N=0 the whole button hides, reducing header visual noise. */}
           {!readOnly && publishableCount > 0 && (
             <button
               type="button"
@@ -120,7 +120,7 @@ export function PrHeader({
               {t('mainPane.publishComments', { n: publishableCount })}
             </button>
           )}
-          {/* 合并按钮：仅在服务端判定可合并 (canMerge) 时出现。点击直接合并（无二次确认）。只读隐藏。 */}
+          {/* Merge button: appears only when the server deems it mergeable (canMerge). Clicking merges directly (no confirmation). Hidden when read-only. */}
           {!hideLifecycle && pr.mergeStatus?.canMerge && (
             <button
               type="button"

--- a/apps/desktop/src/renderer/src/components/features/pr/PrItem.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/PrItem.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import type { AgentRecommendationVerdict, StoredPullRequest } from '@meebox/shared';
 import { Avatar, PersonIcon, PullRequestIcon, StarIcon } from '../../common';
 
-/** 评审建议 verdict → 复用 chatPane.agent.* 文案（不另加 i18n）。 */
+/** Review recommendation verdict → reuse chatPane.agent.* strings (no extra i18n). */
 const VERDICT_TITLE: Record<string, string> = {
   approve: 'chatPane.agent.verdictApprove',
   needs_work: 'chatPane.agent.verdictNeedsWork',
@@ -13,9 +13,9 @@ interface PrItemProps {
   pr: StoredPullRequest;
   selected: boolean;
   onClick: () => void;
-  /** 评审建议倾向（手动 / AutoPilot 评审写入的台账，一视同仁）；无则不显示 ★ 徽标。 */
+  /** Review recommendation leaning (ledger written by manual / AutoPilot review, treated alike); absent → no ★ badge. */
   reviewVerdict?: AgentRecommendationVerdict | null;
-  /** 该 PR 当前有在执行的 agent 任务（工具 run 在跑 / 排队）：同位置显示蓝色「执行中」动画指示。 */
+  /** This PR currently has a running agent task (tool run running / queued): shows a blue "executing" animated indicator in the same spot. */
   executing?: boolean;
 }
 
@@ -23,11 +23,11 @@ export function PrItem({ pr, selected, onClick, reviewVerdict, executing }: PrIt
   const { t } = useTranslation();
   const approvedCount = pr.reviewers.filter((r) => r.status === 'approved').length;
   const needsWorkCount = pr.reviewers.filter((r) => r.status === 'needsWork').length;
-  // 「@我 / 回复我」未读条数：>0 时标题左的未读圆点替换为中性数字 chip（封顶 10 → 显示「10+」）；
-  // 仅新到达 / 新 commit 的未读（计数为 0）仍显示圆点。二者在该槽位互斥。
+  // "@me / replied to me" unread count: when >0, the unread dot left of the title is replaced by a neutral number chip (capped at 10 → shows "10+");
+  // unread from only new arrivals / new commits (count 0) still shows the dot. The two are mutually exclusive in that slot.
   const mentionCount = pr.unreadMentionCount ?? 0;
-  // 服务端判定可直接合并：列表里用分支合并图标 chip 标注（纯状态，无数值）。
-  // 可选链兜底：升级前持久化的 meta.json 可能尚无 mergeStatus，下一轮 poll 会补齐
+  // Server deems it directly mergeable: marked in the list with a branch-merge icon chip (pure status, no number).
+  // Optional-chaining fallback: meta.json persisted before the upgrade may not yet have mergeStatus; the next poll fills it in
   const canMerge = pr.mergeStatus?.canMerge ?? false;
   return (
     <div
@@ -83,8 +83,8 @@ export function PrItem({ pr, selected, onClick, reviewVerdict, executing }: PrIt
               reviewVerdict ||
               executing) && (
               <span className="pr-item-review-chips">
-                {/* 执行中优先占位（同 ★ 位置）：复用运行卡片同款 .spinner（蓝色环旋转、中心对称），
-                    裸图标无 chip 外框，表示该 PR 有在跑的 agent 任务。 */}
+                {/* Executing takes priority in the slot (same ★ position): reuses the run card's .spinner (blue rotating ring, centrally symmetric),
+                    a bare icon with no chip frame, indicating this PR has a running agent task. */}
                 {executing && (
                   <span
                     className="spinner pr-item-spinner"

--- a/apps/desktop/src/renderer/src/components/features/pr/PrPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/PrPanel.tsx
@@ -13,8 +13,8 @@ import { useDraftsForPr } from '../../../stores/drafts-store';
 import { PaneLoading } from '../../common';
 import { ActivityPanel } from './tabs/activity/ActivityPanel';
 import { CommitsPanel } from './tabs/CommitsPanel';
-// Monaco 编辑器（~10MB）懒加载：只有真正切到 Diff tab 才拉取 DiffView chunk，
-// 不阻塞窗口首帧 / PR 列表 / 首启向导。
+// Monaco editor (~10MB) lazy-loaded: the DiffView chunk is fetched only when actually switching to the Diff tab,
+// so it doesn't block the window's first frame / PR list / first-run wizard.
 const DiffView = lazy(() => import('./tabs/diff/DiffView').then((m) => ({ default: m.DiffView })));
 import type { PendingCommitView } from './tabs/diff/DiffView';
 import { DraftsPanel } from './tabs/drafts/DraftsPanel';
@@ -30,9 +30,9 @@ export interface PrPanelProps {
   merging?: boolean;
   capabilities?: PlatformCapabilities;
   currentUserName?: string | null;
-  /** 隐藏 PR 生命周期操作（合并 / 审批）：已关闭范围恒置（退场 PR 不再做评审决断 / 合并）。 */
+  /** Hide PR lifecycle actions (merge / approval): always set for the closed scope (departed PRs no longer take review decisions / merges). */
   hideLifecycle?: boolean;
-  /** 内容只读（decline / 不可参与）：隐藏评论 / 草稿等写入入口，仅供浏览。合并 / 仍开放的归档 PR 为 false。 */
+  /** Content read-only (declined / cannot participate): hides comment / draft and other write entries, browse-only. False for merged / still-open archived PRs. */
   readOnly?: boolean;
   pendingDiffNav?: {
     runId?: string;
@@ -45,17 +45,17 @@ export interface PrPanelProps {
     findingId?: string;
     anchor: { path: string; startLine: number; endLine: number };
   }) => void;
-  /** 外部请求切到指定标签（如通知点击 summary 评论 → 'activity'）；消费后经 onPendingTabConsumed 清空。 */
+  /** External request to switch to a given tab (e.g. clicking a summary comment notification → 'activity'); cleared via onPendingTabConsumed after consumption. */
   pendingTab?: PrTab | null;
   onPendingTabConsumed?: () => void;
-  /** Diff 视图当前查看的单 commit 范围变化上报（→ App → ChatPane 隐式范围）；全部变更 / root commit 为 null。 */
+  /** Reports changes to the single-commit scope currently viewed in the Diff view (→ App → ChatPane implicit scope); null for all changes / root commit. */
   onViewCommitScopeChange?: (scope: ReviewRunCommitScope | null) => void;
 }
 
 /**
- * PR 评审工作区：头部（标题 / 动作）+ tab 栏 + tab 内容（diff / 评论 / 草稿 / 提交 / 信息）+
- * 发布评论弹窗。承载 PR 详情相关的全部状态（当前 tab / diff 视图选项 / 评论 + 提交计数 /
- * 草稿池 / 发布弹窗），由 layout/MainPane 在选中 PR 时挂载。
+ * PR review workspace: header (title / actions) + tab bar + tab content (diff / comments / drafts / commits / info) +
+ * publish-comments modal. Holds all PR-detail-related state (current tab / diff view options / comment + commit counts /
+ * draft pool / publish modal), mounted by layout/MainPane when a PR is selected.
  */
 export function PrPanel({
   pr,
@@ -75,9 +75,9 @@ export function PrPanel({
 }: PrPanelProps) {
   const { t } = useTranslation();
   const [tab, setTab] = useState<PrTab>('diff');
-  // 活动标签页「新建评论」编辑框开关（由标签栏「评论」按钮触发，编辑框出现在时间线顶部）
+  // Activity tab "new comment" editor toggle (triggered by the tab bar's "comment" button; the editor appears at the top of the timeline)
   const [composingComment, setComposingComment] = useState(false);
-  // 「查看特定 commit」请求：提交 / 活动标签页点击某 commit → 切到 Diff tab 本地渲染该 commit 变更
+  // "View a specific commit" request: clicking a commit in the commits / activity tab → switch to Diff tab and locally render that commit's changes
   const [pendingCommitView, setPendingCommitView] = useState<PendingCommitView | null>(null);
   const viewCommit = (commit: PrCommit): void => {
     setPendingCommitView({
@@ -88,11 +88,11 @@ export function PrPanel({
     });
     setTab('diff');
   };
-  // 收到跳转请求 → 强制切到 Diff tab，DiffView 自己负责消费 anchor
+  // On receiving a jump request → force-switch to the Diff tab; DiffView consumes the anchor itself
   useEffect(() => {
     if (pendingDiffNav) setTab('diff');
   }, [pendingDiffNav]);
-  // 外部请求切标签（通知点击 summary 评论 → 活动标签）：切换后即清空请求。
+  // External tab-switch request (clicking a summary comment notification → activity tab): clear the request right after switching.
   useEffect(() => {
     if (!pendingTab) return;
     setTab(pendingTab);
@@ -102,17 +102,17 @@ export function PrPanel({
     const v = localStorage.getItem('meebox.diffMode');
     return v === null ? true : v === 'side-by-side';
   });
-  // Blame 默认关：每次启动都得手动开（blame fetch 可能慢/失败，不希望用户进来就被错误 banner 干扰）
+  // Blame off by default: must be turned on manually each launch (blame fetch may be slow/fail; we don't want users greeted by an error banner on entry)
   const [showBlame, setShowBlame] = useState<boolean>(false);
-  // 空白字符可视化：默认关（大多数 review 不关心空格 / tab；强调时再开）
+  // Whitespace visualization: off by default (most reviews don't care about spaces / tabs; turn on when it matters)
   const [showWhitespace, setShowWhitespace] = useState<boolean>(
     () => localStorage.getItem('meebox.showWhitespace') === '1',
   );
   useEffect(() => {
     localStorage.setItem('meebox.showWhitespace', showWhitespace ? '1' : '0');
   }, [showWhitespace]);
-  // 评论 / commits 数 chip：PR 切换时各拉一次，cancelled token 防 race。deps 含 pr.updatedAt：
-  // 远端变更后 poller 拉到 → store 更新 → 这里重跑刷新计数，app 一直开着也能跟上远端变动。
+  // Comment / commit count chips: each fetched once on PR switch, cancelled token guards against races. deps include pr.updatedAt:
+  // after a remote change the poller pulls it → store updates → this reruns to refresh counts, so counts keep up with remote changes even with the app left open.
   const [commentCount, setCommentCount] = useState<number | null>(null);
   const [commitCount, setCommitCount] = useState<number | null>(null);
   const prLocalId = pr.localId;
@@ -124,7 +124,7 @@ export function PrPanel({
     void (async () => {
       try {
         const [cm, cc] = await Promise.all([
-          // force:true 跳过 cache stale 比对 — 本地 PR.updatedAt 可能滞后于远端（poller 周期性拉）。
+          // force:true skips the cache stale comparison — the local PR.updatedAt may lag the remote (poller pulls periodically).
           invoke('diff:listComments', { localId: prLocalId, force: true }),
           invoke('diff:commitCount', { localId: prLocalId }),
         ]);
@@ -132,7 +132,7 @@ export function PrPanel({
         setCommentCount(cm.length);
         setCommitCount(cc?.count ?? null);
       } catch {
-        // 静默：角标不显示数字，不该挡用户视线
+        // Silent: the badge shows no number, shouldn't block the user's view
       }
     })();
     return () => {
@@ -142,15 +142,15 @@ export function PrPanel({
   useEffect(() => {
     localStorage.setItem('meebox.diffMode', renderSideBySide ? 'side-by-side' : 'unified');
   }, [renderSideBySide]);
-  // 清掉历史遗留的 showBlame 持久化值；新逻辑不再读写它
+  // Clear the legacy persisted showBlame value; the new logic no longer reads/writes it
   useEffect(() => {
     if (localStorage.getItem('meebox.showBlame') !== null) {
       localStorage.removeItem('meebox.showBlame');
     }
   }, []);
 
-  // M4 草稿池 → "提交评论 (N)" 按钮的 N。pending + edited 才算 publishable；
-  // rejected（用户决断不发）/ posted（远端已发）都排除
+  // M4 draft pool → the N in the "publish comments (N)" button. Only pending + edited count as publishable;
+  // rejected (user decided not to send) / posted (already sent remotely) are both excluded
   const drafts = useDraftsForPr(prLocalId);
   const publishableCount = useMemo(
     () =>
@@ -160,10 +160,10 @@ export function PrPanel({
       ),
     [drafts],
   );
-  // 草稿 tab 显示条件用总数（任何 status 都算）；只有从来没创建过草稿的 PR 才完全隐藏 tab
+  // The drafts tab's visibility uses the total count (any status counts); only PRs that never created a draft hide the tab entirely
   const totalDraftCount = (drafts ?? []).length;
   const [publishModalOpen, setPublishModalOpen] = useState(false);
-  // 兜底：停在 'drafts' tab 但草稿全清空 → 切回 'diff' 避免显示孤儿空白内容区
+  // Fallback: sitting on the 'drafts' tab but all drafts cleared → switch back to 'diff' to avoid showing an orphan blank content area
   useEffect(() => {
     if (tab === 'drafts' && totalDraftCount === 0) setTab('diff');
   }, [tab, totalDraftCount]);
@@ -200,8 +200,8 @@ export function PrPanel({
         onSetRenderSideBySide={setRenderSideBySide}
       />
       <div className="pr-tab-content">
-        {/* keep-alive：各 tab 首访才挂载、之后保活仅 CSS 显隐（见 KeepAliveTab）。
-            切走再切回瞬时、无重拉、内嵌 Monaco / 滚动位置 / 展开态全部保留，消除切换抖动。 */}
+        {/* keep-alive: each tab mounts only on first visit, then stays alive with only CSS show/hide (see KeepAliveTab).
+            Switching away and back is instant, no refetch, embedded Monaco / scroll position / expanded state all preserved, eliminating switch jitter. */}
         <KeepAliveTab active={tab === 'diff'}>
           <Suspense fallback={<PaneLoading label={t('mainPane.loadingEditor')} />}>
             <DiffView
@@ -267,8 +267,8 @@ export function PrPanel({
           drafts={drafts ?? []}
           onClose={() => setPublishModalOpen(false)}
           onJumpToAnchor={(draftId) => {
-            // 点 anchor → 关 modal + 转 pendingDiffNav 上抛给 App。runId/findingId 不带 →
-            // DiffView 仅 navigate 不进 edit（用户想看代码上下文，不一定是要改草稿）。
+            // Click anchor → close modal + turn into pendingDiffNav bubbled up to App. runId/findingId omitted →
+            // DiffView only navigates, doesn't enter edit (the user wants to see the code context, not necessarily edit the draft).
             const d = (drafts ?? []).find((x) => x.id === draftId);
             if (!d) return;
             setPublishModalOpen(false);
@@ -287,13 +287,13 @@ export function PrPanel({
 }
 
 /**
- * tab 内容保活容器：首次 active 才挂载（保留 DiffView 等的懒加载优势），此后**不卸载**，
- * 仅靠 CSS `display` 显隐。切走再切回瞬时、无重拉、内嵌 Monaco / 滚动位置 / 展开态全保留 →
- * 消除切换抖动。隐藏期 Monaco 容器尺寸为 0，再显示需重排——由编辑器侧 `automaticLayout`
- * 自动处理（见 DiffView / InlineCodeContext）。
+ * Tab content keep-alive container: mounts only on first active (preserving DiffView's etc. lazy-load benefit), thereafter **never unmounts**,
+ * relying only on CSS `display` to show/hide. Switching away and back is instant, no refetch, embedded Monaco / scroll position / expanded state all preserved →
+ * eliminates switch jitter. While hidden the Monaco container size is 0 and reshowing needs a reflow — handled automatically by the editor-side `automaticLayout`
+ * (see DiffView / InlineCodeContext).
  */
 function KeepAliveTab({ active, children }: { active: boolean; children: ReactNode }) {
-  // 「一旦 active 过就保活」latch：ref 在 render 期写入是幂等闩锁，与本仓 stablePr 同模式。
+  // "Stay alive once active" latch: writing the ref during render is an idempotent latch, same pattern as this repo's stablePr.
   const mounted = useRef(false);
   if (active) mounted.current = true;
   if (!mounted.current) return null;

--- a/apps/desktop/src/renderer/src/components/features/pr/ReviewerStack.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/ReviewerStack.tsx
@@ -7,7 +7,7 @@ import { REVIEWER_STATUS_META, ReviewerBadgeGlyph } from './reviewer-status';
 
 const STACK_AVATAR_SIZE = 32;
 
-/** 单个头像 + 右上角决断角标（approved 绿勾 / needsWork 琥珀叹号；待评审无角标）。栈内项与「我」项共用。 */
+/** A single avatar + top-right decision badge (approved green check / needsWork amber exclamation; no badge when pending review). Shared by stack items and the "me" item. */
 function StackAvatar({ r, connectionId }: { r: Reviewer; connectionId: string }) {
   return (
     <>
@@ -26,19 +26,19 @@ function StackAvatar({ r, connectionId }: { r: Reviewer; connectionId: string })
     </>
   );
 }
-// 总数 ≤ MAX_VISIBLE 全显；超出则显示 (MAX_VISIBLE-1) 个头像 + 一个「+n」溢出项
+// Total ≤ MAX_VISIBLE shows all; beyond that shows (MAX_VISIBLE-1) avatars + one "+n" overflow item
 const MAX_VISIBLE = 4;
-// 排序优先级：needsWork（待处理，最该被看到）> approved > 待评审
+// Sort priority: needsWork (pending, most in need of attention) > approved > pending review
 const STATUS_RANK: Record<ReviewerStatus, number> = { needsWork: 0, approved: 1, unapproved: 2 };
 
 /**
- * PR 头部右上角的 reviewer 头像栈（Bitbucket 风格，略重叠）：
- * - 过滤掉当前用户自己；needsWork > approved > 待评审 优先排序，同级按 displayName 稳定排序
- * - approved 右上角绿勾、needsWork 右上角琥珀叹号角标（待评审无角标）
- * - 至多展示 4 个；超出显示 3 个 + 「+n」，点击「+n」下拉展示其余 reviewer（头像 + 名 + 决断 chip）
- * - 直接展示的头像 hover 出名字（走 Avatar 自带 title）
- * - `self`（当前用户的「我的评审」）非空时，在栈右侧分隔展示其头像 + 当前评审角标
- * 栈内无他人且无 self 则不渲染。
+ * Reviewer avatar stack at the top-right of the PR header (Bitbucket style, slightly overlapping):
+ * - Filters out the current user; sorted by priority needsWork > approved > pending review, same-rank by stable displayName sort
+ * - approved gets a top-right green check, needsWork a top-right amber exclamation badge (no badge for pending review)
+ * - Shows at most 4; beyond that shows 3 + "+n", clicking "+n" drops down the remaining reviewers (avatar + name + decision chip)
+ * - Directly shown avatars reveal the name on hover (via Avatar's built-in title)
+ * - When `self` (the current user's "my review") is non-null, shows its avatar + current review badge separated on the stack's right
+ * Not rendered when the stack has no others and no self.
  */
 export function ReviewerStack({
   reviewers,
@@ -49,7 +49,7 @@ export function ReviewerStack({
   reviewers: Reviewer[];
   connectionId: string;
   currentUserName?: string | null;
-  /** 当前用户的「我的评审」：头像 + 当前评审角标，分隔展示在他人头像栈右侧。 */
+  /** The current user's "my review": avatar + current review badge, shown separated to the right of the others' avatar stack. */
   self?: Reviewer | null;
 }) {
   const { t } = useTranslation();
@@ -58,7 +58,7 @@ export function ReviewerStack({
   const menuRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; right: number } | null>(null);
 
-  // 下拉定位 + 外点关闭 + 窗口变化重算（与 DiffScopeSelect 同套，fixed + portal 避免被裁切）
+  // Dropdown positioning + outside-click close + recompute on window changes (same setup as DiffScopeSelect, fixed + portal to avoid clipping)
   useEffect(() => {
     if (!open) return;
     const compute = (): void => {
@@ -96,7 +96,7 @@ export function ReviewerStack({
   const overflow = sorted.length > MAX_VISIBLE;
   const visible = overflow ? sorted.slice(0, MAX_VISIBLE - 1) : sorted;
   const hidden = overflow ? sorted.slice(MAX_VISIBLE - 1) : [];
-  // 重叠下让左侧头像压住右侧（z 递减），使各自的右上角角标不被相邻头像遮挡
+  // Under overlap, let the left avatar sit over the right (decreasing z), so each one's top-right badge isn't occluded by the adjacent avatar
   const topZ = sorted.length + 1;
 
   return (
@@ -125,7 +125,7 @@ export function ReviewerStack({
           +{hidden.length}
         </button>
       )}
-      {/* 「我的评审」：与他人头像栈分隔（左侧细分隔线 + 间距），展示当前用户头像 + 当前评审角标。 */}
+      {/* "My review": separated from the others' avatar stack (thin divider line + spacing on the left), shows the current user's avatar + current review badge. */}
       {self && (
         <span
           className="reviewer-stack-item reviewer-stack-self"

--- a/apps/desktop/src/renderer/src/components/features/pr/hooks/usePullRequests.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/hooks/usePullRequests.ts
@@ -5,16 +5,17 @@ import { invoke } from '../../../../api';
 import { formatBackendError } from '../../../../errors';
 
 /**
- * PR 列表生命周期与详情动作（领域内聚）：列表 state + 选中态、读缓存 reload / 拉远端 refresh、
- * 审批状态决断、合并。不感知 boot/连接（选中连接的反查由 App 持 boot 派生；启动 / 焦点刷新由
- * useBootstrap 经 reloadPrs 驱动），仅依赖 notifyError 弹操作级错误。
+ * PR list lifecycle and detail actions (domain-cohesive): list state + selection, cached reload /
+ * remote refresh, approval status decisions, merge. Unaware of boot/connection (the selected
+ * connection lookup is derived by App from boot; startup / focus refresh is driven by
+ * useBootstrap via reloadPrs), only depends on notifyError to surface operation-level errors.
  */
 export function usePullRequests({ notifyError }: { notifyError: (msg: string) => void }) {
   const { t } = useTranslation();
   const [prs, setPrs] = useState<StoredPullRequest[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  // 合并进行中：GitHub 合并可能较慢（异步算 mergeable），按钮置等待态并防重复点击。
+  // Merge in progress: GitHub merge can be slow (mergeable is computed asynchronously); set the button to a waiting state and prevent repeated clicks.
   const [merging, setMerging] = useState(false);
 
   const reloadPrs = useCallback(async (): Promise<void> => {
@@ -35,12 +36,12 @@ export function usePullRequests({ notifyError }: { notifyError: (msg: string) =>
     }
   }, [refreshing, reloadPrs]);
 
-  // 标记 PR 已读：用户打开 PR 时调用。先乐观清掉本地未读标志（即时反馈），再持久化已读水位——
-  // 下一轮 poll 不会因旧事件把它标回。每次选中都发 IPC：打开 PR 非高频，且推进已读水位本就是对的；
-  // 不靠 setState 更新器的副作用判断「是否未读」——更新器在渲染阶段才跑，同步读其副作用拿不到结果。
-  // 未读标志有两处：`unread` 圆点与 `unreadMentionCount`「@我/回复我」计数 chip（二者在标题槽位互斥、
-  // 计数优先）。两者都要乐观清零 —— 否则计数 chip 会残留到下一轮 poll 重算 lastReadAt 才消失，
-  // 表现为「点开 PR 后未读计数不消除」（与后端 markPrRead 落盘的 unread:false / unreadMentionCount:0 对齐）。
+  // Mark PR as read: called when the user opens a PR. First optimistically clear the local unread flags (instant feedback), then persist the read watermark —
+  // the next poll round won't re-mark it due to stale events. Send IPC on every selection: opening a PR is not high-frequency, and advancing the read watermark is inherently correct;
+  // don't rely on the side effect of the setState updater to decide "is it unread" — the updater only runs during the render phase, so synchronously reading its side effect gets no result.
+  // There are two unread flags: the `unread` dot and the `unreadMentionCount` "@me/replies to me" count chip (the two are mutually exclusive in the title slot, count takes priority).
+  // Both must be optimistically zeroed — otherwise the count chip lingers until the next poll round recomputes lastReadAt before disappearing,
+  // manifesting as "unread count doesn't clear after opening the PR" (aligned with the backend markPrRead persisting unread:false / unreadMentionCount:0).
   const markRead = useCallback(async (localId: string): Promise<void> => {
     setPrs((prev) =>
       prev.map((p) =>
@@ -67,8 +68,8 @@ export function usePullRequests({ notifyError }: { notifyError: (msg: string) =>
           setPrs((prev) => prev.map((p) => (p.localId === updated.localId ? updated : p)));
         }
       } catch (e) {
-        // 远端拒绝（如 PR 已关闭 / 合并 / 权限不足）→ 本地状态不变，弹 toast 提示。
-        // 顺手刷新一次：PR 若已关闭，下一轮 poll 会把它软删，列表自洽
+        // Remote rejection (e.g. PR already closed / merged / insufficient permissions) → local state unchanged, show a toast.
+        // Refresh once as well: if the PR is already closed, the next poll round soft-deletes it and the list stays consistent
         const msg = e instanceof Error ? e.message : String(e);
         notifyError(t('app.approveActionFailed', { msg }));
         void triggerRefresh();
@@ -84,15 +85,15 @@ export function usePullRequests({ notifyError }: { notifyError: (msg: string) =>
     try {
       await invoke('prs:merge', { localId: mergedId });
     } catch (e) {
-      // 合并失败（PR 已合并 / 冲突 / veto / 权限）→ 弹 toast，本地不变。先经 formatBackendError 解码
-      // AppError 错误码做 i18n（如 EPR0003「已被合并」给友好提示），非编码错误回退原始 message。
+      // Merge failed (PR already merged / conflict / veto / permissions) → show a toast, local unchanged. First decode via formatBackendError
+      // to i18n the AppError error code (e.g. EPR0003 "already merged" gives a friendly message), non-coded errors fall back to the original message.
       notifyError(t('app.mergeFailed', { msg: formatBackendError(e).title }));
       void triggerRefresh();
       return;
     } finally {
       setMerging(false);
     }
-    // 合并成功：PR 已转 MERGED，会从 pending 列表退场。取消选中 + 刷新让其消失
+    // Merge succeeded: the PR has transitioned to MERGED and will leave the pending list. Deselect + refresh to make it disappear
     if (selectedId === mergedId) setSelectedId(null);
     await triggerRefresh();
   }, [selected, selectedId, triggerRefresh, notifyError, merging, t]);

--- a/apps/desktop/src/renderer/src/components/features/pr/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/index.ts
@@ -1,5 +1,5 @@
-// features/pr 对外公共 API。内部模块（PrHeader / PrTabs / tabs/* 等）相互引用走相对路径，
-// 不经此 barrel，避免循环依赖。状态栏 chip 走 features/pr/statusbar/* 子路径，不并入此处。
+// Public API of features/pr. Internal modules (PrHeader / PrTabs / tabs/* etc.) reference each other via relative paths,
+// not through this barrel, to avoid circular dependencies. Status bar chips go through the features/pr/statusbar/* subpath and are not merged in here.
 export { PrPanel } from './PrPanel';
 export { PrEmpty } from './PrEmpty';
 export { PrItem } from './PrItem';

--- a/apps/desktop/src/renderer/src/components/features/pr/reviewer-status.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/reviewer-status.tsx
@@ -2,8 +2,8 @@ import type { ReviewerStatus } from '@meebox/shared';
 import { AlertGlyphIcon, ApproveIcon, CheckGlyphIcon, NeedsWorkIcon } from '../../common';
 
 /**
- * reviewer 状态的展示元信息与图标，供详情页 reviewer 列表（PrInfoView）、PR 头部头像栈
- * （ReviewerStack）等共用：状态 → 决断 chip 类型（复用活动时间线 chip 配色）+ 文案 key（复用 prStatus）。
+ * Display metadata and icons for reviewer status, shared by the detail page reviewer list (PrInfoView),
+ * the PR header avatar stack (ReviewerStack), etc.: status → decision chip kind (reuses activity timeline chip colors) + label key (reuses prStatus).
  */
 export const REVIEWER_STATUS_META: Record<ReviewerStatus, { chipKind: string; labelKey: string }> =
   {
@@ -12,7 +12,7 @@ export const REVIEWER_STATUS_META: Record<ReviewerStatus, { chipKind: string; la
     unapproved: { chipKind: 'unapproved', labelKey: 'prStatus.pending' },
   };
 
-/** reviewer 状态图标：approve 绿勾 / needs-work 琥珀叹号 / 待评审 中性空心点。 */
+/** Reviewer status icon: approve green check / needs-work amber exclamation / pending review neutral hollow dot. */
 export function ReviewerStatusIcon({
   status,
   size = 16,
@@ -26,8 +26,8 @@ export function ReviewerStatusIcon({
 }
 
 /**
- * 头像栈角标用的纯符号字形（无外圆环）：搭配实心彩底反色展示，只留内部勾 / 叹号。
- * approved / needsWork 才有；其它返回 null（待评审无角标）。
+ * Pure symbol glyph for the avatar stack badge (no outer ring): displayed reversed on a solid colored background, keeping only the inner check / exclamation.
+ * Only approved / needsWork have one; others return null (pending review has no badge).
  */
 export function ReviewerBadgeGlyph({ status, size = 16 }: { status: ReviewerStatus; size?: number }) {
   if (status === 'approved') return <CheckGlyphIcon size={size} />;

--- a/apps/desktop/src/renderer/src/components/features/pr/statusbar/LastSyncChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/statusbar/LastSyncChip.tsx
@@ -4,8 +4,8 @@ import { SyncIcon, StatusChip } from '../../../common';
 import { formatRelative } from '../../../../utils/time';
 
 /**
- * 刷新按钮 + 同步状态合并：一个可点击 chip，显示最近同步相对时间 + 同步图标
- * （刷新中旋转），点击触发一次轮询。
+ * Refresh button + sync status combined: a clickable chip showing the last sync relative time + sync icon
+ * (spinning while refreshing); clicking triggers one poll.
  */
 export function LastSyncChip({
   at,
@@ -17,7 +17,7 @@ export function LastSyncChip({
   onRefresh: () => void;
 }) {
   const { t } = useTranslation();
-  // 每 30s 重渲染一次，让 "刚刚 / N 分钟前" 文案随时间向前推进
+  // Re-render every 30s so the "just now / N minutes ago" text advances with time
   const [, tick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => tick((n) => n + 1), 30_000);

--- a/apps/desktop/src/renderer/src/components/features/pr/statusbar/PrsCountChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/statusbar/PrsCountChip.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { PullRequestIcon, StatusChip } from '../../../common';
 
-/** 待处理 PR 计数 chip。 */
+/** Pending PR count chip. */
 export function PrsCountChip({ count }: { count: number }) {
   const { t } = useTranslation();
   return (

--- a/apps/desktop/src/renderer/src/components/features/pr/statusbar/RepoSyncChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/statusbar/RepoSyncChip.tsx
@@ -3,19 +3,19 @@ import { useRepoSyncStore } from '../../../../stores/repo-sync-store';
 import { StatusChip } from '../../../common';
 
 /**
- * Repo sync 活动 chip：显示当前正在 clone/fetch 的 repo + 阶段 + 百分比。
- * 队列里只有一条在跑 (RepoMirrorManager 全局单队列)；store 收着多条时只展示首条。
- * idle 不渲染，避免占状态栏宽度。
+ * Repo sync activity chip: shows the repo currently being cloned/fetched + stage + percentage.
+ * Only one runs in the queue at a time (RepoMirrorManager global single queue); when the store holds multiple, only the first is shown.
+ * Not rendered when idle, to avoid taking up status bar width.
  */
 export function RepoSyncChip() {
   const { t } = useTranslation();
   const { active } = useRepoSyncStore();
   if (active.size === 0) return null;
-  // Map 没保证迭代序，但 sync 同时只跑一个，多于一个时按 startedAt 升序选最早的
+  // Map doesn't guarantee iteration order, but only one sync runs at a time; when there's more than one, pick the earliest by startedAt ascending
   const snapshots = Array.from(active.values()).sort((a, b) => a.startedAt - b.startedAt);
   const cur = snapshots[0]!;
   const more = snapshots.length - 1;
-  // repo = "host/projectKey/repoSlug"，UI 紧凑只展示最后一段
+  // repo = "host/projectKey/repoSlug"; for a compact UI show only the last segment
   const shortRepo = cur.repo.split('/').slice(-1)[0] ?? cur.repo;
   const stageLabel = cur.stage ? `${cur.stage}` : t('statusBar.syncing');
   const pct = typeof cur.percent === 'number' ? ` ${String(Math.round(cur.percent))}%` : '';

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/CommitsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/CommitsPanel.tsx
@@ -9,17 +9,17 @@ import { formatExactTime } from './comments/CommentItem';
 
 interface CommitsPanelProps {
   pr: StoredPullRequest;
-  /** 点击某 commit → 在 Diff 标签页本地渲染该 commit 的变更（不再跳浏览器） */
+  /** Click a commit → render that commit's changes locally in the Diff tab (no longer opens browser) */
   onViewCommit?: (commit: PrCommit) => void;
 }
 
 /**
- * PR commits 列表，表格布局。来源 `diff:listCommits` (无缓存，进入面板时拉一次)。
+ * PR commits list, table layout. Source `diff:listCommits` (no cache, fetched once on entering the panel).
  *
- * 列：短 SHA / 提交主题 (commit message 首行) / 作者 / 时间。merge commit 用
- * 标记 chip 区分。点击行 → 在 Diff 标签页本地渲染该 commit 的变更。
+ * Columns: short SHA / commit subject (first line of commit message) / author / time. Merge commits are
+ * distinguished with a marker chip. Click a row → render that commit's changes locally in the Diff tab.
  *
- * 列表默认按平台返回顺序 (newest first)，跟 git log 习惯一致。
+ * List defaults to the platform's return order (newest first), matching git log convention.
  */
 export function CommitsPanel({ pr, onViewCommit }: CommitsPanelProps) {
   const { t } = useTranslation();
@@ -105,7 +105,7 @@ function CommitRow({
     <tr
       className={`pr-commits-row ${onView ? 'pr-commits-row-clickable' : ''}`}
       onClick={() => onView?.(commit)}
-      title={commit.message /* 完整 commit body hover 可见 */}
+      title={commit.message /* full commit body visible on hover */}
     >
       <td className="pr-commits-col-sha">
         <code>{commit.abbreviatedSha}</code>
@@ -150,7 +150,7 @@ function formatCommitTime(iso: string, t: TFunction): string {
   if (diffSec < 3600) return t('commitsPanel.minutesAgo', { count: Math.round(diffSec / 60) });
   if (diffSec < 86400) return t('commitsPanel.hoursAgo', { count: Math.round(diffSec / 3600) });
   if (diffSec < 86400 * 7) return t('commitsPanel.daysAgo', { count: Math.round(diffSec / 86400) });
-  // 一周以上展示 yyyy-mm-dd，避免"X 周前"模糊
+  // Older than a week shows yyyy-mm-dd, avoiding the vagueness of "X weeks ago"
   const d = new Date(parsed);
   const pad = (n: number): string => String(n).padStart(2, '0');
   return `${String(d.getFullYear())}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/PrInfoView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/PrInfoView.tsx
@@ -18,15 +18,15 @@ interface PrInfoViewProps {
 
 export function PrInfoView({ pr }: PrInfoViewProps) {
   const { t } = useTranslation();
-  // 描述 body 内嵌图片走 IPC 代理 (Bitbucket 私有资源需 PAT 鉴权)，与评论/diff 一致
+  // Images embedded in the description body go through the IPC proxy (Bitbucket private resources need PAT auth), consistent with comments/diff
   const mdComponents = useMemo(
     () => ({ ...mermaidComponents, img: makeBitbucketImageFor(pr.localId, pr.url) }),
     [pr.localId, pr.url],
   );
 
-  // 各平台 adapter 产出的 reviewers 顺序不稳定（GitHub 按 Map 插入序，随评审推进
-  // requested_reviewers 会被移除/补到末尾），每次 poll 列表抖动。展示层按 displayName
-  // 字典序固定排序，name 兜底兜稳，与平台无关。
+  // The reviewers order produced by each platform's adapter is unstable (GitHub uses Map insertion order,
+  // and as review progresses requested_reviewers get removed/appended to the end), so the list jitters every poll.
+  // The display layer sorts stably by displayName in lexicographic order, with name as a stable fallback, platform-agnostic.
   const reviewers = useMemo(
     () =>
       [...pr.reviewers].sort(
@@ -38,14 +38,14 @@ export function PrInfoView({ pr }: PrInfoViewProps) {
   return (
     <div className="pr-info-view">
       <div className="pr-info-content pr-info-layout">
-        {/* 左：描述（主内容）；右：时间线 + 评审者（元信息侧栏，参考 PR overview 布局） */}
+        {/* Left: description (main content); right: timeline + reviewers (metadata sidebar, modeled on PR overview layout) */}
         <div className="pr-info-main">
           {pr.description ? (
             <section className="pr-detail-section">
               <h3>{t('prInfo.description')}</h3>
               <div className="pr-detail-description markdown">
-                {/* Bitbucket 远端用 \r\n 行尾，remark 解析时 CR 跟 LF 各算一次换行 → 单换行
-                    被当成段落分隔，每个 list item 之间多一段空白。归一化成 \n */}
+                {/* Bitbucket remote uses \r\n line endings; when remark parses, CR and LF each count as a line break → a single
+                    newline gets treated as a paragraph separator, adding blank space between each list item. Normalize to \n */}
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={REMOTE_REHYPE_PLUGINS}

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/PrTabs.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/PrTabs.tsx
@@ -4,8 +4,8 @@ import { ChatIcon, PersonIcon, WhitespaceIcon } from '../../../common';
 export type PrTab = 'diff' | 'activity' | 'drafts' | 'commits' | 'info';
 
 /**
- * PR 详情 tab 栏：diff / 评论 / 草稿 / 提交 / 信息（带计数徽标），diff tab 时右侧附带
- * 空白可视 / blame / 并排-内联 切换工具条。
+ * PR detail tab bar: diff / comments / drafts / commits / info (with count badges); when on the diff tab, the right side
+ * carries a whitespace-visibility / blame / side-by-side-inline toggle toolbar.
  */
 export function PrTabs({
   tab,
@@ -30,11 +30,11 @@ export function PrTabs({
   commitCount: number | null;
   totalDraftCount: number;
   publishableCount: number;
-  /** 该平台是否提供活动时间线（见 capabilities.activityTimeline）；否则该 tab 标题退化为「评论」 */
+  /** Whether the platform provides an activity timeline (see capabilities.activityTimeline); otherwise this tab's title degrades to "Comments" */
   activityTimeline: boolean;
-  /** 内容只读（decline / 不可参与归档 PR）：隐藏「新建评论」入口。 */
+  /** Content is read-only (declined / non-participable archived PR): hides the "new comment" entry point. */
   readOnly?: boolean;
-  /** 活动标签页右侧「评论」按钮：新建一条不锚到文件的评论 */
+  /** The "Comment" button on the right of the activity tab: creates a comment not anchored to a file */
   onNewComment: () => void;
   showWhitespace: boolean;
   onToggleWhitespace: () => void;
@@ -55,8 +55,9 @@ export function PrTabs({
       >
         {t('mainPane.tabDiff')}
       </button>
-      {/* 活动时间线（评论 + 提交 + 评审决断）在 commits 前：评审决断时讨论权重大于纯 commit 列表。
-          角标仍取评论数——讨论量最具行动指引，提交另有独立 tab 计数。 */}
+      {/* The activity timeline (comments + commits + review decisions) comes before commits: during review, discussion
+          weighs more than a plain commit list. The badge still uses the comment count — discussion volume is the most
+          actionable indicator, and commits have their own separate tab count. */}
       <button
         type="button"
         className={`pr-tab ${tab === 'activity' ? 'active' : ''}`}
@@ -70,8 +71,8 @@ export function PrTabs({
           ariaLabel={(n) => t('mainPane.commentCountAria', { count: n })}
         />
       </button>
-      {/* 草稿 tab：显示条件用总数 — 全发完仍能进 tab 看 posted/rejected 历史；
-          从未创建草稿的 PR 才完全隐藏 tab，避免冗余入口 */}
+      {/* Drafts tab: visibility condition uses the total count — even after all are posted you can still enter the tab
+          to view posted/rejected history; only PRs that never created a draft hide the tab entirely, avoiding a redundant entry point */}
       {totalDraftCount > 0 && (
         <button
           type="button"
@@ -168,10 +169,10 @@ export function PrTabs({
 }
 
 /**
- * tab 计数角标。计数异步加载（评论 / 提交）：
- * - `null`（加载中）：渲染等宽占位 chip，预留角标宽度，消除计数到达时 tab 的横向弹簧抖动；
- * - `> 0`：真实数字角标；
- * - `0`：不渲染（无角标）。
+ * Tab count badge. Counts load asynchronously (comments / commits):
+ * - `null` (loading): renders a fixed-width placeholder chip, reserving badge width to eliminate the tab's horizontal spring-jitter when the count arrives;
+ * - `> 0`: the real numeric badge;
+ * - `0`: not rendered (no badge).
  */
 function TabCountBadge({
   count,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/activity/ActivityPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/activity/ActivityPanel.tsx
@@ -31,25 +31,25 @@ import {
 
 interface ActivityPanelProps {
   pr: StoredPullRequest;
-  /** 顶层评论数（不含 replies）拉取成功后回调，供父组件 tab 角标用 */
+  /** Callback after the top-level comment count (excluding replies) is fetched successfully, for the parent's tab badge */
   onCommentsLoaded?: (count: number) => void;
-  /** 活动连接能力位；此处用 commentHardBreaks 决定评论是否启用 remark-breaks。 */
+  /** Active connection capability flags; here commentHardBreaks decides whether comments enable remark-breaks. */
   capabilities?: PlatformCapabilities;
-  /** 内容只读（decline / 不可参与归档 PR）：隐藏评论回复 / 编辑 / 删除及新建编辑框。 */
+  /** Content is read-only (declined / non-participable archived PR): hides comment reply / edit / delete and the new composer. */
   readOnly?: boolean;
-  /** 是否展开「新建评论」编辑框（由标签栏「评论」按钮控制，出现在时间线顶部） */
+  /** Whether the "new comment" composer is expanded (controlled by the tab bar's "Comment" button, appears at the top of the timeline) */
   composing?: boolean;
-  /** 新建评论编辑框收起（取消 / 发布成功）回调 */
+  /** Callback when the new comment composer collapses (cancel / posted successfully) */
   onComposeClose?: () => void;
-  /** 当前 PAT 用户名（新建评论编辑框头像用） */
+  /** Current PAT username (used for the new comment composer's avatar) */
   currentUserName?: string | null;
-  /** 点击时间线上的 commit 事件 → 在 Diff 标签页本地渲染该 commit 的变更（不再跳浏览器） */
+  /** Click a commit event on the timeline → render that commit's changes locally in the Diff tab (no longer opens browser) */
   onViewCommit?: (commit: PrCommit) => void;
-  /** 点击 inline 评论锚点 chip → 跳到 Diff 对应文件/行 */
+  /** Click an inline comment anchor chip → jump to the corresponding file/line in the Diff */
   onJumpToAnchor?: (anchor: PrCommentAnchor) => void;
 }
 
-/** 三路数据 + 其配对 PR 一起冻结，跨 poll 稳定引用，给评论树（含内联 Monaco）稳定身份避免重渲染。 */
+/** The three data streams + their paired PR are frozen together, a stable reference across polls, giving the comment tree (including inline Monaco) a stable identity to avoid re-renders. */
 interface ActivityView {
   pr: StoredPullRequest;
   comments: PrComment[];
@@ -57,7 +57,7 @@ interface ActivityView {
   activity: PrActivityEvent[];
 }
 
-/** 按 id 列表逐项比对（顺序敏感）。commits 用 sha、activity 用 remoteId，相等则跳过 setState 让 React bail。 */
+/** Compares lists item by item by id (order-sensitive). commits use sha, activity uses remoteId; if equal, skip setState to let React bail. */
 function sameIds<T>(a: readonly T[], b: readonly T[], id: (x: T) => string): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
@@ -67,17 +67,18 @@ function sameIds<T>(a: readonly T[], b: readonly T[], id: (x: T) => string): boo
 }
 
 /**
- * PR 活动时间线（原「评论」标签页演进而来）。把三路数据按时间归并成一条时间线：
- *   1. 评论（summary + inline，含 replies / 编辑 / 删除 / 内联代码，沿用 {@link CommentItem}）
- *   2. 提交更新（{@link PrCommit}）
- *   3. reviewer 评审决断事件（approve / needs-work / unapprove / dismiss，{@link PrActivityEvent}）
+ * PR activity timeline (evolved from the former "Comments" tab). Merges the three data streams by time into one timeline:
+ *   1. Comments (summary + inline, including replies / edit / delete / inline code, reusing {@link CommentItem})
+ *   2. Commit updates ({@link PrCommit})
+ *   3. Reviewer review-decision events (approve / needs-work / unapprove / dismiss, {@link PrActivityEvent})
  *
- * 排序沿用评论页规则：**按时间倒序（newest first）**，最新动态在顶部。评论数据源与 DiffView 的 inline
- * 评论同一份（`diff:listComments`，main 端有 pr_updated_at 缓存）；提交 / 决断各走自己的 IPC，二者
- * 为增益信息，单独失败不影响评论时间线（catch 降级为空）。
+ * Ordering follows the comments page rule: **reverse chronological (newest first)**, latest activity on top. The comment
+ * data source is the same as DiffView's inline comments (`diff:listComments`, the main side has a pr_updated_at cache);
+ * commits / decisions each go through their own IPC, both being additive info, and a standalone failure doesn't affect the
+ * comment timeline (catch degrades to empty).
  *
- * 切 PR 时不立刻清空（stale-while-loading）：旧时间线继续渲染、上盖 loading 遮罩，新数据 ready 后
- * 整体替换，消除「先闪加载中再渲新」的空窗。
+ * Switching PRs doesn't clear immediately (stale-while-loading): the old timeline keeps rendering with a loading overlay
+ * on top, and once new data is ready it's replaced wholesale, eliminating the "flash loading then render new" gap.
  */
 export function ActivityPanel({
   pr,
@@ -90,16 +91,16 @@ export function ActivityPanel({
   onViewCommit,
   onJumpToAnchor,
 }: ActivityPanelProps) {
-  // 评论换行：GitHub/Bitbucket hard-break；GitLab CommonMark 软换行。缺省回退 true。
+  // Comment line breaks: GitHub/Bitbucket hard-break; GitLab CommonMark soft break. Defaults to true.
   const hardBreaks = capabilities?.commentHardBreaks ?? true;
-  // 评论 emoji 反应模式：'fixed'（GitHub 8 种）/ 'free'（GitLab/Bitbucket 精选集+搜索）；false/缺省 = 关闭。
+  // Comment emoji reaction mode: 'fixed' (GitHub's 8) / 'free' (GitLab/Bitbucket curated set + search); false/default = off.
   const reactionsMode = capabilities?.commentReactions || undefined;
-  // 图片附件上传：平台支持时启用评论粘贴上传。缺省保守关闭（GitHub 无上传 API 亦为 false）。
+  // Image attachment upload: enables comment paste-to-upload when the platform supports it. Conservatively off by default (GitHub has no upload API, also false).
   const attachmentsEnabled = capabilities?.commentAttachments ?? false;
-  // 差异化：GitHub/Bitbucket 渲染评论+提交+决断的活动时间线；GitLab（activityTimeline=false）退化为
-  // 纯评论视图（不拉提交/决断、沿用「评论」文案）。缺省（capabilities 未到）保守按纯评论。
+  // Differentiation: GitHub/Bitbucket render the activity timeline of comments+commits+decisions; GitLab (activityTimeline=false) degrades to
+  // a pure comment view (doesn't fetch commits/decisions, keeps the "Comments" wording). Default (capabilities not yet arrived) conservatively treats as pure comments.
   const showTimeline = capabilities?.activityTimeline ?? false;
-  // 文案命名空间：时间线模式用 activityPanel.*，纯评论模式沿用 commentsPanel.*（保持 GitLab 原体验）。
+  // Text namespace: timeline mode uses activityPanel.*, pure comment mode keeps commentsPanel.* (preserving GitLab's original experience).
   const ns = showTimeline ? 'activityPanel' : 'commentsPanel';
   const { t } = useTranslation();
   const [view, setView] = useState<ActivityView | null>(null);
@@ -112,8 +113,8 @@ export function ActivityPanel({
     setError(null);
     const fetchAll = async (): Promise<void> => {
       try {
-        // 评论是核心（失败=整块错误）；提交 / 决断是增益，单独失败 catch 成空，时间线照常展示评论。
-        // 纯评论模式（GitLab）跳过提交 / 决断拉取。
+        // Comments are core (failure = whole-block error); commits / decisions are additive, standalone failures catch to empty, and the timeline still shows comments.
+        // Pure comment mode (GitLab) skips fetching commits / decisions.
         const [comments, commits, activity] = await Promise.all([
           invoke('diff:listComments', { localId: pr.localId, force: true }),
           showTimeline
@@ -126,7 +127,7 @@ export function ActivityPanel({
             : Promise.resolve([] as PrActivityEvent[]),
         ]);
         if (cancelled) return;
-        // 三路都与上次相等：保留旧 view 引用让 React bail（poll 无实质变化时不重渲时间线）。
+        // All three streams equal last time: keep the old view reference to let React bail (don't re-render the timeline when a poll has no substantive change).
         setView((prev) =>
           prev &&
           prev.pr.localId === pr.localId &&
@@ -146,7 +147,7 @@ export function ActivityPanel({
       }
     };
     void fetchAll();
-    // 用户回复 / 编辑 / 删除 / 发布草稿后 main 广播 comments:changed → 重拉
+    // After the user replies / edits / deletes / posts a draft, main broadcasts comments:changed → refetch
     const unsub = subscribe('comments:changed', (e) => {
       if (e.localId === pr.localId) void fetchAll();
     });
@@ -154,13 +155,13 @@ export function ActivityPanel({
       cancelled = true;
       unsub();
     };
-    // onCommentsLoaded 故意不放依赖：父组件每次 render 都会重传新 ref，会触发误重拉
+    // onCommentsLoaded deliberately left out of deps: the parent passes a new ref on every render, which would trigger a spurious refetch
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pr.localId, showTimeline]);
 
   const viewPr = view?.pr;
-  // inline 评论自动挂 Monaco 上限：按 createdAt 倒序后的前 N 条 inline 直接挂；超额走 click-to-expand。
-  // 跟评论页一致取 10——一屏内大概看完，再多需主动展开。
+  // Cap on auto-mounting Monaco for inline comments: the first N inline comments (after sorting by createdAt descending) mount directly; the rest use click-to-expand.
+  // Take 10 to match the comments page — roughly viewable within one screen, beyond that requires active expansion.
   const autoExpandSet = useMemo(() => {
     const out = new Set<string>();
     const inlineByNewest = (view?.comments ?? [])
@@ -170,15 +171,15 @@ export function ActivityPanel({
     return out;
   }, [view]);
 
-  // @提及候选：从已加载的评论作者（含 replies）+ 提交作者派生——有界、零额外取数、安全（仅本 PR 参与者，
-  // 不向远端枚举全员）。仅平台支持反应/提及类增强时无关，纯增益；用户仍可自由手打任意 @name。
+  // @mention candidates: derived from loaded comment authors (including replies) + commit authors — bounded, zero extra fetches, safe (only this PR's participants,
+  // not enumerating everyone from the remote). Independent of whether the platform supports reaction/mention enhancements, purely additive; the user can still freely type any @name.
   const mentionCandidates = useMemo<PlatformUser[]>(
     () => collectMentionCandidates(view?.comments ?? [], view?.commits ?? []),
     [view],
   );
 
-  // 归并三路为时间线条目并按时间倒序。deps 全是稳定引用（view 经上面三路相等比对跳过后不变、
-  // autoExpandSet 随 view）→ poll 无变化时整条时间线（含内联 Monaco）元素身份不变，React 跳过重渲。
+  // Merge the three streams into timeline entries sorted in reverse chronological order. deps are all stable references (view stays unchanged after the three-stream equality comparison above skips it,
+  // autoExpandSet follows view) → when a poll has no change, the whole timeline (including inline Monaco) keeps element identity and React skips re-rendering.
   const timeline = useMemo<ReactElement[]>(() => {
     if (!viewPr || !view) return [];
     type Row = { key: string; at: number; node: ReactElement };
@@ -221,7 +222,7 @@ export function ActivityPanel({
         node: <ReviewEvent key={`review:${ev.remoteId}`} event={ev} pr={viewPr} />,
       });
     }
-    // newest first；稳定排序下同刻条目按 评论→提交→决断 入队序排列
+    // newest first; under a stable sort, same-instant entries are ordered by enqueue order: comment→commit→decision
     rows.sort((a, b) => b.at - a.at);
     return rows.map((r) => r.node);
   }, [
@@ -238,7 +239,7 @@ export function ActivityPanel({
     onJumpToAnchor,
   ]);
 
-  // 首载失败 / 切 PR 失败（无可信展示内容，或现有 view 属于旧 PR）：整块错误，不拿旧 PR 内容冒充新的。
+  // First-load failure / PR-switch failure (no trustworthy content to show, or the existing view belongs to an old PR): whole-block error, don't pass off old PR content as the new one.
   if (error && (!view || view.pr.localId !== pr.localId)) {
     return (
       <div className="pr-comments-panel">
@@ -257,7 +258,7 @@ export function ActivityPanel({
       <div className="pr-comments-scroll">
         {(composing || (view && timeline.length > 0)) && (
           <ul className="pr-comments-list pr-activity-list">
-            {/* 新建评论编辑框作为时间线首个节点：与其它条目同款图标节点 + 头像，编辑框缩进挂在轨上。 */}
+            {/* The new comment composer as the first node of the timeline: same icon node + avatar as other entries, the composer indented and mounted on the rail. */}
             {composing && !readOnly && (
               <li className="pr-comment pr-comment-timeline pr-comment-depth-0">
                 <div className="pr-activity-item pr-activity-comment-head">
@@ -289,16 +290,16 @@ export function ActivityPanel({
           <p className="muted">{t(`${ns}.empty`)}</p>
         )}
       </div>
-      {/* 加载遮罩盖住旧内容（或首载空面板），ready 后整体替换。PaneLoading 默认 delayMs=150：
-          命中缓存的快切换遮罩根本不出现、旧内容直接换新（零闪）；只有慢加载才显 spinner。 */}
+      {/* The loading overlay covers the old content (or the empty panel on first load), replaced wholesale once ready. PaneLoading defaults to delayMs=150:
+          for cache-hit fast switches the overlay never appears and the old content swaps directly to new (zero flash); only slow loads show a spinner. */}
       {loading && <PaneLoading overlay label={t(`${ns}.loading`)} />}
     </div>
   );
 }
 
 /**
- * 从已加载的评论（含 replies 递归）+ 提交派生 @提及候选用户：按 name 去重、保序。候选源刻意只取
- * 本 PR 已出现的参与者（有界、零额外取数、不向远端枚举全员），是安全的 @ 自动补全数据来源。
+ * Derives @mention candidate users from loaded comments (recursing into replies) + commits: dedup by name, order-preserving. The candidate source deliberately takes only
+ * participants who already appear in this PR (bounded, zero extra fetches, doesn't enumerate everyone from the remote), a safe data source for @ autocomplete.
  */
 function collectMentionCandidates(comments: PrComment[], commits: PrCommit[]): PlatformUser[] {
   const seen = new Set<string>();
@@ -322,7 +323,7 @@ function collectMentionCandidates(comments: PrComment[], commits: PrCommit[]): P
   return out;
 }
 
-/** 时间线上的提交事件：commit 图标 + 短 SHA + 主题 + 作者 + 时间；可点击跳远端 commit 页。 */
+/** A commit event on the timeline: commit icon + short SHA + subject + author + time; clickable to jump to the remote commit page. */
 function CommitEvent({
   commit,
   pr,
@@ -344,7 +345,7 @@ function CommitEvent({
       <span className="pr-activity-icon pr-activity-icon-commit" aria-hidden="true">
         <CommitIcon size={18} />
       </span>
-      {/* 作者展示与评论主体人对齐：同尺寸头像 + 加粗名，不做差异化 */}
+      {/* Author display aligns with the comment's main person: same-size avatar + bold name, no differentiation */}
       <Avatar
         connectionId={pr.connectionId}
         slug={commit.author.slug ?? commit.author.name}
@@ -376,7 +377,7 @@ function CommitEvent({
   );
 }
 
-/** kind → 图标 + 语义色 class。approved 绿、needsWork 琥珀、unapproved/dismissed 中性。 */
+/** kind → icon + semantic color class. approved green, needsWork amber, unapproved/dismissed neutral. */
 const REVIEW_ICON: Record<PrActivityKind, ReactElement> = {
   approved: <ApproveIcon size={18} />,
   needsWork: <NeedsWorkIcon size={18} />,
@@ -384,7 +385,7 @@ const REVIEW_ICON: Record<PrActivityKind, ReactElement> = {
   dismissed: <CloseIcon size={18} />,
 };
 
-/** 时间线上的评审决断事件：actor + 判定动词 + 时间。 */
+/** A review-decision event on the timeline: actor + decision verb + time. */
 function ReviewEvent({ event, pr }: { event: PrActivityEvent; pr: StoredPullRequest }) {
   const { t } = useTranslation();
   return (

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentComposer.tsx
@@ -7,18 +7,18 @@ import { uploadCommentImage } from '../shared/uploadCommentImage';
 
 interface CommentComposerProps {
   prLocalId: string;
-  /** `@提及` 自动补全候选（PR 参与者 + 评论作者，由父组件从已加载数据派生）。 */
+  /** `@mention` autocomplete candidates (PR participants + comment authors, derived by the parent from loaded data). */
   mentionCandidates?: PlatformUser[];
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；为真才启用粘贴上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); paste-to-upload is enabled only when true. */
   attachmentsEnabled?: boolean;
   onCancel: () => void;
-  /** 发布成功后调用（收起编辑框；时间线通过 comments:changed 事件自动刷新，新评论出现在顶部） */
+  /** Called after posting succeeds (collapses the composer; the timeline auto-refreshes via the comments:changed event, the new comment appears at the top) */
   onPosted: () => void;
 }
 
 /**
- * 新建 summary（不锚到文件）评论的编辑框：textarea + 发送/取消。出现在活动时间线最上方。
- * Cmd/Ctrl+Enter 发送，Esc 取消；空 body disabled 发送。版式复用回复编辑框样式。
+ * Composer for a new summary (not anchored to a file) comment: textarea + send/cancel. Appears at the top of the activity timeline.
+ * Cmd/Ctrl+Enter sends, Esc cancels; send is disabled on an empty body. Layout reuses the reply composer's styles.
  */
 export function CommentComposer({
   prLocalId,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentEditEditor.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentEditEditor.tsx
@@ -5,25 +5,25 @@ import { invoke } from '../../../../../api';
 interface CommentEditEditorProps {
   prLocalId: string;
   commentId: string;
-  /** 当前评论 version (乐观锁，Bitbucket PUT 必带)；版本不一致 Bitbucket 回 409 */
+  /** Current comment version (optimistic lock, required for Bitbucket PUT); Bitbucket returns 409 on version mismatch */
   version: number;
-  /** 初始 body — 进编辑态时 textarea 预填，避免用户从空白重写 */
+  /** Initial body — prefills the textarea when entering edit mode, so the user does not rewrite from blank */
   initialBody: string;
   onCancel: () => void;
-  /** 保存成功后调用：UI 收起编辑器；评论树通过 comments:changed 事件自动刷新 */
+  /** Called after a successful save: UI collapses the editor; the comment tree auto-refreshes via the comments:changed event */
   onSaved: () => void;
 }
 
 /**
- * 已有评论的编辑器：textarea + 保存/取消，跟 CommentReplyEditor 同套视觉与
- * 快捷键 (Cmd/Ctrl+Enter 保存，Esc 取消)。
+ * Editor for an existing comment: textarea + save/cancel, sharing the same visuals and
+ * shortcuts as CommentReplyEditor (Cmd/Ctrl+Enter to save, Esc to cancel).
  *
- * 跟 reply 区别：
- * - 初始 body = 现有评论文本，进编辑后用户改的是已存内容而非新建
- * - 走 comments:edit IPC (PUT)，必须带 version
- * - body 没变时禁用保存按钮 (no-op 不调远端)
- * - 失败常见情形：Bitbucket 409 (用户在别处先改过 → version 错位) — 错误原文直接
- *   显示在编辑器底部，用户看到提示后可以关闭编辑器、等评论树刷新后再次编辑
+ * Differences from reply:
+ * - Initial body = existing comment text; after entering edit mode the user modifies stored content rather than creating new
+ * - Goes through the comments:edit IPC (PUT), must carry version
+ * - Save button is disabled when body is unchanged (no-op, does not call remote)
+ * - Common failure: Bitbucket 409 (user edited elsewhere first → version mismatch) — the raw error is shown
+ *   directly at the bottom of the editor; after seeing it the user can close the editor and re-edit once the comment tree refreshes
  */
 export function CommentEditEditor({
   prLocalId,
@@ -39,7 +39,7 @@ export function CommentEditEditor({
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // mount 自动 focus + 光标到末尾，方便接着原文继续打字
+  // On mount, auto-focus + move cursor to the end, so typing continues from the existing text
   useEffect(() => {
     const el = textareaRef.current;
     if (el) {

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentItem.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentItem.tsx
@@ -14,15 +14,15 @@ import { CommentReplyEditor } from './CommentReplyEditor';
 import { CommentMarkdown } from '../shared/CommentMarkdown';
 import { ReactionAddButton, ReactionChips, useReactions } from '../shared/ReactionBar';
 import { useCommentThread } from '../shared/useCommentThread';
-// 行内代码上下文用 Monaco，懒加载随 DiffView 同一套 Monaco chunk 按需拉取，不进入口包。
+// Inline code context uses Monaco; lazy-loaded and pulled on demand with the same Monaco chunk as DiffView, not in the entry bundle.
 const InlineCodeContext = lazy(() =>
   import('./InlineCodeContext').then((m) => ({ default: m.InlineCodeContext })),
 );
 
 /**
- * 评论树结构相等比较（按 remoteId + 正文 + version + 编辑/删除权限 + 递归 replies）。poll 多数返回
- * 内容不变的评论：相等就跳过 setState、保留旧引用，让 React bail-out，避免整棵评论树（含内联
- * Monaco）无谓重渲染（刷新抖动）。
+ * Structural equality comparison of the comment tree (by remoteId + body + version + edit/delete permissions + recursive replies). poll mostly returns
+ * comments with unchanged content: on equality, skip setState and keep the old reference so React bails out, avoiding pointless re-render of the whole
+ * comment tree (including inline Monaco) (refresh flicker).
  */
 export function sameCommentList(a: readonly PrComment[], b: readonly PrComment[]): boolean {
   if (a.length !== b.length) return false;
@@ -44,7 +44,7 @@ export function sameCommentList(a: readonly PrComment[], b: readonly PrComment[]
   return true;
 }
 
-/** 反应数组相等比较（emoji + count + mine 三元组逐项一致）：让 toggle 后的反应变化能触发重渲染。 */
+/** Equality comparison of the reactions array (emoji + count + mine triple matching item by item): lets reaction changes after a toggle trigger a re-render. */
 function sameReactions(a: PrComment['reactions'], b: PrComment['reactions']): boolean {
   const x = a ?? [];
   const y = b ?? [];
@@ -58,20 +58,20 @@ function sameReactions(a: PrComment['reactions'], b: PrComment['reactions']): bo
 }
 
 /**
- * 嵌套回复的最大缩进层级：满此层级后继续递归但**不再加缩进**（拉平展示），避免深嵌套把内容挤到
- * 右侧极窄。depth 0 为顶层评论；depth 1..MAX 逐级缩进，超过 MAX 的更深回复一律平铺在 MAX 层缩进上，
- * 仍按作者归属可读。Bitbucket 实际只一层 reply，GitHub / GitLab 可深嵌套，故设上限。
+ * Maximum indent level for nested replies: past this level recursion continues but **no further indent is added** (flattened display), avoiding
+ * deep nesting squeezing content into a very narrow right side. depth 0 is the top-level comment; depth 1..MAX indent progressively, and deeper replies
+ * beyond MAX are all laid flat at the MAX-level indent, still readable by author attribution. Bitbucket actually has only one reply level, while GitHub / GitLab can nest deeply, hence the cap.
  */
 const MAX_REPLY_DEPTH = 5;
 
 /**
- * 单条评论 + 嵌套 replies。inline 评论顶部显示 `path:line side` chip 区分锚点位置；
- * summary 评论不挂 chip。replies 走递归，depth 控制左侧缩进；满 MAX_REPLY_DEPTH 层后拉平
- * （不再加缩进，见该常量）。
+ * A single comment + nested replies. inline comments show a `path:line side` chip at the top to distinguish the anchor location;
+ * summary comments carry no chip. replies recurse, with depth controlling the left indent; past MAX_REPLY_DEPTH levels they flatten
+ * (no further indent, see that constant).
  *
- * `timeline` 模式（活动时间线，GitHub/Bitbucket）下的**顶层评论**改走时间线行版式：与其它事件统一
- * 「评论图标 + 头像 + 加粗作者名 + 『评论』动词 + 时间」标题，正文整体缩进成挂在时间线轨上的卡片。
- * 非 timeline（GitLab 纯评论视图）或回复（depth>0）维持原卡片版式。
+ * In `timeline` mode (activity timeline, GitHub/Bitbucket), the **top-level comment** switches to the timeline-row layout: a header unified with other events
+ * ("comment icon + avatar + bold author name + 'commented' verb + time"), with the body indented as a whole into a card hung on the timeline rail.
+ * Non-timeline (GitLab pure comment view) or replies (depth>0) keep the original card layout.
  */
 export function CommentItem({
   comment,
@@ -89,29 +89,29 @@ export function CommentItem({
   comment: PrComment;
   pr: StoredPullRequest;
   depth: number;
-  /** 顶层 (depth=0) 由父组件按 CAP 决定 true/false；replies 总是 false (不渲染 code) */
+  /** Top-level (depth=0) is decided true/false by the parent per CAP; replies are always false (do not render code) */
   autoExpandCode?: boolean;
   hardBreaks: boolean;
-  /** 评论 emoji 反应模式（capabilities.commentReactions）：'fixed'/'free' 才渲染；缺省 = 不支持。 */
+  /** Comment emoji reaction mode (capabilities.commentReactions): renders only for 'fixed'/'free'; absent = unsupported. */
   reactionsMode?: 'fixed' | 'free';
-  /** `@提及` 自动补全候选（PR 参与者 + 评论作者）；透传给回复编辑框。 */
+  /** `@mention` autocomplete candidates (PR participants + comment authors); passed through to the reply editor. */
   mentionCandidates?: PlatformUser[];
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；透传给回复编辑框启用粘贴上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); passed through to the reply editor to enable paste upload. */
   attachmentsEnabled?: boolean;
-  /** 是否处于活动时间线模式（仅影响顶层评论版式，见上方说明） */
+  /** Whether in activity timeline mode (only affects top-level comment layout, see the note above) */
   timeline?: boolean;
-  /** 内容只读（decline / 不可参与归档 PR）：隐藏回复 / 编辑 / 删除操作，仅供浏览。 */
+  /** Content read-only (decline / non-participable archived PR): hides reply / edit / delete actions, browse only. */
   readOnly?: boolean;
-  /** inline 评论锚点 chip 点击 → 跳到 Diff 对应文件/行。提供时 chip 变可点击。 */
+  /** Clicking the inline comment anchor chip → jump to the corresponding file/line in the Diff. When provided, the chip becomes clickable. */
   onJumpToAnchor?: (anchor: PrCommentAnchor) => void;
 }) {
   const { t } = useTranslation();
-  // 评论 body 内嵌图片走 IPC 代理 (Bitbucket 私有资源需 PAT 鉴权)
+  // Images embedded in the comment body go through the IPC proxy (Bitbucket private resources need PAT auth)
   const mdComponents = useMemo(
     () => ({ ...mermaidComponents, img: makeBitbucketImageFor(pr.localId, pr.url) }),
     [pr.localId, pr.url],
   );
-  // 回复 / 编辑 / 删除 交互状态机（与 diff 行内评论 zone 共用，见 shared/useCommentThread）
+  // Reply / edit / delete interaction state machine (shared with the diff inline comment zone, see shared/useCommentThread)
   const {
     replyOpen,
     setReplyOpen,
@@ -127,15 +127,15 @@ export function CommentItem({
     handleDelete,
   } = useCommentThread(pr.localId, comment);
 
-  // 反应状态 + 切换（hook 无条件调用；输出仅在 reactionsMode 存在时渲染）。
+  // Reaction state + toggle (hook called unconditionally; output rendered only when reactionsMode exists).
   const { reactions, busy: reactionBusy, toggle: toggleReaction } = useReactions(
     pr.localId,
     comment,
     readOnly,
   );
 
-  // inline 评论锚点 chip：path:line + 侧别 (old=base / new=head)，让用户在评论里定位到代码位置。
-  // 提供 onJumpToAnchor 时（活动视图）chip 变可点击 → 跳到 Diff 对应文件/行。
+  // inline comment anchor chip: path:line + side (old=base / new=head), letting the user locate the code position from the comment.
+  // When onJumpToAnchor is provided (activity view) the chip becomes clickable → jump to the corresponding file/line in the Diff.
   const anchor = comment.anchor;
   const anchorChip = anchor ? (
     onJumpToAnchor ? (
@@ -160,7 +160,7 @@ export function CommentItem({
     )
   ) : null;
 
-  // inline 评论：在正文上方嵌一段代码上下文 (Monaco read-only)。replies (depth > 0) 不重复展示。
+  // inline comment: embed a code context (Monaco read-only) above the body. replies (depth > 0) do not repeat it.
   const inlineCode =
     comment.anchor && depth === 0 ? (
       <Suspense
@@ -170,7 +170,7 @@ export function CommentItem({
       </Suspense>
     ) : null;
 
-  // 编辑态：textarea 占位替换 markdown 正文；非编辑态：渲染 markdown
+  // Edit mode: textarea replaces the markdown body in place; non-edit mode: render markdown
   const bodyOrEdit =
     editOpen && typeof comment.version === 'number' ? (
       <CommentEditEditor
@@ -190,7 +190,7 @@ export function CommentItem({
       />
     );
 
-  // 操作行：编辑态隐藏所有按钮（避免跟编辑器底部按钮组重复）；只读（decline / 不可参与）整行隐藏。
+  // Action row: edit mode hides all buttons (avoiding duplication with the editor's bottom button group); read-only (decline / non-participable) hides the whole row.
   const foot = !editOpen && !readOnly ? (
     <div className="pr-comment-foot">
       {!replyOpen && (
@@ -208,7 +208,7 @@ export function CommentItem({
           {t('common.edit')}
         </button>
       )}
-      {/* 删除按钮在最后，跟其它按钮风格对齐 — disable 期间文案变"删除中…" */}
+      {/* Delete button last, aligned in style with the other buttons — while disabled the label becomes "deleting…" */}
       {canDelete && !replyOpen && (
         <button
           type="button"
@@ -220,7 +220,7 @@ export function CommentItem({
           {deleting ? t('commentsPanel.deleting') : t('common.delete')}
         </button>
       )}
-      {/* 「加反应」按钮放在操作按钮之后；回复编辑态下隐藏避免拥挤 */}
+      {/* The "add reaction" button goes after the action buttons; hidden in reply edit mode to avoid crowding */}
       {reactionsMode && !replyOpen && (
         <ReactionAddButton
           reactions={reactions}
@@ -247,7 +247,7 @@ export function CommentItem({
     </div>
   ) : null;
 
-  // 已有反应：单独成行，渲染在操作按钮行下方（编辑态隐藏）。readOnly 下只展示、不可切换。
+  // Existing reactions: on their own row, rendered below the action button row (hidden in edit mode). Under readOnly they only display, not toggle.
   const reactionChipsEl =
     reactionsMode && !editOpen ? (
       <ReactionChips
@@ -261,7 +261,7 @@ export function CommentItem({
   const replyEditor = replyOpen ? (
     <CommentReplyEditor
       prLocalId={pr.localId}
-      // 回复目标抽象（threadId）：GitLab=discussion id（reply 必需）；Bitbucket 空 / GitHub=remoteId → 回退 remoteId。
+      // Reply target abstraction (threadId): GitLab=discussion id (required for reply); Bitbucket empty / GitHub=remoteId → fall back to remoteId.
       parentCommentId={comment.threadId ?? comment.remoteId}
       mentionCandidates={mentionCandidates}
       attachmentsEnabled={attachmentsEnabled}
@@ -272,8 +272,8 @@ export function CommentItem({
 
   const repliesEl =
     comment.replies.length > 0 ? (
-      // 满 MAX_REPLY_DEPTH 层后用 pr-comments-flat 取代 pr-comments-replies（不再缩进 / 左边框）→
-      // 更深回复拉平在该层缩进上；pr-comments-flat 据此给同层级相邻评论加横向分割线区分。
+      // Past MAX_REPLY_DEPTH levels, use pr-comments-flat instead of pr-comments-replies (no more indent / left border) →
+      // deeper replies flatten at that indent level; pr-comments-flat accordingly adds a horizontal divider between adjacent same-level comments to distinguish them.
       <ul
         className={`pr-comments-list ${depth < MAX_REPLY_DEPTH ? 'pr-comments-replies' : 'pr-comments-flat'}`}
       >
@@ -306,7 +306,7 @@ export function CommentItem({
     />
   ) : null;
 
-  // 时间线模式的顶层评论：与其它事件统一的标题行（图标 + 头像 + 作者 + 『评论』+ 时间），正文挂成缩进卡片。
+  // Top-level comment in timeline mode: a header row unified with other events (icon + avatar + author + 'commented' + time), with the body hung as an indented card.
   if (timeline && depth === 0) {
     return (
       <li className="pr-comment pr-comment-timeline pr-comment-depth-0">
@@ -381,7 +381,7 @@ export function CommentItem({
 }
 
 /**
- * 精确到秒的本地时间文案（`YYYY-MM-DD HH:mm:ss`），供时间标签 hover tooltip 展示实际时间点。
+ * Local time text to the second (`YYYY-MM-DD HH:mm:ss`), for the time label's hover tooltip to show the actual time point.
  */
 export function formatExactTime(iso: string): string {
   const ms = Date.parse(iso);
@@ -392,7 +392,7 @@ export function formatExactTime(iso: string): string {
 }
 
 /**
- * 相对时间文案（刚刚 / N 分钟前 / …），一周以上回退本地日期。供评论与活动事件共用。
+ * Relative time text (just now / N minutes ago / …), falling back to the local date beyond a week. Shared by comments and activity events.
  */
 export function formatRelativeTime(iso: string): string {
   const t = Date.parse(iso);

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentReplyEditor.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/CommentReplyEditor.tsx
@@ -8,18 +8,18 @@ import { uploadCommentImage } from '../shared/uploadCommentImage';
 interface CommentReplyEditorProps {
   prLocalId: string;
   parentCommentId: string;
-  /** `@提及` 自动补全候选（PR 参与者 + 评论作者）。 */
+  /** `@mention` autocomplete candidates (PR participants + comment authors). */
   mentionCandidates?: PlatformUser[];
-  /** 平台是否支持图片附件上传；为真才启用粘贴上传。 */
+  /** Whether the platform supports image attachment upload; paste upload is enabled only when true. */
   attachmentsEnabled?: boolean;
   onCancel: () => void;
-  /** reply 创建成功后调用 (UI 收起编辑框；评论列表通过 comments:changed 事件自动刷新) */
+  /** Called after a reply is created successfully (UI collapses the editor; the comment list auto-refreshes via the comments:changed event) */
   onPosted: () => void;
 }
 
 /**
- * 已有评论的人工回复编辑框：textarea + 保存/取消。展开在被回复评论的下方。
- * Cmd/Ctrl+Enter 保存，Esc 取消；空 body disabled 保存
+ * Manual reply editor for an existing comment: textarea + save/cancel. Expands below the comment being replied to.
+ * Cmd/Ctrl+Enter to save, Esc to cancel; empty body disables save
  */
 export function CommentReplyEditor({
   prLocalId,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/InlineCodeContext.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/comments/InlineCodeContext.tsx
@@ -1,5 +1,5 @@
-// 必须在用到 @monaco-editor/react 之前执行（见 DiffView 同款说明）。本文件经
-// React.lazy 动态加载 → Monaco 随本 chunk 按需拉取，不进入口包。
+// Must run before @monaco-editor/react is used (see the same note in DiffView). This file is
+// dynamically loaded via React.lazy → Monaco is pulled on demand with this chunk, not in the entry bundle.
 import '../../../../../lib/monaco-setup';
 import { Editor, type Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
@@ -17,25 +17,25 @@ import { languageFor } from '../../../../../utils/language';
 interface InlineCodeContextProps {
   pr: StoredPullRequest;
   anchor: PrCommentAnchor;
-  /** 锚定行前后展示的上下文行数；默认 5 */
+  /** Number of context lines shown around the anchored line; defaults to 5 */
   contextLines?: number;
   /**
-   * 进入页面时是否自动挂 Monaco 编辑器。CommentsPanel 默认对最新前 N 条 inline
-   * 评论 (AUTO_EXPAND_CAP) 传 true，超额条目传 false → 渲染"展开代码"按钮，
-   * 用户点击才挂 editor (懒加载)，避免 PR 评论很多时一次性把页面拖慢
+   * Whether to auto-mount the Monaco editor on entering the page. CommentsPanel passes true by default
+   * for the latest N inline comments (AUTO_EXPAND_CAP), and false for the rest → renders an "expand code" button;
+   * the editor mounts only when the user clicks (lazy load), avoiding slowing the page down all at once when a PR has many comments
    */
   autoExpand?: boolean;
 }
 
 /**
- * 评论里 inline 引用的代码上下文：Monaco read-only 编辑器，展示锚定行前后若干行，
- * 锚定行用整行底色高亮 (跟 Bitbucket 内嵌评论的视觉惯例一致)。
+ * Inline code context referenced in a comment: a Monaco read-only editor showing a few lines around the anchored line,
+ * with the anchored line highlighted by a full-line background (matching Bitbucket's inline-comment visual convention).
  *
- * 取数走 `diff:getFileContent` —— 跟 DiffView 同一份本地 git blob，无远端往返；
- * mirror 还没拉齐 base/head sha 时 (rare，poll 已经先 sync 过) 走 syncMirror 兜底。
+ * Data comes from `diff:getFileContent` — the same local git blob as DiffView, no remote round trip;
+ * when the mirror has not yet fetched the base/head sha (rare, poll already synced first) it falls back to syncMirror.
  *
- * 性能：每个 inline 评论都会挂一个 Monaco 实例 (读 + tokenize)。CommentsPanel 控
- * 默认只 auto-expand 前 N 条 (按时间线)，超额走 click-to-expand 懒加载。
+ * Performance: each inline comment mounts a Monaco instance (read + tokenize). CommentsPanel controls this:
+ * by default it only auto-expands the first N (by timeline); the rest use click-to-expand lazy loading.
  */
 function InlineCodeContextImpl({
   pr,
@@ -53,7 +53,7 @@ function InlineCodeContextImpl({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // 未展开时不拉文件 — 给用户主动控制懒加载的语义
+    // Do not fetch the file while collapsed — gives the user active control over lazy-load semantics
     if (!expanded) return;
     let cancelled = false;
     setSnippet(null);
@@ -62,7 +62,7 @@ function InlineCodeContextImpl({
       try {
         const c = await invoke('diff:getFileContent', {
           localId: pr.localId,
-          // anchor.side 'old' 锚到 base 侧，'new' 锚到 head 侧
+          // anchor.side 'old' anchors to the base side, 'new' anchors to the head side
           side: anchor.side === 'old' ? 'base' : 'head',
           path: anchor.path,
         });
@@ -85,9 +85,9 @@ function InlineCodeContextImpl({
     return () => {
       cancelled = true;
     };
-    // 故意不依赖 t：useTranslation 的 t 会在 i18n languageChanged 时换新引用（poll 刷新也可能触发），
-    // 把它放进依赖会让本 effect 无谓重跑 → setSnippet(null) → 内嵌 Monaco 卸载重建（刷新抖动）。
-    // t 仅用于错误文案，重抓时机只该由 expanded / pr / anchor 决定。
+    // Intentionally not depending on t: useTranslation's t swaps to a new reference on i18n languageChanged (poll refresh may also trigger it),
+    // putting it in deps would make this effect re-run pointlessly → setSnippet(null) → the embedded Monaco unmounts and rebuilds (refresh flicker).
+    // t is only used for error text; the refetch timing should be decided solely by expanded / pr / anchor.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expanded, pr.localId, anchor.path, anchor.side, anchor.line, contextLines]);
 
@@ -115,13 +115,13 @@ function InlineCodeContextImpl({
   return <CodeSnippet snippet={snippet} language={languageFor(anchor.path)} />;
 }
 
-/** 行内片段行高 / 字号比（源自 fs=12 时行高 19）；按配置字号等比缩放行高。 */
+/** Inline snippet line-height / font-size ratio (derived from line-height 19 at fs=12); scales line height proportionally to the configured font size. */
 const SNIPPET_LINE_HEIGHT_RATIO = 19 / 12;
 
 const READONLY_OPTIONS: editor.IStandaloneEditorConstructionOptions = {
   readOnly: true,
-  // keep-alive：评论 tab 切走时本编辑器被 display:none（尺寸归 0），切回需重排。
-  // automaticLayout 让 Monaco 自带 ResizeObserver 在显隐时自动 layout，避免切回空白/错位。
+  // keep-alive: when the comment tab is switched away, this editor is display:none (size collapses to 0), and needs reflow on switch-back.
+  // automaticLayout lets Monaco's built-in ResizeObserver auto-layout on show/hide, avoiding blank/misaligned rendering on switch-back.
   automaticLayout: true,
 };
 
@@ -132,11 +132,11 @@ interface Snippet {
 }
 
 /**
- * 只读代码片段编辑器。**独立 memo 组件**：props 只有稳定的 snippet（值不变就同一引用）+ language，
- * 与父级 CommentItem / CommentsPanel 的任何重渲染（poll / 焦点刷新触发的 pr 换引用等）彻底隔离。
- * 父级重渲染时本组件按 props 浅比较 bail → 不重建 <Editor> 元素 → @monaco-editor/react 的 value /
- * options effect 都不触发（避免只读编辑器被无条件 setValue 重置 → 重新 tokenize 的刷新抖动）。
- * onMount / options 也用稳定引用，杜绝即便重渲染时的 updateOptions 抖动。
+ * Read-only code snippet editor. **Standalone memo component**: props are only the stable snippet (same reference when value unchanged) + language,
+ * fully isolated from any re-render of parent CommentItem / CommentsPanel (pr reference swaps triggered by poll / focus refresh, etc.).
+ * On parent re-render this component bails via shallow props comparison → does not rebuild the <Editor> element → @monaco-editor/react's value /
+ * options effects do not fire (avoiding the read-only editor being unconditionally reset by setValue → re-tokenize refresh flicker).
+ * onMount / options also use stable references, eliminating updateOptions flicker even on re-render.
  */
 const CodeSnippet = memo(function CodeSnippet({
   snippet,
@@ -145,10 +145,10 @@ const CodeSnippet = memo(function CodeSnippet({
   snippet: Snippet;
   language: string;
 }) {
-  // Monaco 内置主题不走 CSS 自定义属性，须显式切换：按编辑器主题偏好（'auto' 跟随 GUI 深浅）解析。
+  // Monaco's built-in themes do not use CSS custom properties, so they must be switched explicitly: resolved by the editor theme preference ('auto' follows GUI light/dark).
   const monacoTheme = useMonacoEditorTheme();
-  // 等宽字体 + 字号随配置切换。行内片段比主编辑器小 2px（保留历史观感）、随配置字号联动，下限受 MIN 约束；
-  // 行高按字号等比缩放。字号 / 行高 / 字体一并进 options（@monaco-editor/react 按引用比对，useMemo 稳定）。
+  // Monospace font + font size switch with config. Inline snippets are 2px smaller than the main editor (preserving the historical look), track the configured font size, with a MIN lower bound;
+  // line height scales proportionally to the font size. Font size / line height / font all go into options (@monaco-editor/react compares by reference, kept stable via useMemo).
   const appearance = useEditorAppearance();
   const fontFamily = resolveEditorFontFamily(appearance.fontFamily);
   const snippetFontSize = Math.max(EDITOR_FONT_SIZE_MIN, appearance.fontSize - 2);
@@ -167,8 +167,8 @@ const CodeSnippet = memo(function CodeSnippet({
 
   const handleMount = useCallback(
     (ed: editor.IStandaloneCodeEditor, monaco: Monaco): void => {
-      // 真实文件行号 = snippet 内部行号 + startLine - 1。Monaco lineNumbers 函数式
-      // 完全可控，把内部 1..N 映射回去
+      // Real file line number = snippet-internal line number + startLine - 1. Monaco's functional lineNumbers
+      // is fully controllable, mapping the internal 1..N back
       ed.updateOptions({
         readOnly: true,
         domReadOnly: true,
@@ -182,12 +182,12 @@ const CodeSnippet = memo(function CodeSnippet({
         contextmenu: false,
         folding: false,
         glyphMargin: false,
-        // 字号 / 行高 / 字体由 options 统一驱动（随配置实时更新），不在此固定。
+        // Font size / line height / font are driven uniformly by options (updated live with config), not fixed here.
         padding: { top: 6, bottom: 6 },
-        // 行宽自适应，长行用 word wrap 而不是横向滚动条 (滚动条已禁)
+        // Line width adapts; long lines use word wrap instead of a horizontal scrollbar (scrollbars are disabled)
         wordWrap: 'on',
       });
-      // 锚定行整行底色：用 Monaco decorations。线条 className 走 CSS 决定颜色
+      // Full-line background for the anchored line: via Monaco decorations. The line className lets CSS decide the color
       ed.createDecorationsCollection([
         {
           range: new monaco.Range(snippet.anchorInSnippet, 1, snippet.anchorInSnippet, 1),
@@ -217,9 +217,10 @@ const CodeSnippet = memo(function CodeSnippet({
 });
 
 /**
- * 按**锚点值**（path / line / side）+ pr.localId + 展示选项比较的 memo：父级（CommentsPanel）在 poll
- * 重渲染时会传新的 anchor / pr **对象引用**（值未变），默认浅比较会误判变化 → 内嵌 Monaco 重渲染重排
- * （刷新抖动）。这里按值比较，定位信息没变就跳过整个组件，Monaco 不动。
+ * A memo comparing by **anchor value** (path / line / side) + pr.localId + display options: on poll re-render the parent
+ * (CommentsPanel) passes new anchor / pr **object references** (unchanged values), and the default shallow comparison would
+ * mistake this for a change → embedded Monaco re-renders and reflows (refresh flicker). Here it compares by value, skipping the
+ * whole component when the location info is unchanged, leaving Monaco untouched.
  */
 export const InlineCodeContext = memo(
   InlineCodeContextImpl,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffPane.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffPane.tsx
@@ -30,52 +30,52 @@ export function DiffPane({
   onMount: (editor: MonacoEditor.IStandaloneDiffEditor) => void;
 }) {
   const { t } = useTranslation();
-  // Monaco 内置主题不走 CSS 自定义属性，须显式切换：按编辑器主题偏好（'auto' 跟随 GUI 深浅）解析。
+  // Monaco's built-in themes do not use CSS custom properties, so they must be switched explicitly: resolved by the editor theme preference ('auto' follows GUI light/dark).
   const monacoTheme = useMonacoEditorTheme();
-  // 编辑器等宽字体 + 字号：随配置切换（字体空 = Monaco 默认；字号按平台再做微调）。
+  // Editor monospace font + font size: switch with config (empty font = Monaco default; font size gets a per-platform tweak).
   const editorAppearance = useEditorAppearance();
   const fontFamily = resolveEditorFontFamily(editorAppearance.fontFamily);
-  // Monaco 挂载后 diff 还要异步计算 + hideUnchangedRegions 折叠才稳定（见上文 reveal 逻辑），
-  // 期间编辑器是「空 → 跳一下」的重排。在它之上盖一层 overlay loading，首次 onDidUpdateDiff
-  // （或挂载即已算完）后卸载，遮住这段抖动一次性 reveal。DiffPane 按 file path keyed →
-  // 切文件自然 remount，diffReady 随之复位。
+  // After Monaco mounts, the diff still needs async computation + hideUnchangedRegions collapsing before it stabilizes (see the reveal logic below),
+  // during which the editor reflows from "empty → jump". Lay an overlay loading on top of it, unmount after the first onDidUpdateDiff
+  // (or if already computed on mount), covering this flicker for a one-shot reveal. DiffPane is keyed by file path →
+  // switching files naturally remounts, and diffReady resets with it.
   const [diffReady, setDiffReady] = useState(false);
-  // options 必须 useMemo 稳定引用：@monaco-editor/react 对 options **按引用**比对，引用一变就
-  // editor.updateOptions()。父级 DiffView 随 poll（pr 换新对象引用）重渲染 → DiffPane 重渲染，
-  // 若每次新建 options 字面量，每次 poll 都触发 updateOptions → hideUnchangedRegions 折叠布局重算 →
-  // 编辑器渲染抖动。只在真正影响项（并排/空白/字号）变化时重建。
+  // options must use a stable useMemo reference: @monaco-editor/react compares options **by reference**, and any reference change triggers
+  // editor.updateOptions(). The parent DiffView re-renders with poll (pr swaps to a new object reference) → DiffPane re-renders,
+  // and if the options literal is rebuilt each time, every poll triggers updateOptions → hideUnchangedRegions collapse layout recompute →
+  // editor render flicker. Rebuild only when items that truly matter (side-by-side / whitespace / font size) change.
   const fontSize = editorFontSize(editorAppearance.fontSize);
   const editorOptions = useMemo<MonacoEditor.IDiffEditorConstructionOptions>(
     () => ({
       readOnly: true,
       renderSideBySide,
-      // keep-alive：tab 切走时本编辑器被 display:none（尺寸归 0），切回需重排。automaticLayout
-      // 让 Monaco 自带 ResizeObserver 在显隐/尺寸变化时自动 layout，避免切回空白/错位。
+      // keep-alive: when the tab is switched away, this editor is display:none (size collapses to 0), and needs reflow on switch-back. automaticLayout
+      // lets Monaco's built-in ResizeObserver auto-layout on show/hide/size change, avoiding blank/misaligned rendering on switch-back.
       automaticLayout: true,
       minimap: { enabled: false },
       fontSize,
       fontFamily,
       scrollBeyondLastLine: false,
-      // 关掉 diff 专属的合并总览列（renderOverviewRuler=true 会在两侧滚动条之外再加一条宽列，
-      // 跟 VS Code 编辑模式「滚动条内打标」不一致）。改走编辑模式效果：内层 modified 编辑器自带的
-      // overview ruler（默认渲染、独立于 minimap）+ 行内评论装饰的 overviewRuler 投影（见 useCommentZones）。
+      // Turn off the diff-specific merged overview column (renderOverviewRuler=true adds an extra wide column outside both scrollbars,
+      // inconsistent with VS Code edit mode's "marks inside the scrollbar"). Go with the edit-mode effect instead: the inner modified editor's own
+      // overview ruler (rendered by default, independent of the minimap) + inline comment decorations' overviewRuler projection (see useCommentZones).
       renderOverviewRuler: false,
-      // 显式 3 道：让 overview ruler 按 1/3 分道（diff 占左道、评论占右道，各 1/3 宽），
-      // 避免被按 2 道算成各占一半，色条更细。
+      // Explicit 3 lanes: split the overview ruler into thirds (diff takes the left lane, comments the right, each 1/3 wide),
+      // avoiding being computed as 2 lanes each taking half, for thinner color bars.
       overviewRulerLanes: 3,
-      // 显式开 glyph margin，给行内评论标记留位置
+      // Explicitly enable glyph margin, leaving room for inline comment markers
       glyphMargin: true,
-      // 空白字符可视化：toolbar 按钮控制；'all' 时空格显示 · / Tab 显示 →
+      // Whitespace visualization: controlled by a toolbar button; when 'all', spaces show as · / Tab shows as →
       renderWhitespace: showWhitespace ? 'all' : 'none',
-      // GitHub 风格折叠：未变更段缩成可展开占位行
+      // GitHub-style folding: unchanged sections collapse into expandable placeholder rows
       hideUnchangedRegions: {
         enabled: true,
         contextLineCount: 10,
         minimumLineCount: 5,
         revealLineCount: 20,
       },
-      // 关掉依赖 ts.worker 的高级特性（diff review 不需要），同时消掉
-      // `Missing requestHandler` 噪音。hover 保留给 blame / 评论装饰用。
+      // Turn off advanced features that depend on ts.worker (diff review does not need them), which also silences
+      // the `Missing requestHandler` noise. hover is kept for blame / comment decorations.
       inlayHints: { enabled: 'off' },
       quickSuggestions: false,
       suggestOnTriggerCharacters: false,
@@ -89,9 +89,9 @@ export function DiffPane({
   const handleMount = useCallback(
     (editor: MonacoEditor.IStandaloneDiffEditor) => {
       onMount(editor);
-      // diff 算完触发 onDidUpdateDiff，但 hideUnchangedRegions 折叠的布局还要再 paint
-      // 一两帧才稳定 → 不在事件里立即揭开（否则露出折叠那一跳），略等 80ms 让折叠 paint
-      // 完成、overlay 一直盖着，再一次性 reveal。
+      // The diff computation fires onDidUpdateDiff, but the hideUnchangedRegions collapse layout still needs another
+      // frame or two of painting to stabilize → do not reveal immediately in the event (else the collapse jump shows); wait ~80ms to let the collapse
+      // paint finish while the overlay stays on, then reveal in one shot.
       const reveal = (): void => {
         window.setTimeout(() => setDiffReady(true), 80);
       };

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffScopeSelect.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffScopeSelect.tsx
@@ -7,9 +7,9 @@ import { formatRelativeTime } from '../comments/CommentItem';
 import type { DiffScope } from './diff-types';
 
 /**
- * 变更范围选择器：文件树头部「<n> 个文件 · 全部变更 / <commit>」，点击展开下拉切换查看范围。
- * commit 列表懒加载（首次展开才拉）。选「全部变更」= PR 全量 diff；选某 commit = 该 commit
- * 的 parent..sha 只读 diff。
+ * Diff scope selector: file-tree header "<n> files · All changes / <commit>", click to expand a dropdown to switch the view scope.
+ * Commit list is lazy-loaded (fetched only on first expand). Picking "All changes" = full PR diff; picking a commit = that
+ * commit's parent..sha read-only diff.
  */
 export function DiffScopeSelect({
   fileCount,
@@ -31,13 +31,13 @@ export function DiffScopeSelect({
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
-  // 下拉用 fixed 定位 + portal 挂到 body：否则会被 .diff-file-list 的 overflow 裁切、被右侧 Monaco 盖住。
+  // Dropdown uses fixed positioning + portal mounted to body: otherwise it gets clipped by .diff-file-list overflow and covered by the Monaco editor on the right.
   const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null);
   const computePos = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
-    // 菜单整体拉宽：不小于触发器宽度，且给 commit 主题留足空间
+    // Widen the whole menu: no smaller than the trigger width, and leave enough room for the commit subject
     setMenuPos({ top: r.bottom + 2, left: r.left, width: Math.max(r.width, 440) });
   }, []);
   useEffect(() => {
@@ -48,7 +48,7 @@ export function DiffScopeSelect({
       if (ref.current?.contains(target) || menuRef.current?.contains(target)) return;
       setOpen(false);
     };
-    // 触发器在文件树头部（不随文件列表滚动），但窗口缩放 / 外层滚动时重算位置
+    // Trigger sits in the file-tree header (doesn't scroll with the file list), but recompute position on window resize / outer scroll
     const onReflow = (): void => computePos();
     document.addEventListener('mousedown', onDoc);
     window.addEventListener('resize', onReflow);
@@ -92,7 +92,7 @@ export function DiffScopeSelect({
             role="listbox"
             style={{ top: menuPos.top, left: menuPos.left, width: menuPos.width }}
           >
-            {/* 「全部变更」：标题 + 提交数副行（参考 Bitbucket 两行布局） */}
+            {/* "All changes": title + commit-count subrow (mirrors the Bitbucket two-line layout) */}
             <li>
               <button
                 type="button"
@@ -115,7 +115,7 @@ export function DiffScopeSelect({
                 </span>
               </button>
             </li>
-            {/* 每个 commit：标题（首行 message）+ 作者 / 短 SHA / 时间副行 */}
+            {/* Each commit: title (first line of message) + author / short SHA / time subrow */}
             {(commits ?? []).map((c) => {
               const subject = c.message.split('\n', 1)[0]!;
               const active = scope.kind === 'commit' && scope.sha === c.sha;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffSearchPanel.tsx
@@ -5,19 +5,19 @@ import { PER_FILE_MATCH_CAP, basename, dirname } from './search/diff-search';
 import { useDiffSearch } from './search/useDiffSearch';
 
 /**
- * 搜索 PR diff 全部变更文件内容。仿 Bitbucket "Search code" 入口的行为：
+ * Search the content of all changed files in the PR diff. Mimics the behavior of Bitbucket's "Search code" entry:
  *
- * - query 在 head + base 两端 line-by-line 找匹配
- * - 每个匹配行带 side 标记：
- *     'added'   — 仅出现在 head 端 (前缀 `+`)
- *     'removed' — 仅出现在 base 端 (前缀 `-`)
- *     'context' — 两端都有相同内容 (无前缀)
- * - 按文件 group，文件名右侧 badge 显示该文件匹配数
- * - 文件级 expand/collapse，默认全展开
- * - 点击某条结果 → 调 onJumpToMatch 切换文件 + scroll 到对应行
+ * - query matches line-by-line on both the head + base sides
+ * - each matched line carries a side marker:
+ *     'added'   — appears only on the head side (prefix `+`)
+ *     'removed' — appears only on the base side (prefix `-`)
+ *     'context' — same content on both sides (no prefix)
+ * - grouped by file, a badge to the right of the file name shows that file's match count
+ * - file-level expand/collapse, all expanded by default
+ * - clicking a result → calls onJumpToMatch to switch file + scroll to the corresponding line
  *
- * 搜索算法见 [search/diff-search](./search/diff-search.ts)，状态机见
- * [search/useDiffSearch](./search/useDiffSearch.ts)；本组件只负责渲染。
+ * Search algorithm in [search/diff-search](./search/diff-search.ts), state machine in
+ * [search/useDiffSearch](./search/useDiffSearch.ts); this component only handles rendering.
  */
 
 interface DiffSearchPanelProps {
@@ -25,8 +25,8 @@ interface DiffSearchPanelProps {
   prLocalId: string;
   onJumpToMatch: (file: DiffChangedFile, line: number, side: 'old' | 'new') => void;
   /**
-   * 用户按 Esc 时调 — 父端通常把 sidebarMode 切回 'tree'。无论焦点在 input 还是
-   * 结果列表都生效 (走 window 层 keydown)
+   * Called when the user presses Esc — the parent usually switches sidebarMode back to 'tree'. Works whether focus is
+   * on the input or the result list (via a window-level keydown)
    */
   onExit?: () => void;
 }
@@ -47,9 +47,9 @@ export function DiffSearchPanel({ files, prLocalId, onJumpToMatch, onExit }: Dif
     inputRef,
   } = useDiffSearch(files, prLocalId);
 
-  // Esc 退出搜索：用 window capture-stage listener 让焦点在 input / 结果按钮 /
-  // 任何子元素都生效。子元素的 input 自带 Esc 清空行为浏览器不一定有 (type=text)
-  // 不会跟它冲突
+  // Esc to exit search: a window capture-stage listener makes it work whether focus is on the input / result button /
+  // any child element. Browsers don't necessarily give a child input a built-in Esc-to-clear behavior (type=text)
+  // so there's no conflict with it
   useEffect(() => {
     if (!onExit) return;
     const onKey = (e: KeyboardEvent): void => {
@@ -143,9 +143,9 @@ export function DiffSearchPanel({ files, prLocalId, onJumpToMatch, onExit }: Dif
                           {m.diffRole === 'added' ? '+' : m.diffRole === 'removed' ? '-' : ' '}
                         </span>
                         <span className="diff-search-match-line">{m.line}</span>
-                        {/* colorize 完成后用 dangerouslySetInnerHTML 渲染带语法
-                            着色的 HTML；未完成 / plaintext 文件走 fallback 走纯
-                            文本 + 关键词 <mark> 高亮 */}
+                        {/* Once colorize finishes, render the syntax-colored HTML via
+                            dangerouslySetInnerHTML; not-yet-done / plaintext files fall
+                            back to plain text + keyword <mark> highlight */}
                         {m.colorizedHtml ? (
                           <span
                             className="diff-search-match-content"
@@ -181,8 +181,8 @@ export function DiffSearchPanel({ files, prLocalId, onJumpToMatch, onExit }: Dif
 }
 
 /**
- * 关键词高亮：把 content 按 [matchStart, matchEnd) 拆三段，中间一段套 <mark>。
- * 只高亮第一处命中，避免渲染额外计算
+ * Keyword highlight: split content into three parts by [matchStart, matchEnd), wrapping the middle part in <mark>.
+ * Only highlights the first hit, avoiding extra render computation
  */
 function renderHighlight(content: string, start: number, end: number): React.ReactNode {
   if (start < 0 || end <= start) return content;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffStatus.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffStatus.tsx
@@ -22,7 +22,7 @@ export function SyncProgress({ progress }: { progress: SyncProgressEvent | null 
       </span>
     );
   }
-  // sync 完成后 IPC handler 还在跑 git diff 算变更文件列表，显示对应阶段提示
+  // After sync completes the IPC handler is still running git diff to compute the changed files list; show the matching phase hint
   if (progress.phase === 'done') {
     return (
       <span className="muted">
@@ -54,7 +54,7 @@ export function SyncProgress({ progress }: { progress: SyncProgressEvent | null 
   );
 }
 
-/** 整块替代 diff 区的硬错误展示（如变更文件列表本身拉不下来） */
+/** Hard-error display that replaces the whole diff area (e.g. the changed files list itself can't be fetched) */
 export function BackendErrorView({
   err,
   scope,
@@ -81,7 +81,7 @@ export function BackendErrorView({
   );
 }
 
-/** 顶部细 banner，部分功能拉不下来但 diff 主体仍可用时显示 */
+/** Thin top banner, shown when some features can't be fetched but the diff body is still usable */
 export function BackendErrorBanner({
   err,
   scope,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DiffView.tsx
@@ -1,5 +1,5 @@
-// 必须在用到 @monaco-editor/react 之前执行（loader.config 指向本地 monaco）。
-// 本文件经 React.lazy 动态加载，故 Monaco 随本 chunk 按需拉取，不进入口包。
+// Must run before @monaco-editor/react is used (loader.config points to the local monaco).
+// This file is dynamically loaded via React.lazy, so Monaco is fetched on demand with this chunk and stays out of the entry bundle.
 import '../../../../../lib/monaco-setup';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +36,7 @@ import {
   useSyncProgress,
 } from './hooks';
 
-// commit「查看特定 commit」请求载荷类型（PrPanel 引用）；定义在 diff-types，此处 re-export 保持入口稳定。
+// Payload type for the "view specific commit" request (referenced by PrPanel); defined in diff-types, re-exported here to keep the entry stable.
 export type { PendingCommitView } from './diff-types';
 
 interface DiffViewProps {
@@ -44,16 +44,16 @@ interface DiffViewProps {
   renderSideBySide: boolean;
   showBlame: boolean;
   showWhitespace: boolean;
-  /** 活动连接能力位；此处用 commentHardBreaks 决定评论是否启用 remark-breaks。 */
+  /** Active connection capability bits; here commentHardBreaks decides whether comments enable remark-breaks. */
   capabilities?: PlatformCapabilities;
-  /** 内容只读（decline / 不可参与归档 PR）：不挂行内「+」新建评论、隐藏行内评论的回复 / 编辑 / 删除。 */
+  /** Content read-only (declined / non-participatable archived PR): don't mount the inline "+" new-comment affordance, hide reply / edit / delete on inline comments. */
   readOnly?: boolean;
   /**
-   * 跳转目标：来自 ChatPane finding card → App pendingDiffNav。
-   * 非 null 时 DiffView 切到该文件 + 滚到 anchor 行 + 短暂高亮 + (带 runId/findingId
-   * 时) 打开 inline 草稿编辑 zone (草稿已由 ChatPane 端懒创建)。
-   * runId/findingId 缺省 (PublishReviewModal anchor 点击) → 仅 navigate 不 enter edit。
-   * 消费完调 onNavConsumed 清空 token
+   * Navigation target: from a ChatPane finding card → App pendingDiffNav.
+   * When non-null, DiffView switches to that file + scrolls to the anchor line + briefly highlights + (when runId/findingId
+   * are present) opens the inline draft edit zone (the draft is already lazily created on the ChatPane side).
+   * When runId/findingId are absent (PublishReviewModal anchor click) → navigate only, don't enter edit.
+   * Once consumed, call onNavConsumed to clear the token
    */
   pendingNav?: {
     runId?: string;
@@ -62,22 +62,22 @@ interface DiffViewProps {
   } | null;
   onNavConsumed?: () => void;
   /**
-   * 外部请求切到「查看特定 commit」视图（来自 提交 / 活动 标签页点击某 commit）。
-   * 非 null 时 DiffView 把变更范围切到该 commit 的 `parent..sha`；消费完调 onCommitViewConsumed。
+   * External request to switch to the "view specific commit" view (from clicking a commit on the Commits / Activity tab).
+   * When non-null, DiffView switches the scope to that commit's `parent..sha`; once consumed, calls onCommitViewConsumed.
    */
   pendingCommitView?: PendingCommitView | null;
   onCommitViewConsumed?: () => void;
   /**
-   * 当前变更范围切到 / 离开单 commit 时上报（commit 有父 → 传该 commit 范围，全部变更 / root commit → null）。
-   * 上层（App）据此把「正在查看的 commit」作为聊天区命令的隐式范围（见 ChatPane viewCommitScope）。
+   * Reported when the current scope switches to / leaves a single commit (commit has a parent → pass that commit's scope, all changes / root commit → null).
+   * The parent (App) uses this to treat the "currently viewed commit" as the implicit scope for chat-pane commands (see ChatPane viewCommitScope).
    */
   onViewCommitScopeChange?: (scope: ReviewRunCommitScope | null) => void;
 }
 
 /**
- * PR diff 视图（组合根）：左侧文件树 / 范围选择 / 跨文件搜索，右侧 Monaco DiffEditor + blame 列 +
- * 行内评论 / 草稿 view zone。数据流（变更文件 / 内容 / 评论 / blame / 范围 / 跳转）拆到 ./hooks/*；
- * 行内 view-zone 挂载走 ./zones/mountInlineZones；行内评论渲染见 ./inline-comments/。
+ * PR diff view (composition root): file tree / scope select / cross-file search on the left, Monaco DiffEditor + blame column +
+ * inline comment / draft view zones on the right. Data flow (changed files / content / comments / blame / scope / navigation) is split into ./hooks/*;
+ * inline view-zone mounting goes through ./zones/mountInlineZones; inline comment rendering is in ./inline-comments/.
  */
 export function DiffView({
   pr,
@@ -92,16 +92,16 @@ export function DiffView({
   onCommitViewConsumed,
   onViewCommitScopeChange,
 }: DiffViewProps) {
-  // 评论换行策略：GitHub/Bitbucket hard-break（单 \n → <br>）；GitLab CommonMark 软换行。
-  // 能力位缺省（旧数据/无连接）回退 true，保持既有行为。
+  // Comment line-break policy: GitHub/Bitbucket hard-break (single \n → <br>); GitLab CommonMark soft-wrap.
+  // When the capability bit is absent (old data / no connection), fall back to true to preserve existing behavior.
   const commentHardBreaks = capabilities?.commentHardBreaks ?? true;
-  // 行内评论 emoji 反应 / 图片附件能力（与评论 / 活动 tab 同源能力位）：缺省 = 不支持（不渲染加反应按钮 / 不启用粘贴上传）。
+  // Inline comment emoji reaction / image attachment capabilities (same capability bits as the comments / activity tab): absent = unsupported (don't render the add-reaction button / don't enable paste upload).
   const reactionsMode = capabilities?.commentReactions || undefined;
   const attachmentsEnabled = capabilities?.commentAttachments ?? false;
   const { t } = useTranslation();
-  // 草稿池：跨 ChatPane / DiffView 共享 store；本组件需要它来渲染 inline zones
+  // Draft pool: store shared across ChatPane / DiffView; this component needs it to render inline zones
   const drafts = useDraftsForPr(pr.localId);
-  // 用 state 而非 ref：onMount 异步触发，必须靠 state 变更触发后续 useEffect 重新运行装饰逻辑。
+  // Use state, not a ref: onMount fires asynchronously, so a state change is required to re-run the subsequent useEffect decoration logic.
   const [diffEditor, setDiffEditor] = useState<MonacoEditor.IStandaloneDiffEditor | null>(null);
 
   const progress = useSyncProgress(pr);
@@ -111,8 +111,8 @@ export function DiffView({
     pendingCommitView,
     onCommitViewConsumed,
   );
-  // 把「正在查看的单 commit」上报给上层，作为聊天区命令的隐式范围。commit 有父才可 parent..sha 定界；
-  // 全部变更 / root commit（无父）上报 null。
+  // Report the "currently viewed single commit" to the parent as the implicit scope for chat-pane commands. Only a commit with a parent can be bounded as parent..sha;
+  // all changes / root commit (no parent) reports null.
   useEffect(() => {
     if (!onViewCommitScopeChange) return;
     onViewCommitScopeChange(
@@ -128,7 +128,7 @@ export function DiffView({
   }, [scope, onViewCommitScopeChange]);
   const { files, filesError, retryFiles, selectedKey, setSelectedKey, selected, loadedKey } =
     useChangedFiles(pr, range, viewKey);
-  // 合并会冲突的文件路径集合（仅 pr.hasConflict 时实拉），文件树据此标三角警示。
+  // Set of file paths that would conflict on merge (only fetched when pr.hasConflict), the file tree marks a triangle warning based on this.
   const conflictPaths = useConflictFiles(pr);
   const { content, contentLoading, contentError, setContentError } = useFileContent(
     pr,
@@ -165,18 +165,18 @@ export function DiffView({
     onNavConsumed,
     triggerAutoEdit,
   });
-  // 捕获 Diff 选区 → selectionStore，供 ChatPane 把选中代码作为隐式上下文带进 agent/ask 提问。
+  // Capture the Diff selection → selectionStore, so ChatPane can carry the selected code as implicit context into agent/ask questions.
   useSelectionCapture({ diffEditor, selected, prLocalId: pr.localId, renderSideBySide });
 
-  // sidebar 模式：'tree' (文件树) / 'search' (跨文件搜索)，默认进文件树。PR 切换时回到 'tree'。
+  // sidebar mode: 'tree' (file tree) / 'search' (cross-file search), defaults to the file tree. Returns to 'tree' on PR switch.
   const [sidebarMode, setSidebarMode] = useState<'tree' | 'search'>('tree');
   useEffect(() => {
     setSidebarMode('tree');
   }, [pr.localId]);
 
-  // Bitbucket 评论附件 markdown 形如 `![alt](attachment:HASH)`；CommentNode 里把
-  // `attachment:` 协议改写成此基址 + `/HASH`，让 <a> 能打开（点击走 Electron
-  // setWindowOpenHandler 转 shell.openExternal，用户在系统浏览器看附件）。
+  // Bitbucket comment attachment markdown looks like `![alt](attachment:HASH)`; CommentNode rewrites
+  // the `attachment:` protocol to this base + `/HASH` so the <a> can open (clicking goes through Electron's
+  // setWindowOpenHandler to shell.openExternal, and the user views the attachment in the system browser).
   const attachmentBase = useMemo(() => {
     try {
       const u = new URL(pr.url);
@@ -186,7 +186,7 @@ export function DiffView({
     }
   }, [pr.url, pr.repo.projectKey, pr.repo.repoSlug]);
 
-  // 给文件树用：path → 锚到该文件的评论数（含双 path 别名 + renamed 的 oldPath）
+  // For the file tree: path → number of comments anchored to that file (including dual-path aliases + renamed oldPath)
   const commentCountByPath = useMemo(() => {
     const m = new Map<string, number>();
     if (!files) return m;
@@ -199,8 +199,8 @@ export function DiffView({
     return m;
   }, [files, comments]);
 
-  // 给文件树用：path → 该文件下的待发布草稿数 (pending + edited)。
-  // rejected (用户决断不发) / posted (已发，已在 comments chip 算了) 都排除。
+  // For the file tree: path → number of unpublished drafts under that file (pending + edited).
+  // Both rejected (user decided not to post) and posted (already posted, already counted in the comments chip) are excluded.
   const draftCountByPath = useMemo(() => {
     const m = new Map<string, number>();
     if (!files || !drafts) return m;
@@ -214,9 +214,9 @@ export function DiffView({
     return m;
   }, [files, drafts]);
 
-  // diff 增/删/改投影到滚动条总览标尺左道（编辑模式风格；评论锚点走右道，见下）
+  // diff add/delete/modify projected onto the left lane of the scrollbar overview ruler (edit-mode style; comment anchors take the right lane, see below)
   useDiffOverviewMarks({ diffEditor, content, selected, renderSideBySide });
-  // 行内评论标记 + view zone
+  // Inline comment marks + view zone
   useCommentZones({
     diffEditor,
     comments,
@@ -232,7 +232,7 @@ export function DiffView({
     attachmentsEnabled,
     readOnly,
   });
-  // 内联草稿 view zone（commit 只读视图不渲染）
+  // Inline draft view zone (not rendered in the commit read-only view)
   useDraftZones({
     diffEditor,
     drafts,
@@ -245,7 +245,7 @@ export function DiffView({
     attachmentsEnabled,
     scopeKind: scope.kind,
   });
-  // 行 hover '+' 新建草稿（commit 只读视图不挂）
+  // Line hover '+' to create a new draft (not mounted in the commit read-only view)
   useLineCommentAdder({
     diffEditor,
     content,
@@ -260,9 +260,9 @@ export function DiffView({
     t,
   });
 
-  // 切 PR 进行中：仍渲染旧 PR 的树/内容（stale），由下方遮罩盖住，待新 files 到位再整体替换。
+  // PR switch in progress: still render the old PR's tree/content (stale), covered by the overlay below, replaced wholesale once the new files arrive.
   const switching = files !== null && loadedKey !== viewKey;
-  // 错误仅在「无可信内容可展示」时整块呈现：首载失败（无 files）或切 PR 失败（现有 files 属于旧 PR）。
+  // The error is shown as a full block only when "there's no trustworthy content to display": initial load failed (no files) or PR switch failed (existing files belong to the old PR).
   if (filesError && (!files || loadedKey !== viewKey)) {
     return (
       <BackendErrorView
@@ -285,12 +285,12 @@ export function DiffView({
 
   return (
     <div className="diff-view">
-      {/* 切 PR 加载遮罩：盖住旧树/内容，新数据 ready（loadedKey 推进）后自动消失整体换新。
-          PaneLoading 默认 delayMs=150：命中缓存的快切换遮罩不出现、直接换新（零闪）。 */}
+      {/* PR-switch loading overlay: covers the old tree/content, disappears automatically and swaps in the new one once the new data is ready (loadedKey advances).
+          PaneLoading defaults to delayMs=150: cache-hit fast switches don't show the overlay and swap directly (zero flash). */}
       {switching && <PaneLoading overlay label={t('mainPane.loadingEditor')} />}
       <aside className="diff-file-list" style={{ width: `${String(fileListWidth)}px` }}>
-        {/* header 一直显示。tree 模式右侧是"搜索"图标 (进搜索)；search 模式
-            换"文件树"图标 (明示这是回到文件树的入口) */}
+        {/* header is always shown. In tree mode the right side is the "search" icon (enter search); in search mode
+            it becomes the "file tree" icon (making clear this is the entry back to the file tree) */}
         <div className="diff-file-list-header">
           {sidebarMode === 'search' ? (
             <span>{t('diffView.searchChanges')}</span>
@@ -336,7 +336,7 @@ export function DiffView({
             prLocalId={pr.localId}
             onJumpToMatch={(f, line, side) => {
               setSelectedKey(fileKey(f));
-              // 复用现有 pendingScroll 机制定位行 — 不带 draftId 仅 navigate
+              // Reuse the existing pendingScroll mechanism to locate the line — no draftId, navigate only
               setPendingScroll({ line, side });
             }}
             onExit={() => setSidebarMode('tree')}

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DraftZoneList.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/DraftZoneList.tsx
@@ -5,10 +5,10 @@ import { formatBackendError } from '../../../../../errors';
 import { DraftZone } from '../drafts/DraftZone';
 
 /**
- * 同行多条草稿的容器；每条独立 DraftZone (read/edit 各自维护)，组件间用 hr 分隔。
- * onSave / onDelete 在这里调 IPC drafts:update / drafts:delete；写盘后 main 端
- * 广播 drafts:changed 事件 → drafts-store 重拉 → DiffView 顶层 useEffect 重建
- * zones (此组件随之 unmount/remount)。
+ * Container for multiple drafts on the same line; each is an independent DraftZone (maintaining its own read/edit), separated by hr.
+ * onSave / onDelete call IPC drafts:update / drafts:delete here; after writing to disk the main side
+ * broadcasts a drafts:changed event → drafts-store refetches → DiffView's top-level useEffect rebuilds the
+ * zones (this component unmounts/remounts along with it).
  */
 export function DraftZoneList({
   drafts,
@@ -21,7 +21,7 @@ export function DraftZoneList({
   prLocalId: string;
   registerEditTrigger: (draftId: string, fn: (() => void) | null) => void;
   hardBreaks: boolean;
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；透传给草稿编辑框启用粘贴 / 选取上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); passed through to the draft editor to enable paste / pick upload. */
   attachmentsEnabled?: boolean;
 }) {
   const { t } = useTranslation();
@@ -35,10 +35,10 @@ export function DraftZoneList({
   const onDelete = async (draftId: string): Promise<void> => {
     await invoke('drafts:delete', { localId: prLocalId, draftId });
   };
-  // 单条发布：复用 drafts:publishBatch handler，传 [draftId] 单元素。这样跟
-  // PublishReviewModal 的批量路径共用同一份 main 端逻辑 (anchor 映射 / posted
-  // 回写 / force-refresh 评论 / 失败收集都一致)，行为可预测，未来改任一处不会
-  // 让两条路径分叉
+  // Single publish: reuse the drafts:publishBatch handler, passing a single-element [draftId]. This shares the same
+  // main-side logic with PublishReviewModal's batch path (anchor mapping / posted
+  // write-back / force-refresh comments / failure collection are all consistent), keeping behavior predictable so a future
+  // change to either doesn't fork the two paths
   const onPublish = async (draftId: string): Promise<{ ok: boolean; error?: string }> => {
     const resp = await invoke('drafts:publishBatch', {
       localId: prLocalId,
@@ -46,7 +46,7 @@ export function DraftZoneList({
     });
     const r = resp.results[0];
     if (!r) return { ok: false, error: t('diffView.noResultFromMain') };
-    // r.error 是 AppError 编码串（草稿域 EPR* / 发布异常），在此解码为本地化文案再上交展示。
+    // r.error is an AppError encoded string (draft-domain EPR* / publish exception), decoded here into localized text before being handed up for display.
     return { ok: r.ok, error: r.error ? formatBackendError(r.error).title : undefined };
   };
   return (

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/FileTree.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/FileTree.tsx
@@ -8,11 +8,11 @@ import { ChevronIcon, ConflictIcon } from '../../../../common';
 interface FileTreeProps {
   files: DiffChangedFile[];
   selectedKey: string | null;
-  /** path → 远端已发布的 inline 评论数 (含 renamed 文件的 oldPath 兼容) */
+  /** path → number of published remote inline comments (with renamed-file oldPath compatibility) */
   commentCountByPath: Map<string, number>;
-  /** path → 本地待发布草稿数 (pending + edited)。跟 PR header "提交评审 (N)" 同口径 */
+  /** path → number of local unpublished drafts (pending + edited). Same measure as the PR header "Submit review (N)" */
   draftCountByPath: Map<string, number>;
-  /** 合并会冲突的文件路径集合：命中的文件行在状态点左侧标三角警示图标。 */
+  /** Set of file paths that would conflict on merge: matched file rows show a triangle warning icon to the left of the status dot. */
   conflictPaths: Set<string>;
   onSelect: (file: DiffChangedFile) => void;
 }
@@ -31,7 +31,7 @@ interface TreeFolder {
   name: string;
   path: string;
   children: TreeNode[];
-  /** 聚合自所有后代文件的状态，用于给 folder name 着色 */
+  /** Status aggregated from all descendant files, used to color the folder name */
   aggregateStatus: FolderAggregateStatus;
 }
 
@@ -51,7 +51,7 @@ export function FileTree({
 }: FileTreeProps) {
   const { t } = useTranslation();
   const tree = useMemo(() => buildTree(files), [files]);
-  // 默认全部展开。collapsed 记的是被折叠的 path 集合（默认空 = 全展开）
+  // All expanded by default. collapsed records the set of collapsed paths (empty by default = all expanded)
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const toggle = (path: string): void => {
@@ -65,9 +65,9 @@ export function FileTree({
 
   return (
     <div className="diff-file-tree" role="tree">
-      {/* 内层 inline-block: 宽度 = max(max-content, 100%)，让所有 row 撑到同一宽度，
-          否则不同长度的 row 各自 100%-vs-max-content 会让 sticky dots 落在各自行尾，
-          滚动时位置参差不齐 */}
+      {/* Inner inline-block: width = max(max-content, 100%), stretching all rows to the same width,
+          otherwise rows of different lengths each go 100%-vs-max-content, leaving sticky dots at their own row ends,
+          misaligned when scrolling */}
       <div className="diff-file-tree-inner">
         {renderChildren(tree.children, 0, {
           selectedKey,
@@ -160,8 +160,8 @@ function renderChildren(nodes: TreeNode[], depth: number, ctx: RenderCtx): React
           </span>
           <span className="tree-name">{n.name}</span>
           <span className="tree-row-right" aria-hidden="false">
-            {/* draft chip 在前 / comment chip 在后：阅读顺序 "未发的 → 已发的"，
-                跟 PR header "提交评审 → 通过/需修改" 的左右顺序对齐 */}
+            {/* draft chip first / comment chip after: reading order "unpublished → published",
+                aligned with the left-to-right order of the PR header "Submit review → Approve/Needs work" */}
             {draftCount > 0 && (
               <span
                 className="tree-draft-count"
@@ -250,9 +250,9 @@ function sortTree(node: TreeFolder): void {
 }
 
 /**
- * 递归算每个 folder 的聚合状态。
- * 优先级：modified/typechange > 混合 added+deleted > added/renamed/copied > deleted
- * （与 VS Code 文件资源管理器观感对齐：folder 含修改即橙黄，纯新增才绿）
+ * Recursively compute each folder's aggregate status.
+ * Priority: modified/typechange > mixed added+deleted > added/renamed/copied > deleted
+ * (aligned with the VS Code file explorer look: a folder with any modification is amber, only pure additions are green)
  */
 function computeAggregateStatus(node: TreeFolder): FolderAggregateStatus {
   let hasModified = false;
@@ -283,7 +283,7 @@ function fileIconFor(filePath: string): string {
   const base = filePath.split('/').pop()?.toLowerCase() ?? '';
   const withPrefix = (name: string): string => `material-icon-theme:${name}`;
 
-  // 特殊文件名先匹配
+  // Match special file names first
   const byBasename: Record<string, string> = {
     dockerfile: 'docker',
     'docker-compose.yml': 'docker',

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/blame/BlameColumn.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/blame/BlameColumn.tsx
@@ -13,13 +13,14 @@ import {
 } from './blame-utils';
 
 /**
- * Bitbucket 风格 blame 列。独立于 Monaco DOM 之外，作为 diff-pane-wrapper 的左侧
- * flex 子项；内部用 absolute 子项画各 commit 区块，按 Monaco scrollTop 平移。
+ * Bitbucket-style blame column. Lives outside the Monaco DOM, as the left flex
+ * child of diff-pane-wrapper; internally draws each commit block with absolute
+ * children, shifted by Monaco scrollTop.
  *
- * 设计权衡：
- * - 不走 Monaco InjectedText (DiffEditor 里实测不渲染，详见 commit 提交记录)
- * - 不走 Monaco overlay widget (没有"绝对行号"定位选项，只能贴角)
- * - 独立 DOM 列：可控、稳定、跟 React 生命周期一致；唯一成本是要同步 scrollTop
+ * Design trade-offs:
+ * - Not using Monaco InjectedText (verified not rendered inside DiffEditor, see commit history)
+ * - Not using Monaco overlay widget (no "absolute line number" positioning option, can only pin to corners)
+ * - Independent DOM column: controllable, stable, in sync with the React lifecycle; the only cost is syncing scrollTop
  */
 export function BlameColumn({
   blame,
@@ -34,20 +35,21 @@ export function BlameColumn({
 }) {
   const { t } = useTranslation();
   const blocks = useMemo(() => groupBlameByCommit(blame.lines), [blame.lines]);
-  // 把 changedLines 合并成连续区段，渲染色带（减少 DOM 数量）
+  // Merge changedLines into contiguous ranges to render color bands (reduces DOM count)
   const changedRanges = useMemo(
     () => mergeContiguousLines(blame.changedLines),
     [blame.changedLines],
   );
   const modifiedEditor = diffEditor.getModifiedEditor();
-  // layout 只是触发器：scrollTop / viewportHeight 任一变就重渲，重渲时再走 Monaco
-  // 实时坐标 API，避免行数学手算和 Monaco 实际渲染的偏差（padding / view zones /
-  // hideUnchangedRegions 占位 / sticky scroll 全靠 Monaco 自己算）
-  // 注意：layout 也被上面 style 的 --blame-lh 引用
+  // layout is only a trigger: any change to scrollTop / viewportHeight re-renders, and on re-render
+  // we go through Monaco's live coordinate API, avoiding manual line math and its divergence from
+  // Monaco's actual rendering (padding / view zones / hideUnchangedRegions placeholders / sticky
+  // scroll are all computed by Monaco itself)
+  // Note: layout is also referenced by --blame-lh in the style above
 
-  // 只渲染 Monaco 当前可见的行：hideUnchangedRegions 折叠掉的行返回的 range
-  // 里不会出现，自然不画 blame；评论 view zone 撑出的额外高度也由 Monaco 的
-  // getTopForLineNumber 反映
+  // Only render lines currently visible in Monaco: lines folded away by hideUnchangedRegions
+  // won't appear in the returned range, so no blame is drawn for them; the extra height pushed
+  // out by comment view zones is also reflected by Monaco's getTopForLineNumber
   const visibleRanges = modifiedEditor.getVisibleRanges();
   const scrollTop = modifiedEditor.getScrollTop();
 
@@ -68,7 +70,7 @@ export function BlameColumn({
   type Item = BlameItem | ChangeItem | FoldItem;
   const items: Item[] = [];
 
-  // 1) Blame 区块：跟 visible range 求交集
+  // 1) Blame blocks: intersect with visible range
   for (const range of visibleRanges) {
     for (const block of blocks) {
       const from = Math.max(block.lineFrom, range.startLineNumber);
@@ -86,8 +88,8 @@ export function BlameColumn({
     }
   }
 
-  // 2) PR 改动行色带：在可见 range 内的部分画绿色竖条占位（不带文字，跟 Monaco
-  //    diff 的"added"装饰呼应）
+  // 2) PR changed-line color band: draw a green vertical bar placeholder for the part within the
+  //    visible range (no text, echoing Monaco diff's "added" decoration)
   for (const range of visibleRanges) {
     for (const [from0, to0] of changedRanges) {
       const from = Math.max(from0, range.startLineNumber);
@@ -104,14 +106,14 @@ export function BlameColumn({
     }
   }
 
-  // 3) 折叠占位行（"X hidden lines"）：相邻两个 visibleRange 之间一行的位置，
-  //    用斜纹/灰底标识"无效行"——这一行不对应 head 文件里任何 line，blame
-  //    自然没有。
+  // 3) Fold placeholder line ("X hidden lines"): the position of the one line between two adjacent
+  //    visibleRanges, marked with hatching/gray background as an "invalid line"—this line does not
+  //    correspond to any line in the head file, so naturally has no blame.
   for (let i = 0; i < visibleRanges.length - 1; i++) {
     const cur = visibleRanges[i]!;
     const next = visibleRanges[i + 1]!;
     if (next.startLineNumber - cur.endLineNumber <= 1) continue;
-    // 占位行在 cur 的最后一行底部与 next 第一行顶部之间
+    // The placeholder line sits between the bottom of cur's last line and the top of next's first line
     const yTop = modifiedEditor.getTopForLineNumber(cur.endLineNumber + 1) - scrollTop;
     const yBottom = modifiedEditor.getTopForLineNumber(next.startLineNumber) - scrollTop;
     if (yBottom <= yTop) continue;
@@ -126,8 +128,8 @@ export function BlameColumn({
   return (
     <aside
       className="blame-column"
-      // --blame-lh = Monaco 的实际行高，让 blame-row 的 grid 行轨道 / line-height
-      // 都用同一个值，垂直跟 Monaco 第一行代码同高、同 baseline
+      // --blame-lh = Monaco's actual line height, so blame-row's grid row track / line-height
+      // both use the same value, vertically matching Monaco's first code line in height and baseline
       style={
         {
           width: BLAME_COLUMN_WIDTH,
@@ -186,8 +188,8 @@ function BlameRow({
   height: number;
   connectionId: string;
 }) {
-  // 用 ISO 风格 YYYY-MM-DD：locale 无关、固定 10 字符，在 70px 列宽稳定显示。
-  // toLocaleDateString 的中文输出 "2023年3月29日" 太宽会被截断。
+  // Use ISO-style YYYY-MM-DD: locale-independent, fixed 10 characters, displays stably in the 70px column width.
+  // toLocaleDateString's Chinese output "2023年3月29日" is too wide and would be truncated.
   const dateStr = block.authorDate ? formatIsoDate(new Date(block.authorDate)) : '';
   const title = `${block.author}\n${block.commit.slice(0, 12)}\n${block.summary}\n${
     block.authorDate ? new Date(block.authorDate).toLocaleString() : ''

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/blame/blame-utils.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/blame/blame-utils.ts
@@ -1,14 +1,14 @@
 import type { DiffBlameLine } from '@meebox/ipc';
 
-/** Bitbucket 风格 blame 列宽：头像(20) + name(80) + sha(75) + date(45) + padding */
+/** Bitbucket-style blame column width: avatar(20) + name(80) + sha(75) + date(45) + padding */
 export const BLAME_COLUMN_WIDTH = 240;
 
 export interface BlameLayout {
-  /** Monaco modified editor 可视高度 (px) */
+  /** Monaco modified editor visible height (px) */
   viewportHeight: number;
-  /** Monaco 当前行高 (px) */
+  /** Monaco current line height (px) */
   lineHeight: number;
-  /** Monaco 当前垂直滚动 (px) */
+  /** Monaco current vertical scroll (px) */
   scrollTop: number;
 }
 
@@ -27,7 +27,7 @@ export function formatIsoDate(d: Date): string {
   return `${String(d.getFullYear())}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
-/** 把行号列表合并为连续区段 [from, to]，便于画色带（减少 DOM 节点） */
+/** Merge a list of line numbers into contiguous ranges [from, to] to ease drawing color bands (reduces DOM nodes) */
 export function mergeContiguousLines(lines: number[]): Array<[number, number]> {
   if (lines.length === 0) return [];
   const sorted = [...lines].sort((a, b) => a - b);
@@ -48,7 +48,7 @@ export function mergeContiguousLines(lines: number[]): Array<[number, number]> {
   return out;
 }
 
-/** 合并连续同 commit 的 blame 行为区块（Bitbucket 风格：一个 commit 一格） */
+/** Merge contiguous blame lines of the same commit into blocks (Bitbucket-style: one cell per commit) */
 export function groupBlameByCommit(blame: DiffBlameLine[]): BlameBlock[] {
   const sorted = [...blame].sort((a, b) => a.line - b.line);
   const blocks: BlameBlock[] = [];

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/diff-types.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/diff-types.ts
@@ -1,8 +1,8 @@
 import type { DiffChangedFile, DiffFileContent } from '@meebox/ipc';
 
 /**
- * diff 变更范围：'all' = PR 全部变更（merge-base..head）；'commit' = 单个 commit 的 parent..sha。
- * commit 视图为只读 diff（行内评论 / 草稿锚定在 PR 全量 diff 行号上，不套用于单 commit 版本）。
+ * diff change scope: 'all' = all PR changes (merge-base..head); 'commit' = a single commit's parent..sha.
+ * commit view is a read-only diff (inline comments / drafts are anchored to the full-PR diff line numbers, not applied to the single-commit version).
  */
 export type DiffScope =
   | { kind: 'all' }
@@ -19,7 +19,7 @@ export interface LoadedContent {
   head: DiffFileContent;
 }
 
-/** 「查看特定 commit」请求载荷（parent 来自 PrCommit.parents[0]，root commit 无 parent 为 null）。 */
+/** "View specific commit" request payload (parent comes from PrCommit.parents[0]; a root commit has no parent, so null). */
 export interface PendingCommitView {
   sha: string;
   parent: string | null;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/index.ts
@@ -1,5 +1,5 @@
-// diff 业务 hooks 的 barrel：数据流（变更文件 / 内容 / 评论 / blame / 范围 / 跳转）与
-// 行内 view-zone 装配（评论 / 草稿 / hover「+」新建草稿）各自成 hook，由 DiffView 组合根聚合。
+// Barrel for diff business hooks: data flow (changed files / content / comments / blame / scope / navigation) and
+// inline view-zone assembly (comments / drafts / hover "+" to create a draft) are each their own hook, aggregated by the DiffView composition root.
 export { useFileListWidth } from './useFileListWidth';
 export { useSyncProgress } from './useSyncProgress';
 export { useDiffScope, type DiffScopeState } from './useDiffScope';

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useBlame.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useBlame.ts
@@ -15,9 +15,9 @@ export interface BlameState {
 }
 
 /**
- * blame 数据 + Monaco 视图坐标同步。仅在开关开 + 文件有 head 内容时拉；deleted / 二进制不拉。
- * blameLayout 从 Monaco modified editor 同步 lineHeight / scrollTop / viewportHeight，供独立
- * React blame 列定位（见 BlameColumn）。
+ * blame data + Monaco view coordinate sync. Only fetched when the toggle is on + the file has head content; deleted / binary are not fetched.
+ * blameLayout syncs lineHeight / scrollTop / viewportHeight from the Monaco modified editor, for positioning the independent
+ * React blame column (see BlameColumn).
  */
 export function useBlame(
   pr: StoredPullRequest,
@@ -34,13 +34,13 @@ export function useBlame(
     changedLines: number[];
   } | null>(null);
   const [blameError, setBlameError] = useState<FormattedError | null>(null);
-  // Monaco modified editor 的视图坐标 (用于 React overlay 渲染 blame 列)；
-  // null = blame 关 / blame 数据没好 / editor 未挂载
+  // View coordinates of the Monaco modified editor (used by the React overlay to render the blame column);
+  // null = blame off / blame data not ready / editor not mounted
   const [blameLayout, setBlameLayout] = useState<BlameLayout | null>(null);
 
-  // 拉 blame：仅在开关开 + 文件有 head 内容时跑。deleted 文件 / 二进制不跑。
+  // Fetch blame: only runs when the toggle is on + the file has head content. deleted files / binary do not run.
   useEffect(() => {
-    // 门控：切视图期间不拉 blame（同 content：避免新视图 + 旧文件错拉），保留旧 blame。
+    // Gate: don't fetch blame while switching views (same as content: avoids mis-fetching new view + old file), keep old blame.
     if (loadedKey !== viewKey) return;
     if (!showBlame || !selected || !content || content.head.binary) {
       setBlame(null);
@@ -70,9 +70,9 @@ export function useBlame(
     };
   }, [showBlame, selected, content, pr.localId, loadedKey, viewKey, range]);
 
-  // Blame 走独立 React 列（Bitbucket 风格），不在 Monaco DOM 里。只需要从 Monaco
-  // 同步 lineHeight / scrollTop / viewportHeight，BlameColumn 自己用 absolute
-  // 子项画 row 并按 scrollTop 平移。
+  // Blame uses an independent React column (Bitbucket-style), not inside the Monaco DOM. It only needs to
+  // sync lineHeight / scrollTop / viewportHeight from Monaco; BlameColumn draws rows with its own absolute
+  // children and shifts them by scrollTop.
   useEffect(() => {
     if (!diffEditor || !showBlame || !blame || blame.lines.length === 0) {
       setBlameLayout(null);
@@ -91,7 +91,7 @@ export function useBlame(
       });
     };
     update();
-    // 初次 mount 时 layout 可能还在计算，下一 tick 再算一次
+    // On initial mount layout may still be computing, so recompute once on the next tick
     const t = setTimeout(update, 0);
     const subs = [
       modifiedEditor.onDidScrollChange(update),

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useChangedFiles.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useChangedFiles.ts
@@ -12,13 +12,13 @@ export interface ChangedFilesState {
   selectedKey: string | null;
   setSelectedKey: React.Dispatch<React.SetStateAction<string | null>>;
   selected: DiffChangedFile | null;
-  /** 已渲染视图标识：新 files 到位才推进到当前 viewKey，在此之前各 effect 门控、旧视图保活。 */
+  /** Rendered view identifier: only advances to the current viewKey once new files land; before that each effect is gated and the old view is kept alive. */
   loadedKey: string | null;
 }
 
 /**
- * 拉变更文件列表 + 选中文件管理。切 PR / 切范围期间保留旧 files 渲染（stale-while-loading），
- * 新 files 到位才把 loadedKey 推进到 viewKey、整体替换。
+ * Fetch changed files list + selected file management. Keeps rendering old files while switching PR / scope (stale-while-loading),
+ * only advancing loadedKey to viewKey and replacing wholesale once new files land.
  */
 export function useChangedFiles(
   pr: StoredPullRequest,
@@ -31,7 +31,7 @@ export function useChangedFiles(
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [filesRetry, setFilesRetry] = useState(0);
 
-  // 拉变更文件列表 (fatal 失败 → 整个 diff 区域 fallback)
+  // Fetch changed files list (fatal failure → fallback for the entire diff area)
   useEffect(() => {
     let cancelled = false;
     setFilesError(null);
@@ -39,9 +39,9 @@ export function useChangedFiles(
       .then((f) => {
         if (cancelled) return;
         setFiles(f);
-        // 新 files 到位才把「已渲染视图」推进到当前 viewKey —— 在此之前各 effect 门控、旧视图保活。
+        // Only advance the "rendered view" to the current viewKey once new files land — before that each effect is gated and the old view is kept alive.
         setLoadedKey(viewKey);
-        // 选中项：仍存在则保留（同视图重试 / 切范围后同名文件仍在则不丢选中），否则回落首个。
+        // Selection: keep it if still present (same-view retry / same-named file still there after scope switch keeps selection), otherwise fall back to the first.
         setSelectedKey((prev) =>
           prev && f.some((x) => fileKey(x) === prev) ? prev : f.length > 0 ? fileKey(f[0]!) : null,
         );

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useCommentZones.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useCommentZones.tsx
@@ -11,8 +11,9 @@ import { mountInlineZones } from '../zones/mountInlineZones';
 import type { LoadedContent } from '../diff-types';
 
 /**
- * 行内评论标记：评论锚定行 glyph margin 蓝点（hover 出 markdown 摘要）+ 行下方插 view zone 渲染
- * 评论内容。zone 挂载 / 清理走通用 mountInlineZones；glyph decorations 由本 hook 自管。
+ * Inline comment markers: a blue dot in the glyph margin on the comment's anchored line (hover shows a
+ * markdown summary) + a view zone inserted below the line rendering the comment content. Zone mount /
+ * cleanup goes through the shared mountInlineZones; glyph decorations are managed by this hook itself.
  */
 export function useCommentZones(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
@@ -25,11 +26,11 @@ export function useCommentZones(opts: {
   prWebUrl: string;
   renderSideBySide: boolean;
   commentHardBreaks: boolean;
-  /** 评论 emoji 反应模式（capabilities.commentReactions）：'fixed'/'free' 才渲染加反应按钮；缺省 = 不支持。 */
+  /** Comment emoji reaction mode (capabilities.commentReactions): only 'fixed'/'free' render the add-reaction button; absent = unsupported. */
   reactionsMode?: 'fixed' | 'free';
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；透传给行内回复编辑框启用粘贴上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); passed through to the inline reply editor to enable paste upload. */
   attachmentsEnabled?: boolean;
-  /** 内容只读（decline / 不可参与归档 PR）：行内评论 zone 隐藏回复 / 编辑 / 删除。 */
+  /** Content read-only (declined / non-participatable archived PR): inline comment zones hide reply / edit / delete. */
   readOnly?: boolean;
 }): void {
   const {
@@ -76,8 +77,8 @@ export function useCommentZones(opts: {
           glyphMarginClassName: 'monaco-comment-glyph',
           glyphMarginHoverMessage: { value: renderHoverMd(cs) },
           linesDecorationsClassName: 'monaco-comment-line-deco',
-          // 评论锚点行在滚动条总览标尺投一个蓝色刻度（与评论 glyph 同色系），
-          // 用户拖滚动条一眼可见「哪里有评论」；minimap 仍关闭。
+          // The comment anchor line projects a blue tick on the scrollbar overview ruler (same color family as
+          // the comment glyph), so users see "where the comments are" at a glance when dragging; minimap stays off.
           overviewRuler: {
             color: '#3794ff',
             position: MonacoEditorNs.OverviewRulerLane.Right,
@@ -101,8 +102,8 @@ export function useCommentZones(opts: {
       newByLine,
       zoneClassName: 'monaco-comment-zone',
       innerClassName: 'monaco-comment-zone-inner',
-      // 不拦 wheel —— 评论区 auto-size 无内部滚动，滚轮要冒泡给 Monaco 滚编辑器，
-      // 否则鼠标停在评论上时整个 diff 无法滚动（stopPropagation 会吃掉滚动）。
+      // Don't intercept wheel — comment zones auto-size with no inner scroll, so the wheel must bubble to Monaco to
+      // scroll the editor, otherwise the whole diff can't scroll while hovering a comment (stopPropagation would eat the scroll).
       stopEvents: ['mousedown', 'mouseup', 'click', 'dblclick'],
       initialHeight: (cs, lineHeight) =>
         Math.max(estimateZoneHeight(cs) * lineHeight, lineHeight * 3),
@@ -126,7 +127,7 @@ export function useCommentZones(opts: {
         originalDecorations.clear();
         modifiedDecorations.clear();
       } catch {
-        // editor 已 dispose
+        // editor already disposed
       }
       cleanupZones();
     };

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useConflictFiles.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useConflictFiles.ts
@@ -3,8 +3,9 @@ import type { StoredPullRequest } from '@meebox/shared';
 import { invoke } from '../../../../../../api';
 
 /**
- * 拉「合并会冲突的文件」路径集合，供文件树标三角警示。仅当远端判定 PR 有冲突（pr.hasConflict）时才打
- * 后端（后端再跑本地 merge-tree 试合并）；无冲突直接给空集。失败保守返回空集（不标记，不报错）。
+ * Fetch the set of paths for "files that will conflict on merge", for the file tree to mark with a warning
+ * triangle. Only hits the backend when the remote deems the PR conflicted (pr.hasConflict) (the backend then
+ * runs a local merge-tree trial merge); no conflict returns an empty set directly. On failure conservatively returns an empty set (no marking, no error).
  */
 export function useConflictFiles(pr: StoredPullRequest): Set<string> {
   const [paths, setPaths] = useState<Set<string>>(() => new Set());

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffComments.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffComments.ts
@@ -11,8 +11,8 @@ export interface DiffCommentsState {
 }
 
 /**
- * 拉 PR 评论（inline + summary）。打开 / 范围切换后强制远端拉一次；订阅 comments:changed 重拉。
- * commit 只读视图不展示行内评论（锚定在 PR 全量 diff 行号上，套到单 commit 会错位）。
+ * Fetch PR comments (inline + summary). Force a remote fetch once after open / scope switch; subscribe to comments:changed to refetch.
+ * The commit read-only view doesn't show inline comments (they anchor to the PR full-diff line numbers, so applying them to a single commit misaligns).
  */
 export function useDiffComments(
   pr: StoredPullRequest,
@@ -25,9 +25,9 @@ export function useDiffComments(
   const [commentsRetry, setCommentsRetry] = useState(0);
 
   useEffect(() => {
-    // 门控：切 PR 期间（新 files 未到）不拉新评论，保留旧评论与旧内容一致渲染，避免 view zone 错位。
+    // Gate: during PR switch (new files not yet arrived) don't fetch new comments, keep old comments rendering consistent with old content, avoid view zone misalignment.
     if (loadedKey !== viewKey) return;
-    // commit 只读视图：行内评论锚定在 PR 全量 diff 行号上，套到单 commit 版本会错位，故不展示。
+    // commit read-only view: inline comments anchor to the PR full-diff line numbers, applying them to a single commit version misaligns, so don't show.
     if (scopeKind !== 'all') {
       setComments([]);
       return;
@@ -48,8 +48,8 @@ export function useDiffComments(
         });
     };
     fetchList(true);
-    // 评论 reply / 状态变更后 main 端 broadcast comments:changed，inline view zone
-    // 需要重拉刷新评论树 (含新 reply 嵌到父评论 .replies)
+    // After a comment reply / status change the main process broadcasts comments:changed, the inline view zone
+    // needs to refetch to refresh the comment tree (including new replies nested into the parent comment's .replies)
     const unsub = subscribe('comments:changed', (e) => {
       if (e.localId === pr.localId) fetchList(true);
     });

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffNav.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffNav.ts
@@ -17,9 +17,9 @@ export interface PendingNav {
 }
 
 /**
- * 跳转消费：来自 ChatPane → App.pendingDiffNav。设 selectedKey 切到目标文件 + 找关联草稿，
- * 再由 reveal 副作用等 selected / diffEditor / drafts 就绪后 revealLine + 短暂高亮 + autoEdit。
- * 同时把 pendingScroll 暴露给跨文件搜索跳转（DiffSearchPanel）复用。
+ * Navigation consumption: from ChatPane → App.pendingDiffNav. Set selectedKey to switch to the target file + find the associated draft,
+ * then the reveal side effect waits for selected / diffEditor / drafts to be ready before revealLine + brief highlight + autoEdit.
+ * Also exposes pendingScroll for cross-file search navigation (DiffSearchPanel) to reuse.
  */
 export function useDiffNav(opts: {
   files: DiffChangedFile[] | null;
@@ -56,9 +56,9 @@ export function useDiffNav(opts: {
     if (target) {
       setSelectedKey(fileKey(target));
     }
-    // 查现有草稿；ChatPane 端已经懒创建过了，正常情况能找到。
-    // 没传 runId/findingId (PublishReviewModal anchor 点击场景) → 直接跳过查找，
-    // draftId 留 undefined → 下游 effect 不会触发 autoEdit，纯 navigate
+    // Look up the existing draft; ChatPane has already lazily created it, so normally it's found.
+    // No runId/findingId passed (PublishReviewModal anchor click scenario) → skip the lookup directly,
+    // draftId stays undefined → downstream effect won't trigger autoEdit, pure navigate
     const matchingDraft =
       pendingNav.runId && pendingNav.findingId
         ? (drafts ?? []).find(
@@ -69,19 +69,19 @@ export function useDiffNav(opts: {
           )
         : undefined;
     setPendingScroll({
-      // 取 endLine 跟草稿 zone / 发布锚点对齐（见 zone 行号注释），高亮行与草稿区同位
+      // Take endLine to align with the draft zone / publish anchor (see zone line number comment), so the highlight line matches the draft zone
       line: pendingNav.anchor.endLine,
       side: 'new',
       draftId: matchingDraft?.id,
     });
     onNavConsumed?.();
-    // drafts 不放 dep —— nav 进来时已 ack；后续 drafts 变化不该重复触发本逻辑
+    // drafts not in deps — already acked when nav arrives; later drafts changes shouldn't retrigger this logic
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingNav, files, onNavConsumed]);
 
-  // nav 完成消费：scroll + highlight + autoEdit 关联草稿。等 selected 文件
-  // 切换 + content 加载 + diffEditor 就绪 + drafts hydrated 完，再 revealLine。
-  // pendingScroll 来自 nav effect (setSelectedKey 同时设的)；reveal 后清空
+  // nav consumption complete: scroll + highlight + autoEdit the associated draft. Wait for the selected file
+  // switch + content load + diffEditor ready + drafts hydrated, then revealLine.
+  // pendingScroll comes from the nav effect (set alongside setSelectedKey); cleared after reveal
   useEffect(() => {
     if (!pendingScroll || !diffEditor || !content || !selected) return;
     const editor =
@@ -92,12 +92,12 @@ export function useDiffNav(opts: {
     let highlightTimer: ReturnType<typeof setTimeout> | undefined;
     let revealed = false;
     const reveal = () => {
-      // onDidUpdateDiff 可能多次触发，只跳一次
+      // onDidUpdateDiff may fire multiple times, only jump once
       if (revealed) return;
       revealed = true;
-      // 居中滚到目标行
+      // Center-scroll to the target line
       editor.revealLineInCenter(pendingScroll.line);
-      // 短暂高亮：300ms 黄底脉冲
+      // Brief highlight: 300ms yellow-background pulse
       const collection = editor.createDecorationsCollection([
         {
           range: {
@@ -119,17 +119,17 @@ export function useDiffNav(opts: {
           /* editor disposed */
         }
       }, 800);
-      // 同时触发关联草稿的 autoEdit (DraftZone 自动 enter edit mode)
+      // Also trigger autoEdit for the associated draft (DraftZone auto-enters edit mode)
       if (pendingScroll.draftId) {
         triggerAutoEdit(pendingScroll.draftId);
       }
       setPendingScroll(null);
     };
 
-    // Monaco diff 是异步算的：models 挂上(onMount)后还要等 diff 计算 +
-    // hideUnchangedRegions 折叠布局完成，行号到视口位置的映射才稳定。此时
-    // 直接 revealLine 会定位到旧布局/错误位置。getLineChanges() 在算完前
-    // 返回 null、算完返回数组 → 已就绪直接跳，否则等 onDidUpdateDiff 首次触发。
+    // Monaco diff is computed asynchronously: after models mount (onMount) it still waits for diff computation +
+    // hideUnchangedRegions collapse layout to complete before the line-number-to-viewport-position mapping is stable. At this point
+    // revealLine directly would locate to the old layout / wrong position. getLineChanges() returns null before
+    // computation finishes, returns an array after → already ready jump directly, otherwise wait for onDidUpdateDiff to first fire.
     if (diffEditor.getLineChanges() != null) {
       reveal();
       return () => {
@@ -141,7 +141,7 @@ export function useDiffNav(opts: {
       disposable.dispose();
       if (highlightTimer) clearTimeout(highlightTimer);
     };
-    // triggerAutoEdit 不入 deps —— 它每次 render 换新引用，列进去会让 reveal 每帧重跑、反复定位高亮
+    // triggerAutoEdit not in deps — it changes reference every render, including it would make reveal rerun every frame, repeatedly locating/highlighting
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingScroll, diffEditor, content, selected]);
 

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffOverviewMarks.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffOverviewMarks.ts
@@ -3,26 +3,26 @@ import { editor as MonacoEditorNs, type editor as MonacoEditor } from 'monaco-ed
 import type { DiffChangedFile } from '@meebox/ipc';
 import type { LoadedContent } from '../diff-types';
 
-// 增/改绿、删红（与 GitHub diff 配色同系）。diff 标记走 overview ruler 的 Left 道，
-// 跟评论锚点（Right 道，见 useCommentZones）分列，互不遮挡。
+// Add/change green, delete red (same color family as GitHub diff). diff marks go on the overview ruler's Left lane,
+// separate from comment anchors (Right lane, see useCommentZones), so they don't overlap.
 const ADDED_COLOR = '#3fb950';
 const REMOVED_COLOR = '#f85149';
 
 /**
- * 把 diff 增/删/改投影到内层编辑器自带的 overview ruler（编辑模式风格，单条滚动条标尺），
- * 替代 diff 专属的 renderOverviewRuler 宽列（那条在并排视图会多出独立列，见 DiffPane）。
+ * Project diff add/delete/change onto the inner editor's built-in overview ruler (edit-mode style, single scrollbar ruler),
+ * replacing the diff-specific renderOverviewRuler wide column (that one adds a separate column in side-by-side view, see DiffPane).
  *
- * - modified 编辑器：增 / 改行绿色；纯删在删除点打一条红 tick
- * - 并排视图下 original 编辑器：删 / 改行红色
+ * - modified editor: add / change lines green; pure delete draws a red tick at the delete point
+ * - original editor under side-by-side view: delete / change lines red
  *
- * 注意：`renderSideBySide` 是用户在工具栏选的「并排 / 统一」**意向**，而 Monaco 在宽度不足时会
- * 自动把并排降级成 inline/unified 布局（useInlineViewWhenSpaceIsLimited 默认开），此时意向仍为
- * 并排但实际渲染是统一。若按意向把删除红标画到 original 编辑器，降级后 original 不可见 → 红标全丢、
- * 滚动条只剩绿色。故按 **实际渲染模式** 决定红标去向：Monaco 把实际模式反映在 `.monaco-diff-editor`
- * 根节点的 `side-by-side` class 上（降级 inline 时去掉），据此判定，而非用户意向 prop。
+ * Note: `renderSideBySide` is the user's toolbar-selected "side-by-side / unified" **intent**, while Monaco, when width is insufficient, will
+ * automatically downgrade side-by-side to inline/unified layout (useInlineViewWhenSpaceIsLimited on by default), where the intent is still
+ * side-by-side but the actual rendering is unified. If we draw the delete red mark to the original editor by intent, after downgrade original is invisible → red marks all lost,
+ * scrollbar left with green only. So decide red-mark placement by the **actual render mode**: Monaco reflects the actual mode in the `.monaco-diff-editor`
+ * root node's `side-by-side` class (removed when downgrading to inline), judge by that rather than the user intent prop.
  *
- * diff 异步算完后 getLineChanges() 才有值；首帧已算完直接刷，否则等 onDidUpdateDiff。布局在断点处
- * 切换并排 ↔ 统一时（onDidLayoutChange）按新模式重画红标（rAF 合并、待 class 切换稳定后再读）。
+ * getLineChanges() only has a value after the async diff finishes; if the first frame already finished refresh directly, otherwise wait for onDidUpdateDiff. When the layout
+ * switches side-by-side ↔ unified at a breakpoint (onDidLayoutChange) redraw red marks by the new mode (rAF-coalesced, read after the class switch stabilizes).
  */
 export function useDiffOverviewMarks(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
@@ -38,8 +38,8 @@ export function useDiffOverviewMarks(opts: {
     const modCol = modifiedEditor.createDecorationsCollection([]);
     const origCol = originalEditor.createDecorationsCollection([]);
 
-    // 实际是否并排：读 Monaco 反映实际渲染模式的 `.monaco-diff-editor.side-by-side` class
-    // （宽度不足自动降级 inline 时去掉该 class）；取不到时回退用户意向 prop。
+    // Whether actually side-by-side: read Monaco's `.monaco-diff-editor.side-by-side` class that reflects the actual render mode
+    // (the class is removed when auto-downgrading to inline on insufficient width); fall back to the user intent prop when unavailable.
     const isSideBySide = (): boolean => {
       if (!renderSideBySide) return false;
       const el = diffEditor.getContainerDomNode().querySelector('.monaco-diff-editor');
@@ -63,25 +63,25 @@ export function useDiffOverviewMarks(opts: {
       const modDecos: MonacoEditor.IModelDeltaDecoration[] = [];
       const origDecos: MonacoEditor.IModelDeltaDecoration[] = [];
       for (const c of changes) {
-        const isInsert = c.originalEndLineNumber === 0; // 纯增（原始侧无行）
-        const isDelete = c.modifiedEndLineNumber === 0; // 纯删（修改侧无行）
-        // 增 / 改：modified 侧 modifiedStart..End 标绿（左道）
+        const isInsert = c.originalEndLineNumber === 0; // pure add (no line on original side)
+        const isDelete = c.modifiedEndLineNumber === 0; // pure delete (no line on modified side)
+        // add / change: modified side modifiedStart..End marked green (Left lane)
         if (!isDelete) {
           modDecos.push(
             deco(c.modifiedStartLineNumber, c.modifiedEndLineNumber, ADDED_COLOR, Lane.Left),
           );
         }
-        // 删 / 改的「移除部分」标红：
+        // mark the "removed part" of delete / change red:
         if (!isInsert) {
           if (sideBySide) {
-            // 并排：红画在左侧 original 编辑器自带 ruler（左道），与右侧绿互不干扰
+            // side-by-side: red drawn on the left original editor's built-in ruler (Left lane), doesn't interfere with the right-side green
             origDecos.push(
               deco(c.originalStartLineNumber, c.originalEndLineNumber, REMOVED_COLOR, Lane.Left),
             );
           } else {
-            // 统一视图（含并排降级而来）：original 编辑器不可见，红 tick 与绿同画在 modified 左道。
-            // 被删行在 unified 下是 view zone（无 model 行号），只能标在删除点 modifiedStartLineNumber；
-            // 改块同一行既绿又红时绿覆盖红 → 改块呈绿、纯删那行（无绿）呈红。
+            // unified view (including downgraded from side-by-side): original editor invisible, red tick and green both drawn on modified Left lane.
+            // Deleted lines under unified are view zones (no model line number), can only be marked at the delete point modifiedStartLineNumber;
+            // when a change block's same line is both green and red, green covers red → change block shows green, pure-delete line (no green) shows red.
             const line = Math.max(1, c.modifiedStartLineNumber);
             modDecos.push(deco(line, line, REMOVED_COLOR, Lane.Left));
           }
@@ -93,8 +93,8 @@ export function useDiffOverviewMarks(opts: {
 
     if (diffEditor.getLineChanges() != null) refresh();
     const disp = diffEditor.onDidUpdateDiff(refresh);
-    // 宽度跨断点导致并排 ↔ 统一切换时，红标去向随之改变 → 重画。layout 事件可能早于 Monaco 切
-    // `side-by-side` class，故用 rAF 推迟到本帧末再读 class；rAF 同时合并 resize 期间的高频事件。
+    // When width crosses a breakpoint causing side-by-side ↔ unified switch, red-mark placement changes accordingly → redraw. The layout event may precede Monaco switching
+    // the `side-by-side` class, so use rAF to defer reading the class to the end of this frame; rAF also coalesces high-frequency events during resize.
     let raf = 0;
     const scheduleRefresh = (): void => {
       if (raf) return;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffScope.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDiffScope.ts
@@ -6,27 +6,27 @@ import type { DiffScope, PendingCommitView } from '../diff-types';
 export interface DiffScopeState {
   scope: DiffScope;
   setScope: (scope: DiffScope) => void;
-  /** 范围下拉用的 commit 列表（懒加载：首次展开下拉才拉） */
+  /** Commit list for the scope dropdown (lazy-loaded: fetched only on first dropdown expand) */
   scopeCommits: PrCommit[] | null;
   loadScopeCommits: () => void;
-  /** 当前视图标识 = PR + 范围。切 PR 或切范围都视为内容换新，驱动 stale-while-loading。 */
+  /** Current view identifier = PR + scope. Switching PR or scope is both treated as content refresh, driving stale-while-loading. */
   viewKey: string;
-  /** commit 视图的 diff 范围（parent..sha）；'all' 或 root commit（无 parent）为 null → 走 PR 默认范围。 */
+  /** commit view's diff range (parent..sha); 'all' or root commit (no parent) is null → uses the PR default range. */
   range: { base: string; head: string } | null;
 }
 
 /**
- * diff 变更范围状态：全部变更 / 单个 commit。含切 PR 复位、消费外部「查看特定 commit」请求、
- * 懒加载范围下拉的 commit 列表。
+ * diff change scope state: all changes / a single commit. Includes PR-switch reset, consuming external "view a specific commit" requests,
+ * and lazy-loading the commit list for the scope dropdown.
  */
 export function useDiffScope(
   pr: StoredPullRequest,
   pendingCommitView: PendingCommitView | null | undefined,
   onCommitViewConsumed: (() => void) | undefined,
 ): DiffScopeState {
-  // 变更范围：全部变更 / 单个 commit。commit 视图为只读 diff（见 DiffScope）。
+  // Change scope: all changes / a single commit. commit view is a read-only diff (see DiffScope).
   const [scope, setScope] = useState<DiffScope>({ kind: 'all' });
-  // 范围下拉用的 commit 列表（懒加载：首次展开下拉才拉）。
+  // Commit list for the scope dropdown (lazy-loaded: fetched only on first dropdown expand).
   const [scopeCommits, setScopeCommits] = useState<PrCommit[] | null>(null);
   const viewKey = useMemo(
     () => (scope.kind === 'all' ? `${pr.localId}|all` : `${pr.localId}|c:${scope.sha}`),
@@ -47,13 +47,13 @@ export function useDiffScope(
     });
   }, [pr.localId]);
 
-  // 切 PR 回到「全部变更」范围，并丢弃旧 PR 的范围下拉 commit 列表
+  // On PR switch return to the "all changes" scope, and discard the old PR's scope-dropdown commit list
   useEffect(() => {
     setScope({ kind: 'all' });
     setScopeCommits(null);
   }, [pr.localId]);
 
-  // 消费外部「查看特定 commit」请求（提交 / 活动标签页点击 commit）→ 切到该 commit 范围。
+  // Consume external "view a specific commit" requests (commit / activity tab clicking a commit) → switch to that commit's scope.
   useEffect(() => {
     if (!pendingCommitView) return;
     setScope({

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDraftAutoEdit.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDraftAutoEdit.ts
@@ -7,19 +7,19 @@ export interface DraftAutoEdit {
 }
 
 /**
- * autoEdit 触发器表：draft.id → "进入编辑模式" fn。供两个来源用：
- *   1. ChatPane → App.pendingDiffNav 跳转完后，目标 draft 自动 enter edit
- *   2. 行 hover '+' 创建 manual draft 后立即 enter edit (新草稿空 body 必须能输入)
+ * autoEdit trigger table: draft.id → "enter edit mode" fn. Used by two sources:
+ *   1. ChatPane → after App.pendingDiffNav navigation completes, the target draft auto-enters edit
+ *   2. after a line hover '+' creates a manual draft, immediately enter edit (a new draft with empty body must be typeable)
  *
- * 用 ref-based fn 而不是 state token。token 方案曾导致 bug：用户取消 → auto save → drafts store
- * 变 → DiffView re-render → DraftZone unmount/mount → 新 instance 看到 props token 仍非 undefined
- * 又 setIsEditing(true) → 用户看似"取消没生效"。ref-fn 调用纯副作用，不引发 re-render。
+ * Uses a ref-based fn rather than a state token. The token approach once caused a bug: user cancels → auto save → drafts store
+ * changes → DiffView re-renders → DraftZone unmount/mount → the new instance sees the props token still non-undefined
+ * and calls setIsEditing(true) again → user perceives "cancel didn't take effect". A ref-fn call is a pure side effect, triggering no re-render.
  */
 export function useDraftAutoEdit(pr: StoredPullRequest): DraftAutoEdit {
   const editTriggerFnsRef = useRef<Map<string, () => void>>(new Map());
-  // pending trigger 兜底：triggerAutoEdit 调用时 DraftZone 还没 mount + register
-  // (典型场景：hover '+' 创建后立即 trigger，drafts store 异步更新)。fn 不在 map
-  // 时把 id 加 pending；registerEditTrigger 时如果发现自己 pending 立即 fire
+  // pending trigger fallback: when triggerAutoEdit is called, the DraftZone has not yet mounted + registered
+  // (typical scenario: trigger immediately after a hover '+' creation, while the drafts store updates asynchronously). When fn is not in the map,
+  // add the id to pending; on registerEditTrigger, if it finds itself pending, fire immediately
   const pendingTriggersRef = useRef<Set<string>>(new Set());
   const registerEditTrigger = useCallback((draftId: string, fn: (() => void) | null): void => {
     if (fn) {
@@ -41,7 +41,7 @@ export function useDraftAutoEdit(pr: StoredPullRequest): DraftAutoEdit {
     }
   };
 
-  // PR 切换清掉所有 trigger fn 引用 + pending (新 PR 的 DraftZone 会重新注册)
+  // PR switch clears all trigger fn references + pending (the new PR's DraftZone will re-register)
   useEffect(() => {
     editTriggerFnsRef.current.clear();
     pendingTriggersRef.current.clear();

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDraftZones.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useDraftZones.tsx
@@ -7,11 +7,11 @@ import { mountInlineZones } from '../zones/mountInlineZones';
 import type { LoadedContent } from '../diff-types';
 
 /**
- * 内联草稿 view zones（蓝底、editable）。跟评论 zone 同套 mountInlineZones 机制，按 anchor.side
- * 分桶、用 endLine 作 zone 行号（跟发布锚点对齐，WYSIWYG）。
+ * Inline draft view zones (blue background, editable). Uses the same mountInlineZones mechanism as comment zones, bucketed by anchor.side,
+ * with endLine as the zone line number (aligned with the publish anchor, WYSIWYG).
  *
- * 不渲染 rejected（用户决断不发）/ posted（远端评论已由 CommentZone 接管，再渲染视觉重复）。
- * commit 只读视图（scopeKind !== 'all'）不渲染草稿（锚定在 PR 全量 diff 行号上，不套用于单 commit）。
+ * Does not render rejected (user decided not to send) / posted (the remote comment is already taken over by CommentZone; re-rendering would be visually duplicate).
+ * The commit read-only view (scopeKind !== 'all') does not render drafts (anchored on the PR full-diff line numbers, not applicable to a single commit).
  */
 export function useDraftZones(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
@@ -22,7 +22,7 @@ export function useDraftZones(opts: {
   registerEditTrigger: (draftId: string, fn: (() => void) | null) => void;
   renderSideBySide: boolean;
   commentHardBreaks: boolean;
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；透传给草稿编辑框启用粘贴 / 选取上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); passed through to the draft editor to enable paste / picker upload. */
   attachmentsEnabled?: boolean;
   scopeKind: 'all' | 'commit';
 }): void {
@@ -41,7 +41,7 @@ export function useDraftZones(opts: {
 
   useEffect(() => {
     if (!diffEditor || !content || !selected) return;
-    // commit 只读视图：不渲染本地草稿 zone（草稿锚定在 PR 全量 diff 行号上，不套用于单 commit）。
+    // commit read-only view: does not render local draft zones (drafts are anchored on the PR full-diff line numbers, not applicable to a single commit).
     if (scopeKind !== 'all') return;
     const fileDrafts = (drafts ?? []).filter((d) => {
       if (d.status === 'rejected' || d.status === 'posted') return false;
@@ -53,9 +53,9 @@ export function useDraftZones(opts: {
     const newByLine = new Map<number, ReviewDraft[]>();
     for (const d of fileDrafts) {
       const target = d.anchor.side === 'old' ? oldByLine : newByLine;
-      // 用 endLine 作为 zone 行号，跟发布锚点对齐 —— publishInlineComment 用 anchor.endLine 发到
-      // 远端，草稿区也落 endLine 即「预览位置 = 最终发布位置」(WYSIWYG)。nav reveal 高亮行同样取
-      // endLine，二者视觉一致，跨多行 finding (startLine=403, endLine=425) 也不会起止错位。
+      // Use endLine as the zone line number, aligned with the publish anchor — publishInlineComment sends to
+      // the remote using anchor.endLine, and the draft zone also lands on endLine, so "preview position = final publish position" (WYSIWYG). nav reveal highlights the same
+      // endLine, so the two are visually consistent, and a multi-line finding (startLine=403, endLine=425) won't have its start/end misplaced.
       const arr = target.get(d.anchor.endLine) ?? [];
       arr.push(d);
       target.set(d.anchor.endLine, arr);
@@ -89,8 +89,8 @@ export function useDraftZones(opts: {
         />
       ),
     });
-    // 不依赖 autoEditTokens / registerEditTrigger 引发的 zone 重建（registerEditTrigger 是稳定的
-    // useCallback）——避免 trigger 引发 DraftZone unmount/mount，根除取消后重入 edit 模式的 race。
+    // Does not depend on zone rebuilds triggered by autoEditTokens / registerEditTrigger (registerEditTrigger is a stable
+    // useCallback) — avoids trigger-induced DraftZone unmount/mount, eliminating the race of re-entering edit mode after cancel.
   }, [
     diffEditor,
     drafts,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useFileContent.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useFileContent.ts
@@ -12,7 +12,7 @@ export interface FileContentState {
   setContentError: (v: FormattedError | null) => void;
 }
 
-/** 读取选中文件 base / head 两侧内容。切视图期间门控（loadedKey !== viewKey）保留旧内容。 */
+/** Reads the base / head content of the selected file. During a view switch it is gated (loadedKey !== viewKey), keeping the old content. */
 export function useFileContent(
   pr: StoredPullRequest,
   selected: DiffChangedFile | null,
@@ -25,8 +25,8 @@ export function useFileContent(
   const [contentError, setContentError] = useState<FormattedError | null>(null);
 
   useEffect(() => {
-    // 门控：切视图期间（新 files 未到、selected 仍指向旧文件）不拉内容，保留旧内容渲染，
-    // 避免用「新视图 + 旧文件路径」错拉。新 files ready 后 selected 切到新文件再拉。
+    // Gate: during a view switch (new files not yet arrived, selected still points to the old file), do not fetch content, keep rendering the old content,
+    // avoiding a wrong fetch with "new view + old file path". After the new files are ready and selected switches to the new file, fetch then.
     if (loadedKey !== viewKey) return;
     if (!selected) {
       setContent(null);

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useFileListWidth.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useFileListWidth.ts
@@ -4,7 +4,7 @@ const DIFF_FILE_LIST_MIN = 180;
 const DIFF_FILE_LIST_MAX = 560;
 const DIFF_FILE_LIST_DEFAULT = 280;
 
-/** 左侧文件列表宽度：localStorage 持久化 + 拖拽柄 resize（夹在 MIN/MAX 之间）。 */
+/** Left file list width: localStorage-persisted + drag handle resize (clamped between MIN/MAX). */
 export function useFileListWidth(): {
   fileListWidth: number;
   startFileListResize: (e: ReactMouseEvent) => void;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useLineCommentAdder.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useLineCommentAdder.ts
@@ -8,14 +8,14 @@ import { invoke } from '../../../../../../api';
 import type { LoadedContent } from '../diff-types';
 
 /**
- * 行 hover '+' 新建 manual 草稿：modifiedEditor (head 侧) + 并排视图下 originalEditor (base 侧)
- * 上加 mousemove + mousedown 监听。**已有评论的行仍可继续追加**（hover 照常出 +，新草稿 zone 挂在评论
- * zone 之下、按时间序在已有评论下方）；仅「已有未发布草稿」的行不重复出 +（避免同行两个编辑器）。点击 →
- * drafts:create + autoEdit 立即进入编辑。
+ * Line hover '+' to create a manual draft: attaches mousemove + mousedown listeners on modifiedEditor (head side)
+ * and, in side-by-side view, originalEditor (base side). **Lines that already have comments can still be appended to** (hover still shows +, the new draft zone mounts below the comment
+ * zone, in time order beneath existing comments); only lines that "already have an unpublished draft" do not show + again (to avoid two editors on the same line). Click →
+ * drafts:create + autoEdit immediately enters edit.
  *
- * Platform policy 过滤：Bitbucket 只允许 hunk 内的行加 inline comment；GitHub/GitLab 宽松。从
- * diffEditor.getLineChanges() 拿 hunks，不允许的行不画 glyph、点击也不创建草稿。commit 只读视图
- * （scopeKind !== 'all'）不挂。
+ * Platform policy filter: Bitbucket only allows lines inside a hunk to have an inline comment; GitHub/GitLab are lenient. Gets
+ * hunks from diffEditor.getLineChanges(); disallowed lines get no glyph, and clicking creates no draft. The commit read-only view
+ * (scopeKind !== 'all') is not wired.
  */
 export function useLineCommentAdder(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
@@ -26,7 +26,7 @@ export function useLineCommentAdder(opts: {
   platform: PlatformKind;
   scopeKind: 'all' | 'commit';
   renderSideBySide: boolean;
-  /** 内容只读（decline / 不可参与归档 PR）：不挂行 hover '+' 新建评论草稿。 */
+  /** Content read-only (declined / non-participable archived PR): does not wire line hover '+' to create comment drafts. */
   readOnly?: boolean;
   triggerAutoEdit: (draftId: string) => void;
   t: TFunction;
@@ -47,29 +47,29 @@ export function useLineCommentAdder(opts: {
 
   useEffect(() => {
     if (!diffEditor || !content || !selected) return;
-    // commit 只读视图：不挂行 hover '+' 新建草稿（草稿锚点属于 PR 全量 diff，不在单 commit 上创建）。
-    // 内容只读（decline / 不可参与归档 PR）：同样不挂 '+'。
+    // commit read-only view: does not wire line hover '+' to create drafts (draft anchors belong to the PR full diff, not created on a single commit).
+    // Content read-only (declined / non-participable archived PR): likewise does not wire '+'.
     if (scopeKind !== 'all' || readOnly) return;
     const modifiedEditor = diffEditor.getModifiedEditor();
     const originalEditor = diffEditor.getOriginalEditor();
-    // 仅「已有未发布草稿」的行算占用、不重复出 +（避免同行两个编辑器）；已有远端评论的行不算占用——
-    // 允许继续追加新评论（新草稿 zone 会挂在评论 zone 之下，按时间序展示在已有评论下方）。
+    // Only lines that "already have an unpublished draft" count as occupied and do not show + again (to avoid two editors on the same line); lines with existing remote comments do not count as occupied —
+    // allowing new comments to be appended (the new draft zone mounts below the comment zone, shown in time order beneath existing comments).
     const occupiedNew = new Set<number>();
     const occupiedOld = new Set<number>();
     for (const d of drafts ?? []) {
       if (d.status === 'rejected') continue;
-      // 跟 zone 创建时一致用 startLine — 之前用 endLine 会让 hover '+' 把行 403
-      // (finding 起始) 当未占用错画 +；finding 跨多行场景下两个 + 同时出现
+      // Use startLine consistently with zone creation — previously using endLine would make hover '+' treat line 403
+      // (finding start) as unoccupied and wrongly draw +; in a multi-line finding scenario two + would appear at once
       (d.anchor.side === 'old' ? occupiedOld : occupiedNew).add(d.anchor.startLine);
     }
 
-    // 把 monaco ILineChange[] 翻成 DiffHunkRange[]。LineChange 的 EndLineNumber=0
-    // 表示该侧无对应（纯增/纯删），翻成 null range。
+    // Translate monaco ILineChange[] into DiffHunkRange[]. A LineChange EndLineNumber=0
+    // means that side has no counterpart (pure add / pure delete), translated into a null range.
     //
-    // **关键**：useEffect 首次执行时 monaco diff 还在异步计算，getLineChanges() 可能
-    // 返回 null/[] → 用 Bitbucket policy 严格判会让"所有行都不允许" → 用户看不到任何 +。
-    // 监听 onDidUpdateDiff 在 diff 算完后刷新 hunks (mutable let，闭包引用最新值)。
-    // 同时：hunks 为空时**兜底允许**（视为 policy 暂不可用），等 update 事件来再收紧
+    // **Key**: on the first useEffect run, the monaco diff is still computing asynchronously, and getLineChanges() may
+    // return null/[] → a strict Bitbucket policy check would make "all lines disallowed" → the user sees no + at all.
+    // Listen to onDidUpdateDiff to refresh hunks after the diff finishes (mutable let, closure references the latest value).
+    // Meanwhile: when hunks is empty, **fall back to allowing** (treated as policy temporarily unavailable), tightening once the update event arrives
     const policy = policyForPlatform(platform);
     const computeHunks = (): DiffHunkRange[] => {
       const lineChanges = diffEditor.getLineChanges() ?? [];
@@ -91,15 +91,15 @@ export function useLineCommentAdder(opts: {
 
     const disposers: Array<() => void> = [];
 
-    // 在指定编辑器 + 侧别上挂「hover 出 + / 点击建草稿」。modified=new（新增/上下文行），
-    // original=old（删除/上下文行，仅并排视图可点 —— 统一视图下原始编辑器隐藏、删除行是 view zone 无行号可 hover）。
+    // Wire "hover shows + / click creates draft" on a given editor + side. modified=new (added/context lines),
+    // original=old (deleted/context lines, clickable only in side-by-side view — in unified view the original editor is hidden, and deleted lines are view zones with no line number to hover).
     const wireAdder = (
       editorInst: MonacoEditor.ICodeEditor,
       side: 'old' | 'new',
       occupied: Set<number>,
     ): void => {
-      /** 兜底允许：hunks 还没算完（空数组）就一律允许，避免初始"什么都点不出来"。
-       *  正常加载完 hunks 非空后才走 policy 严格判 */
+      /** Fallback allow: while hunks are not yet computed (empty array), allow everything, avoiding the initial "nothing is clickable".
+       *  Only after normal loading, when hunks is non-empty, does it run the strict policy check */
       const isAllowed = (line: number): boolean =>
         hunks.length === 0 || policy.isLineAllowed(hunks, side, line);
 
@@ -121,8 +121,8 @@ export function useLineCommentAdder(opts: {
                   },
                   options: {
                     isWholeLine: false,
-                    // 用 glyphMarginClassName 跟 commentZone (远端评论) 一致 —— 渲染在
-                    // editor 最左 glyph margin 列 (跟 GitHub 评论 "+" 位置惯例一致)。
+                    // Use glyphMarginClassName consistent with commentZone (remote comments) — rendered in
+                    // the editor's leftmost glyph margin column (matching the GitHub comment "+" position convention).
                     glyphMarginClassName: 'monaco-draft-add-glyph',
                     glyphMarginHoverMessage: { value: t('diffView.addCommentHint') },
                   },
@@ -169,10 +169,10 @@ export function useLineCommentAdder(opts: {
                   status: 'pending',
                 },
               });
-              // 新建后立即触发 auto edit，让用户能马上输入
+              // Trigger auto edit immediately after creation, so the user can type right away
               triggerAutoEdit(created.id);
             } catch {
-              // 静默；UI 上没出 zone 就视为没创建成功
+              // Silent; if no zone appears in the UI, treat it as a failed creation
             }
           })();
         }
@@ -190,8 +190,8 @@ export function useLineCommentAdder(opts: {
       });
     };
 
-    // 新增 / 上下文行（head 侧）始终可点；删除 / 上下文行（base 侧）仅并排视图可点
-    // （统一视图原始编辑器隐藏，删除行以 view zone 呈现、无可 hover 的行号）。
+    // Added / context lines (head side) are always clickable; deleted / context lines (base side) are clickable only in side-by-side view
+    // (in unified view the original editor is hidden, and deleted lines are presented as view zones with no hoverable line number).
     wireAdder(modifiedEditor, 'new', occupiedNew);
     if (renderSideBySide) {
       wireAdder(originalEditor, 'old', occupiedOld);
@@ -201,7 +201,7 @@ export function useLineCommentAdder(opts: {
       diffUpdateDisp.dispose();
       for (const dispose of disposers) dispose();
     };
-    // triggerAutoEdit 不入 deps —— 它每次 render 换新引用，列进去会让本 effect 每帧重挂监听
+    // triggerAutoEdit is not in deps — it changes reference every render, so listing it would make this effect re-attach listeners every frame
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     diffEditor,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSelectionCapture.ts
@@ -6,20 +6,20 @@ import { selectionStore } from '../../../../../../stores/selection-store';
 const DEBOUNCE_MS = 120;
 
 /**
- * 捕获 Diff 里的代码选区 → 写入 selectionStore，供 ChatPane 把选中代码作为隐式上下文带进提问。
+ * Captures the code selection in the Diff → writes it to selectionStore, so ChatPane can carry the selected code as implicit context into a question.
  *
- * 监听内层两个子编辑器的 onDidChangeCursorSelection（modified=新/head、original=基线/old）；选区空
- * （塌缩成光标、无文本）→ clear，否则去抖 ~120ms 后写入。Monaco diff 子编辑器的行号即该侧显示文件
- * 行号，无需 hunk 映射。文件 / PR 切换或卸载时（依赖变更触发 cleanup）一并清空，避免陈旧选区残留。
+ * Listens to onDidChangeCursorSelection on the two inner sub-editors (modified=new/head, original=base/old); an empty selection
+ * (collapsed to a cursor, no text) → clear, otherwise write after a ~120ms debounce. A Monaco diff sub-editor's line number is that side's displayed file
+ * line number, so no hunk mapping is needed. On file / PR switch or unmount (dependency change triggers cleanup), it clears too, avoiding stale selection residue.
  *
- * 刻意**不**接「可评论区域」守卫（useLineCommentAdder 的 isAllowed）：行内评论受平台 anchor 约束、
- * 只能挂在 diff 命中行；而选区引用只作模型上下文、不回写远端，任意可选代码（含未改动上下文行）皆可
- * 引用——恰恰这些上下文对提问最有用，不应被评论约束挡掉。
+ * Deliberately does **not** apply the "commentable region" guard (useLineCommentAdder's isAllowed): inline comments are constrained by the platform anchor
+ * and can only attach to diff-hit lines; whereas a selection reference is only model context and is not written back to the remote, so any selectable code (including unchanged context lines) can be
+ * referenced — precisely that context is most useful for a question and should not be blocked by the comment constraint.
  *
- * 统一（inline）视图下，Monaco 经典 inline diff 把删除行渲染为 modified 编辑器内的 view-zone（非任何
- * model 的文本行），original 编辑器宽度归 0 → 删除行无法被光标选中。为让删除内容也能「像添加行一样」被
- * 引用：head 选区跨到删除/改动 hunk 时，据 getLineChanges() 把对应基线行从 original model 取出，作为
- * removed 一并写入选区（见 spannedDeletions）。并排视图删除行可直接在 original 编辑器选中，故不做此增补。
+ * In unified (inline) view, Monaco's classic inline diff renders deleted lines as view-zones inside the modified editor (not the text line of any
+ * model), and the original editor width collapses to 0 → deleted lines cannot be cursor-selected. To let deleted content also be referenced "like added lines":
+ * when the head selection spans a deletion/change hunk, based on getLineChanges() the corresponding base lines are taken from the original model and written into the selection as
+ * removed (see spannedDeletions). In side-by-side view, deleted lines can be selected directly in the original editor, so this augmentation is not done.
  */
 export function useSelectionCapture(opts: {
   diffEditor: MonacoEditor.IStandaloneDiffEditor | null;
@@ -34,7 +34,7 @@ export function useSelectionCapture(opts: {
     const original = diffEditor.getOriginalEditor();
     let timer: ReturnType<typeof setTimeout> | null = null;
 
-    // 统一视图：求 head 选区 [s,e] 跨到的删除/改动 hunk 的基线侧原始行（含真实代码）。
+    // Unified view: find the base-side original lines (with real code) of the deletion/change hunks that the head selection [s,e] spans.
     const spannedDeletions = (
       s: number,
       e: number,
@@ -43,11 +43,11 @@ export function useSelectionCapture(opts: {
       if (!origModel) return undefined;
       const segs: Array<{ oStart: number; oEnd: number }> = [];
       for (const c of diffEditor.getLineChanges() ?? []) {
-        // 有删除/改动的基线行（纯新增 originalEndLineNumber===0 → 跳过）。
+        // Base lines with deletion/change (pure addition originalEndLineNumber===0 → skip).
         if (c.originalStartLineNumber <= 0 || c.originalEndLineNumber <= 0) continue;
         const modStart = c.modifiedStartLineNumber;
         const modEnd = c.modifiedEndLineNumber > 0 ? c.modifiedEndLineNumber : c.modifiedStartLineNumber;
-        // 该 hunk 在 modified 侧的落点与选区 [s,e] 有交叠 → 视为被选区跨到。
+        // The hunk's landing on the modified side overlaps the selection [s,e] → treated as spanned by the selection.
         if (modEnd < s || modStart > e) continue;
         segs.push({ oStart: c.originalStartLineNumber, oEnd: c.originalEndLineNumber });
       }
@@ -70,18 +70,18 @@ export function useSelectionCapture(opts: {
     const capture = (ed: MonacoEditor.ICodeEditor, side: 'old' | 'new'): void => {
       const sel = ed.getSelection();
       const model = ed.getModel();
-      // 空选区（光标塌缩、无选中文本）→ 清空。
+      // Empty selection (cursor collapsed, no selected text) → clear.
       if (!sel || !model || (sel.startLineNumber === sel.endLineNumber && sel.startColumn === sel.endColumn)) {
         selectionStore.clear();
         return;
       }
-      // 选到下一行行首（endColumn===1）时该行无实际文本，不计入行数。
+      // When the selection reaches the next line's start (endColumn===1), that line has no actual text and is not counted in the line count.
       const endLine =
         sel.endColumn === 1 && sel.endLineNumber > sel.startLineNumber
           ? sel.endLineNumber - 1
           : sel.endLineNumber;
       const startLine = sel.startLineNumber;
-      // 统一视图 + head 选区：增补跨到的基线删除行（并排视图删除行可直接选中，不增补）。
+      // Unified view + head selection: augment with the spanned base deleted lines (in side-by-side view deleted lines can be selected directly, no augmentation).
       const removed =
         side === 'new' && !renderSideBySide ? spannedDeletions(startLine, endLine) : undefined;
       selectionStore.set({

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSyncProgress.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/hooks/useSyncProgress.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { StoredPullRequest, SyncProgressEvent } from '@meebox/shared';
 
-/** 订阅 sync:progress 并按当前 PR 所属 repo 过滤；切 PR 清旧进度。 */
+/** Subscribes to sync:progress and filters by the repo the current PR belongs to; clears old progress on PR switch. */
 export function useSyncProgress(pr: StoredPullRequest): SyncProgressEvent | null {
   const [progress, setProgress] = useState<SyncProgressEvent | null>(null);
   const repoKeySuffix = `/${pr.repo.projectKey}/${pr.repo.repoSlug}`;
@@ -11,7 +11,7 @@ export function useSyncProgress(pr: StoredPullRequest): SyncProgressEvent | null
     });
     return unsubscribe;
   }, [repoKeySuffix]);
-  // 切 PR 只清瞬态进度（不清 files/content 等，保留 stale-while-loading 旧视图）
+  // PR switch only clears transient progress (does not clear files/content etc., keeping the stale-while-loading old view)
   useEffect(() => {
     setProgress(null);
   }, [pr.localId]);

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/inline-comments/InlineCommentZone.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/inline-comments/InlineCommentZone.tsx
@@ -10,13 +10,13 @@ import { ReactionAddButton, ReactionChips, useReactions } from '../../shared/Rea
 import { useCommentThread } from '../../shared/useCommentThread';
 
 /**
- * 估算 view zone 高度（行数）。每段评论 = header(avatar+name+date, 1.3 行) + body
- * 字数 / 80 行向上取整。回复递归计算，每条 reply 多 0.3 行 (margin/border)。
- * 同行多评论叠加，最后顶天 32 行避免独吞屏幕。
+ * Estimate view zone height (in lines). Each comment = header(avatar+name+date, 1.3 lines) + body
+ * length / 80 rounded up. Replies computed recursively, each reply adds 0.3 line (margin/border).
+ * Multiple comments on the same line stack, capped at 32 lines to avoid hogging the screen.
  */
 export function estimateZoneHeight(comments: PrComment[]): number {
-  let h = 1; // 上下 padding
-  for (const c of comments) h += commentHeight(c) + 0.3; // item 间分隔
+  let h = 1; // top/bottom padding
+  for (const c of comments) h += commentHeight(c) + 0.3; // separator between items
   return Math.min(Math.ceil(h), 32);
 }
 
@@ -43,11 +43,11 @@ export function CommentZone({
   prLocalId: string;
   prWebUrl: string;
   hardBreaks: boolean;
-  /** 评论 emoji 反应模式（capabilities.commentReactions）：'fixed'/'free' 才渲染加反应按钮；缺省 = 不支持。 */
+  /** Comment emoji reaction mode (capabilities.commentReactions): only 'fixed'/'free' render the add-reaction button; absent = unsupported. */
   reactionsMode?: 'fixed' | 'free';
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；透传给回复编辑框启用粘贴上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); passed through to the reply editor to enable paste upload. */
   attachmentsEnabled?: boolean;
-  /** 内容只读（decline / 不可参与归档 PR）：隐藏行内评论的回复 / 编辑 / 删除操作。 */
+  /** Content read-only (decline / archived PR that can't be participated in): hide the inline comment reply / edit / delete actions. */
   readOnly?: boolean;
 }) {
   return (
@@ -76,8 +76,8 @@ export function CommentZone({
 }
 
 /**
- * 把 Bitbucket 评论 markdown 里 `attachment:HASH` 形态的 URL 改写为可点击的 Bitbucket 链接。
- * 返回 null = 不是附件 URL，调用方按原样处理。
+ * Rewrite `attachment:HASH` style URLs in Bitbucket comment markdown into clickable Bitbucket links.
+ * Returns null = not an attachment URL, caller handles it as-is.
  */
 function resolveAttachmentUrl(href: string, base: string | null): string | null {
   if (!base || !href.startsWith('attachment:')) return null;
@@ -87,10 +87,10 @@ function resolveAttachmentUrl(href: string, base: string | null): string | null 
 }
 
 /**
- * react-markdown components 覆盖：a/img 检测 attachment: 协议，改写到 Bitbucket URL。
- * 图片附件因为 Bitbucket 需要会话鉴权，渲染器 fetch 不到，统一退化为可点击链接
- * （📎 alt 文本），点击走 setWindowOpenHandler → shell.openExternal 在系统
- * 浏览器打开，用户的 Bitbucket 登录 session 能正常加载。
+ * react-markdown components override: a/img detect the attachment: protocol and rewrite to a Bitbucket URL.
+ * Image attachments require Bitbucket session auth so the renderer can't fetch them; they fall back to a
+ * clickable link (📎 alt text). Clicking goes through setWindowOpenHandler → shell.openExternal to open in
+ * the system browser, where the user's Bitbucket login session can load them normally.
  */
 function makeCommentMarkdownComponents(
   attachmentBase: string | null,
@@ -111,20 +111,21 @@ function makeCommentMarkdownComponents(
     },
     img: ({ src, alt }) => {
       if (typeof src !== 'string' || !src) return null;
-      // 把 src 原样传 IPC — main 端 adapter 懂 Bitbucket `attachment:HASH` 协议 + 绝对/
-      // 相对 URL，renderer 不需要前置 resolve。外部公网 URL 在 main 端会被认为
-      // 跨 host 返回 null，BitbucketImage 内部 fallback 到原生 <img>
+      // Pass src through to IPC as-is — the main-side adapter understands the Bitbucket `attachment:HASH`
+      // protocol + absolute/relative URLs, so the renderer needn't resolve up front. An external public URL
+      // is treated as cross-host on the main side and returns null; BitbucketImage falls back internally to a native <img>
       return <BitbucketImage src={src} alt={alt} />;
     },
   };
 }
 
 /**
- * 递归渲染单条评论 + 它的回复子树。comment.replies 是任意层级的；这里递归到底。每往下一层
- * 步进缩进 + 一道左竖线（缩进量 / 边框色与评论 tab 的 .pr-comments-replies 对齐，见 comment-zone.scss）。
+ * Recursively render a single comment + its reply subtree. comment.replies is arbitrarily deep; recurse all
+ * the way down. Each level down adds a step of indent + a left vertical line (indent amount / border color
+ * aligned with the comments tab's .pr-comments-replies, see comment-zone.scss).
  */
-/** 嵌套缩进最大 5 层；超过此层级的更深回复**拉平**（comment-zone-reply-flat：去步进 / 边框 / 左 padding），
- *  平铺在第 5 层缩进上、上下排列，避免无限嵌套一直右滑。 */
+/** Nested indent maxes out at 5 levels; deeper replies beyond this level are **flattened** (comment-zone-reply-flat:
+ *  drop step / border / left padding), laid out on the level-5 indent stacked vertically, to avoid infinite nesting sliding ever rightward. */
 const MAX_REPLY_INDENT_DEPTH = 5;
 
 function CommentNode({
@@ -155,14 +156,14 @@ function CommentNode({
     () => makeCommentMarkdownComponents(attachmentBase, prLocalId, prWebUrl),
     [attachmentBase, prLocalId, prWebUrl],
   );
-  // 反应状态 + 切换（与评论 / 活动 tab 的 CommentItem 共用 useReactions；hook 无条件调用，
-  // 输出仅在 reactionsMode 存在时渲染）。kind 由 comment.anchor 推断为 'inline'。
+  // Reaction state + toggle (shares useReactions with the comments / activity tab's CommentItem; the hook is
+  // called unconditionally, output only rendered when reactionsMode is present). kind inferred from comment.anchor as 'inline'.
   const { reactions, busy: reactionBusy, toggle: toggleReaction } = useReactions(
     prLocalId,
     comment,
     readOnly,
   );
-  // 回复 / 编辑 / 删除 交互状态机（与评论/活动 tab 的 CommentItem 共用，见 shared/useCommentThread）
+  // Reply / edit / delete interaction state machine (shared with the comments/activity tab's CommentItem, see shared/useCommentThread)
   const {
     replyOpen,
     setReplyOpen,
@@ -178,8 +179,8 @@ function CommentNode({
     handleDelete,
   } = useCommentThread(prLocalId, comment);
 
-  // body 只包 author + 正文 + 回复按钮 / 编辑器；replies 作为 sibling 放外面 —
-  // 不让 hover 内层 replies 冒泡触发外层 :hover 导致所有祖先 reply 按钮一齐显示
+  // body wraps only author + content + reply button / editor; replies live outside as siblings —
+  // so hovering inner replies doesn't bubble up to trigger the outer :hover and reveal all ancestor reply buttons at once
   const inner = (
     <>
       <div className="comment-zone-item-body">
@@ -207,8 +208,8 @@ function CommentNode({
             className="comment-zone-body markdown"
           />
         )}
-        {/* 回复 / 编辑 / 删除按钮：默认 hidden，hover comment-zone-item-body 显示 (CSS)。
-            编辑态隐藏全部按钮 (避免跟编辑器底部按钮组重复)；只读（decline / 不可参与）整组隐藏。 */}
+        {/* Reply / edit / delete buttons: hidden by default, shown on hover of comment-zone-item-body (CSS).
+            Edit mode hides all buttons (to avoid duplicating the editor's bottom button group); read-only (decline / can't participate) hides the whole group. */}
         {!readOnly && !replyOpen && !editOpen && (
           <div className="comment-zone-foot">
             <button
@@ -239,7 +240,7 @@ function CommentNode({
                 {deleting ? t('commentsPanel.deleting') : t('common.delete')}
               </button>
             )}
-            {/* 「加反应」按钮放在操作按钮之后（与评论 tab 一致）；回复 / 编辑态下整组 foot 已隐藏。 */}
+            {/* The "add reaction" button goes after the action buttons (consistent with the comments tab); the whole foot group is already hidden in reply / edit mode. */}
             {reactionsMode && (
               <ReactionAddButton
                 reactions={reactions}
@@ -253,14 +254,14 @@ function CommentNode({
         {replyOpen && (
           <CommentReplyEditor
             prLocalId={prLocalId}
-            // 回复目标抽象（threadId）：GitLab=discussion id（reply 必需）；Bitbucket 空 / GitHub=remoteId → 回退 remoteId。
+            // Reply target abstraction (threadId): GitLab=discussion id (required for reply); Bitbucket empty / GitHub=remoteId → fall back to remoteId.
             parentCommentId={comment.threadId ?? comment.remoteId}
             attachmentsEnabled={attachmentsEnabled}
             onCancel={() => setReplyOpen(false)}
             onPosted={() => setReplyOpen(false)}
           />
         )}
-        {/* 已有反应：单独成行，渲染在操作按钮下方（编辑态隐藏）。readOnly 下只展示、不可切换。 */}
+        {/* Existing reactions: on their own line, rendered below the action buttons (hidden in edit mode). Under readOnly, display only, not toggleable. */}
         {reactionsMode && !editOpen && (
           <ReactionChips
             reactions={reactions}
@@ -313,9 +314,10 @@ function CommentNode({
     </>
   );
   if (depth === 0) return inner;
-  // 满 MAX_REPLY_INDENT_DEPTH 层后**拉平**：去掉步进缩进与左竖线，更深回复平铺在上限层级上
-  // （与评论 tab 设计一致）。关键：必须同时去掉 padding-left 与 border —— 仅去步进、保留每层的
-  // padding/border 会逐级累加仍右移（之前"还是有缩进"的根因）。
+  // Past MAX_REPLY_INDENT_DEPTH levels, **flatten**: drop the step indent and left vertical line, laying deeper
+  // replies out on the max level (consistent with the comments tab design). Key: must drop both padding-left AND
+  // border — dropping only the step while keeping each level's padding/border still accumulates and shifts right
+  // (the root cause of the earlier "still indented" bug).
   const flat = depth > MAX_REPLY_INDENT_DEPTH;
   return (
     <div className={`comment-zone-reply${flat ? ' comment-zone-reply-flat' : ''}`}>{inner}</div>
@@ -350,7 +352,7 @@ function CommentAuthorRow({
   );
 }
 
-/** 把多条同行评论合成 markdown hover 文本（含回复嵌套） */
+/** Combine multiple same-line comments into markdown hover text (including nested replies) */
 export function renderHoverMd(comments: PrComment[]): string {
   return comments
     .map((c) => {

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/colorize.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/colorize.ts
@@ -4,14 +4,14 @@ import { languageFor } from '../../../../../../utils/language';
 import type { FileResults } from './diff-search';
 
 /**
- * 异步着色：对每个 file 的每条 match.content 用 Monaco colorize 加语法高亮。
+ * Async colorize: apply syntax highlighting via Monaco colorize to each file's every match.content.
  *
- * Monaco colorize 返回带 inline style 的 HTML — 不依赖 monaco theme CSS，
- * dangerouslySetInnerHTML 即可用。串行 file 但并发 line 平衡 throughput vs
- * 启动开销 (一个文件的 language 加载只一次)。
+ * Monaco colorize returns HTML with inline styles — doesn't depend on monaco theme CSS,
+ * usable directly via dangerouslySetInnerHTML. Serial per file but concurrent per line balances throughput vs
+ * startup cost (a file's language loads only once).
  *
- * session token 检查：search session 已经被新 query 取代时立即放弃，避免
- * setState 到过期结果上
+ * session token check: bail immediately when the search session has been superseded by a new query, to avoid
+ * setState onto a stale result
  */
 export async function colorizeAll(
   results: FileResults[],
@@ -22,7 +22,7 @@ export async function colorizeAll(
   for (const fr of results) {
     if (token !== sessionRef.current) return results;
     const langId = languageFor(fr.file.path);
-    // plaintext 文件没意义着色 — 直接复用原 matches
+    // plaintext files aren't worth colorizing — just reuse the original matches
     if (langId === 'plaintext') {
       out.push(fr);
       continue;
@@ -31,7 +31,7 @@ export async function colorizeAll(
       fr.matches.map(async (m) => {
         try {
           const html = await MonacoEditorNs.colorize(m.content, langId, { tabSize: 2 });
-          // colorize 输出末尾会加 `<br/>`；裁掉避免行高跳一档
+          // colorize output appends a trailing `<br/>`; trim it to avoid a line-height jump
           return { ...m, colorizedHtml: html.replace(/<br\/?>$/i, '') };
         } catch {
           return m;

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/diff-search.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/diff-search.ts
@@ -4,34 +4,34 @@ import { invoke } from '../../../../../../api';
 
 export const CASE_SENSITIVE_LS_KEY = 'meebox.diffSearch.caseSensitive';
 
-/** 大文件保护：单文件超过 N 条命中只展示前 N + "更多" */
+/** Large-file guard: when a single file exceeds N matches, show only the first N + "more" */
 export const PER_FILE_MATCH_CAP = 200;
 
 export const SEARCH_DEBOUNCE_MS = 220;
 
 /**
- * 搜索范围限制：仅扫"变更行 + 上下 N 行 context"，跟 Monaco DiffEditor 视觉上
- * 用户能看到的"diff 周围若干行 context"对齐。N=10 比 git diff 默认 unified=3
- * 更宽松，让搜索能命中变更附近稍远的引用 (常见场景：改了某个函数实现，调用方
- * 在其上下 5-10 行能被搜到)
+ * Search scope limit: scan only "changed lines + N lines of context above/below", aligned with the
+ * "few lines of context around the diff" the user visually sees in the Monaco DiffEditor. N=10 is more
+ * generous than git diff's default unified=3, letting search match references slightly farther from a
+ * change (common case: changed a function's implementation, callers 5-10 lines above/below get found)
  */
 const CONTEXT_LINES = 10;
 
 export interface LineMatch {
-  /** 1-based 行号 (在 srcSide 端的行号) */
+  /** 1-based line number (line number on the srcSide side) */
   line: number;
   content: string;
-  /** 该行在 diff 中的角色 */
+  /** The line's role in the diff */
   diffRole: 'added' | 'removed' | 'context';
-  /** 该行属于 head 还是 base 文件 — 决定 onJumpToMatch 的 side 参数 */
+  /** Whether the line belongs to the head or base file — decides onJumpToMatch's side param */
   srcSide: 'old' | 'new';
-  /** 匹配子串在 content 中的起止位置 (用于高亮渲染) */
+  /** Start/end position of the matched substring within content (used for highlight rendering) */
   matchStart: number;
   matchEnd: number;
   /**
-   * Monaco colorize 后的 HTML (含 inline style 语法着色)。第一波结果回来时为
-   * undefined，后台 colorize 完成后异步填上，UI 再 update 一次。
-   * 未着色时 fallback 到 renderHighlight 走纯文本 + 关键词 `<mark>`
+   * HTML after Monaco colorize (with inline-style syntax coloring). Undefined when the first wave of results
+   * returns; filled in asynchronously after background colorize completes, then the UI updates once more.
+   * When uncolorized, falls back to renderHighlight using plain text + keyword `<mark>`
    */
   colorizedHtml?: string;
 }
@@ -51,19 +51,19 @@ export function dirname(p: string): string {
 }
 
 /**
- * 跨文件搜索主逻辑：
+ * Cross-file search main logic:
  *
- * 对每个 file:
- *   1. 拉 head + base 内容 (有缓存命中即跳过 IPC)
- *   2. 用 multiset consume 算"变更行"集合，扩展 ±CONTEXT_LINES 得到"可见范围"
- *      (跟用户在 Diff 视图能看到的 hunk 周围 context 对齐)
- *   3. 仅在可见范围内扫 line-by-line 找匹配
- *   4. head 命中：base 端也有 → context；否则 added
- *   5. base 命中且 head 端无：removed (排除已被 context 命中的)
- *   6. 同文件结果按 line 升序整理
+ * For each file:
+ *   1. Fetch head + base content (skip IPC on cache hit)
+ *   2. Compute the "changed lines" set via multiset consume, expand ±CONTEXT_LINES to get the "visible range"
+ *      (aligned with the hunk-surrounding context the user sees in the Diff view)
+ *   3. Scan line-by-line for matches only within the visible range
+ *   4. head match: base side also has it → context; otherwise added
+ *   5. base match with none on the head side: removed (excluding those already matched as context)
+ *   6. Sort a file's results in ascending line order
  *
- * 单个文件失败 (binary / 拉取错误) 静默跳过，最后返回 partialError 提示有几个
- * 文件没搜成
+ * A single file failing (binary / fetch error) is silently skipped; finally returns partialError noting how many
+ * files failed to search
  */
 export async function runSearch(
   token: number,
@@ -87,30 +87,30 @@ export async function runSearch(
           loadContent(cache, prLocalId, 'head', headPath),
           loadContent(cache, prLocalId, 'base', basePath),
         ]);
-        // 中途用户切到别的 query — 当前 promise 还没 return 就被取消，直接放弃
+        // User switched to another query midway — this promise was cancelled before returning, so bail
         if (token === -1) return;
 
         const headLines = headText === null ? [] : headText.split('\n');
         const baseLines = baseText === null ? [] : baseText.split('\n');
-        // 用 Multiset 而非 Set — 同内容行可能出现多次 (空行 / 大括号 / 同名变量
-        // 声明)。Set 会让"基础侧某次 instance 仍存在"误判为 context 跳过 added
+        // Use a Multiset rather than a Set — a same-content line may appear multiple times (blank line / brace / same-named
+        // variable declaration). A Set would misjudge "some instance still exists on the base side" as context and skip added
         const baseLineCount = countLines(baseLines);
         const headLineCount = countLines(headLines);
 
-        // 变更行集合 + ±CONTEXT_LINES context = 用户在 Diff 视图看得到的范围
+        // Changed-line set + ±CONTEXT_LINES context = the range the user sees in the Diff view
         const changedHead = findChangedIndices(headLines, baseLineCount);
         const changedBase = findChangedIndices(baseLines, headLineCount);
         const visibleHead = expandToContext(changedHead, headLines.length);
         const visibleBase = expandToContext(changedBase, baseLines.length);
 
         const matches: LineMatch[] = [];
-        // head 端扫
+        // scan the head side
         for (let i = 0; i < headLines.length; i++) {
           if (!visibleHead.has(i)) continue;
           const line = headLines[i]!;
           const span = findMatchSpan(line, rawQuery, caseSensitive, probe);
           if (span === null) continue;
-          // base 端有同样内容 → context；否则 added
+          // base side has the same content → context; otherwise added
           const stillInBase = (baseLineCount.get(line) ?? 0) > 0;
           const stripped = stripLeadingIndent(line, span);
           matches.push({
@@ -122,7 +122,7 @@ export async function runSearch(
             matchEnd: stripped.matchEnd,
           });
         }
-        // base 端扫，仅收集"仅在 base 出现"的 removed 行 (避免跟 context 重复)
+        // scan the base side, collecting only removed lines that "appear only in base" (to avoid duplicating context)
         for (let i = 0; i < baseLines.length; i++) {
           if (!visibleBase.has(i)) continue;
           const line = baseLines[i]!;
@@ -140,7 +140,7 @@ export async function runSearch(
           });
         }
         if (matches.length === 0) return;
-        // 排序：先按 srcSide (head 优先) 再按 line，让结果列表有可预测顺序
+        // Sort: first by srcSide (head first) then by line, giving the result list a predictable order
         matches.sort((a, b) => {
           if (a.srcSide !== b.srcSide) return a.srcSide === 'new' ? -1 : 1;
           return a.line - b.line;
@@ -152,7 +152,7 @@ export async function runSearch(
     }),
   );
 
-  // 文件级排序按 path 字典序，跟文件树视觉对齐
+  // File-level sort by path lexicographic order, aligned with the file tree visually
   out.sort((a, b) => a.file.path.localeCompare(b.file.path));
   return {
     results: out,
@@ -162,11 +162,11 @@ export async function runSearch(
 }
 
 /**
- * 用 multiset consume 算"变更行"行号集合：other 端有同内容行就配对消费 (从
- * count 表里扣 1)，配不上的就是"仅在本侧出现" — 即变更行。
+ * Compute the "changed lines" line-number set via multiset consume: if the other side has a same-content line, pair
+ * and consume it (decrement 1 from the count table); those that can't be paired "appear only on this side" — i.e. changed lines.
  *
- * 比简单 set 含 / 不含判定更准 — 同内容行 (空行 / `}` / 同名 import) 在 PR 一
- * 般是匹配存在，不是变更
+ * More accurate than a simple set contains / doesn't-contain check — same-content lines (blank line / `}` / same-named
+ * import) in a PR are generally matches that exist, not changes
  */
 export function findChangedIndices(
   ownLines: string[],
@@ -183,7 +183,7 @@ export function findChangedIndices(
   return changed;
 }
 
-/** 把变更行索引集合按 ±CONTEXT_LINES 扩展，并合并相邻区间 */
+/** Expand the changed-line index set by ±CONTEXT_LINES and merge adjacent ranges */
 export function expandToContext(changed: Set<number>, total: number): Set<number> {
   const out = new Set<number>();
   for (const idx of changed) {
@@ -208,8 +208,8 @@ export async function loadContent(
       side,
       path,
     });
-    // DiffFileContent 联合：{binary:false, content:string} 或 {binary:true}。
-    // binary 文件跳过搜索 (没有可比对的文本)；non-binary 取 content 字段
+    // DiffFileContent union: {binary:false, content:string} or {binary:true}.
+    // binary files skip search (no comparable text); non-binary takes the content field
     const text = c.binary === false ? c.content : null;
     cache.set(k, text);
     return text;
@@ -220,9 +220,10 @@ export async function loadContent(
 }
 
 /**
- * 剥行首缩进 (tab / 空格) — 搜索面板宽度有限，对齐到代码原缩进会浪费横向空间
- * 也让 match 看起来不显眼。剥掉后视觉上左对齐，关键词高亮起止点也按剥后内容
- * 重算。命中**在**缩进里 (query 包含 leading 空白) → 不剥，保持高亮位置正确
+ * Strip leading indent (tab / space) — the search panel has limited width; keeping the code's original indent
+ * wastes horizontal space and makes the match look inconspicuous. After stripping it's visually left-aligned, and
+ * the keyword highlight start/end are recomputed against the stripped content. If the match is **inside** the
+ * indent (query contains leading whitespace) → don't strip, to keep the highlight position correct
  */
 export function stripLeadingIndent(
   line: string,
@@ -232,7 +233,7 @@ export function stripLeadingIndent(
   if (!m) return { content: line, matchStart: span[0], matchEnd: span[1] };
   const offset = m[0].length;
   if (span[0] < offset) {
-    // 命中在缩进区，剥了就高亮就错位 — 保留原内容
+    // Match is in the indent region; stripping would misalign the highlight — keep the original content
     return { content: line, matchStart: span[0], matchEnd: span[1] };
   }
   return {

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/useDiffSearch.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/search/useDiffSearch.ts
@@ -10,15 +10,15 @@ import {
 } from './diff-search';
 
 /**
- * 跨文件搜索状态机：query / 大小写敏感(localStorage 持久化) / 结果 / loading / error /
- * 文件折叠态 + 去抖搜索 + 异步着色 + 内容缓存（PR 切换清）。mount 自动聚焦输入框。
- * 纯算法见 ./diff-search；着色见 ./colorize。
+ * Cross-file search state machine: query / case sensitivity (localStorage-persisted) / results / loading / error /
+ * file collapse state + debounced search + async colorize + content cache (cleared on PR switch). Auto-focuses the input on mount.
+ * Pure algorithm see ./diff-search; colorize see ./colorize.
  */
 export function useDiffSearch(files: DiffChangedFile[], prLocalId: string) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
-  // 大小写敏感跨 session 持久化 — 用户习惯一旦定下来 (一般是关或开)，每次
-  // 进搜索面板都得重新切一次很烦。localStorage 写一次就记住
+  // Case sensitivity persisted across sessions — once the user's habit settles (usually off or on), having to
+  // toggle it again every time they open the search panel is annoying. Write to localStorage once and remember it
   const [caseSensitive, setCaseSensitive] = useState<boolean>(() => {
     try {
       return localStorage.getItem(CASE_SENSITIVE_LS_KEY) === '1';
@@ -30,26 +30,26 @@ export function useDiffSearch(files: DiffChangedFile[], prLocalId: string) {
     try {
       localStorage.setItem(CASE_SENSITIVE_LS_KEY, caseSensitive ? '1' : '0');
     } catch {
-      // 隐私模式 / 配额满 等失败静默，不影响搜索功能
+      // Silently ignore failures like private mode / quota full, doesn't affect search functionality
     }
   }, [caseSensitive]);
   const [results, setResults] = useState<FileResults[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // 默认全部展开 — 用户已经主动搜索，不需要再点一次才看结果
+  // Expanded by default — the user already actively searched, no need for another click to see results
   const [collapsedFiles, setCollapsedFiles] = useState<ReadonlySet<string>>(new Set());
 
-  // 当前 search session 的 token，让旧的异步任务发现自己被取消
+  // Token for the current search session, letting old async tasks discover they've been cancelled
   const sessionRef = useRef(0);
-  // 内容缓存：同一个 PR 搜不同关键字时 invoke diff:getFileContent 拿过的不重复拉
+  // Content cache: when searching different keywords in the same PR, don't re-fetch what invoke diff:getFileContent already got
   // key: `${side}:${path}` → text content
   const contentCacheRef = useRef<Map<string, string | null>>(new Map());
-  // PR 切换时清缓存
+  // Clear the cache on PR switch
   useEffect(() => {
     contentCacheRef.current = new Map();
   }, [prLocalId]);
 
-  // mount 时自动聚焦输入框，省一次点击
+  // Auto-focus the input on mount, saving a click
   const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     inputRef.current?.focus();
@@ -70,11 +70,11 @@ export function useDiffSearch(files: DiffChangedFile[], prLocalId: string) {
       void runSearch(token, q, caseSensitive, files, prLocalId, contentCacheRef.current, t)
         .then(({ results: r, partialError }) => {
           if (token !== sessionRef.current) return;
-          // 先显示带 <mark> 关键词高亮的纯文本结果 — 用户立刻能看到命中
+          // First show plain-text results with <mark> keyword highlight — the user sees matches immediately
           setResults(r);
           setError(partialError);
-          // 异步着色：Monaco colorize 按文件 language 串行执行；token 跟 session
-          // 关联，过期 session 不再 update state
+          // Async colorize: Monaco colorize runs serially per file language; token is tied to the session,
+          // a stale session no longer updates state
           void colorizeAll(r, token, sessionRef).then((colorized) => {
             if (token === sessionRef.current) setResults(colorized);
           });

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/zones/line-mapping.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/zones/line-mapping.ts
@@ -1,13 +1,14 @@
 import { type editor as MonacoEditor } from 'monaco-editor';
 
 /**
- * 统一(inline)视图下原始编辑器隐藏、删除行由 modified 编辑器以 view zone 呈现，故 old 侧评论/草稿
- * 不能再挂原始编辑器（会出现「大段空白、无内容」），须改挂 modified 编辑器。这里按 diff 行变更把
- * 「原始行号」映射成 modified 的 afterLineNumber：
- *  - 纯删除：删除块落在 modifiedStartLineNumber 之后 → 评论挂该行后；
- *  - 修改：对齐到 modified 块内对应行；
- *  - 上下文行（不在任何变更内）：按之前各变更的累计行数差平移。
- * diff 尚未计算（getLineChanges 为空）时退化为原行号 + 累计平移。
+ * In the unified (inline) view the original editor is hidden and deleted lines are presented by the modified editor
+ * as a view zone, so old-side comments/drafts can no longer mount on the original editor (would show "a large blank
+ * with no content") and must mount on the modified editor. This maps the "original line number" to the modified
+ * afterLineNumber per diff line change:
+ *  - pure deletion: the deletion block falls after modifiedStartLineNumber → comment mounts after that line;
+ *  - modification: align to the corresponding line within the modified block;
+ *  - context lines (not inside any change): shift by the cumulative line-count difference of prior changes.
+ * When the diff isn't computed yet (getLineChanges empty), falls back to the original line number + cumulative shift.
  */
 export function mapOriginalLineToModified(
   changes: readonly MonacoEditor.ILineChange[],
@@ -20,28 +21,28 @@ export function mapOriginalLineToModified(
     const mS = ch.modifiedStartLineNumber;
     const mE = ch.modifiedEndLineNumber;
     if (oE === 0) {
-      // 纯插入（原始侧无行）：仅当插入点在 origLine 之前才计入偏移
+      // Pure insertion (no line on the original side): count into the offset only when the insertion point is before origLine
       if (oS < origLine) delta += mE - mS + 1;
       continue;
     }
     if (oE < origLine) {
-      // 变更整体在 origLine 之前：累计 modified 与 original 的行数差
+      // The change is entirely before origLine: accumulate the line-count difference between modified and original
       const oCount = oE - oS + 1;
       const mCount = mE === 0 ? 0 : mE - mS + 1;
       delta += mCount - oCount;
       continue;
     }
     if (oS <= origLine && origLine <= oE) {
-      // origLine 落在本变更内
-      if (mE === 0) return mS; // 纯删除：删除块在 modified 行 mS 之后
-      return Math.min(mS + (origLine - oS), mE); // 修改：对齐 modified 块
+      // origLine falls within this change
+      if (mE === 0) return mS; // pure deletion: the deletion block is after modified line mS
+      return Math.min(mS + (origLine - oS), mE); // modification: align to the modified block
     }
-    break; // changes 有序，后续都在 origLine 之后
+    break; // changes is ordered, the rest are all after origLine
   }
   return origLine + delta;
 }
 
-/** 把 old 侧分桶按 diff 重映射到 modified 行号（统一视图用）。 */
+/** Remap old-side buckets to modified line numbers per diff (used in the unified view). */
 export function remapOldByLineToModified<T>(
   changes: readonly MonacoEditor.ILineChange[],
   oldByLine: Map<number, T[]>,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/zones/mountInlineZones.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/diff/zones/mountInlineZones.ts
@@ -4,30 +4,31 @@ import { editor as MonacoEditorNs, type editor as MonacoEditor } from 'monaco-ed
 import { remapOldByLineToModified } from './line-mapping';
 
 /**
- * 通用 Monaco 行内 view-zone 挂载机制：行内评论 zone 与草稿 zone 共用同一套管线——
- * 双层 `dom`/`inner` 结构、`stopPropagation` 事件接管、宽度 `applyInnerLayout`、横向滚动
- * `translateX` 同步、高度 `ResizeObserver` 回写、按视图把 old 侧映射到对应编辑器、`removeZone` /
- * `unmount` 清理。差异点（拦截哪些事件、初始高度估算、渲染什么组件）由 options 注入。
+ * Generic Monaco inline view-zone mount mechanism: the inline comment zone and draft zone share one pipeline —
+ * two-layer `dom`/`inner` structure, `stopPropagation` event takeover, width `applyInnerLayout`, horizontal-scroll
+ * `translateX` sync, height write-back via `ResizeObserver`, mapping the old side to the corresponding editor per view,
+ * `removeZone` / `unmount` cleanup. The differences (which events to intercept, initial height estimation, what component
+ * to render) are injected via options.
  *
- * 返回 cleanup 函数（在 effect 的 teardown 调）。评论 zone 额外的 glyph decorations 不在此处
- * 管理（由调用方 useCommentZones 自行 create / clear）。
+ * Returns a cleanup function (called in the effect's teardown). The comment zone's extra glyph decorations are not managed
+ * here (the caller useCommentZones creates / clears them itself).
  */
 export interface MountInlineZonesOptions<T> {
   diffEditor: MonacoEditor.IStandaloneDiffEditor;
   renderSideBySide: boolean;
-  /** old 侧（删除 / base 侧上下文行）分桶：key = 行号 */
+  /** Old-side (deleted / base-side context lines) buckets: key = line number */
   oldByLine: Map<number, T[]>;
-  /** new 侧（新增 / head 侧上下文行）分桶：key = 行号 */
+  /** New-side (added / head-side context lines) buckets: key = line number */
   newByLine: Map<number, T[]>;
-  /** monaco wrapper dom 的 class（'monaco-comment-zone' / 'monaco-draft-zone'） */
+  /** Class of the monaco wrapper dom ('monaco-comment-zone' / 'monaco-draft-zone') */
   zoneClassName: string;
-  /** 真实视觉容器 inner 的 class（'monaco-comment-zone-inner' / 'monaco-draft-zone-inner'） */
+  /** Class of the real visual container inner ('monaco-comment-zone-inner' / 'monaco-draft-zone-inner') */
   innerClassName: string;
-  /** dom + inner 上 stopPropagation 接管的事件集合（草稿含 keydown/wheel 等，评论仅鼠标点击类） */
+  /** Set of events stopPropagation takes over on dom + inner (drafts include keydown/wheel etc., comments only mouse-click kinds) */
   stopEvents: readonly string[];
-  /** 初始 zone 高度（px）估算；lineHeight 为 monaco 当前行高 */
+  /** Initial zone height (px) estimation; lineHeight is monaco's current line height */
   initialHeight: (items: T[], lineHeight: number) => number;
-  /** 渲染 zone 内容（React 节点） */
+  /** Render the zone content (React node) */
   render: (items: T[]) => ReactNode;
 }
 
@@ -59,17 +60,17 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
     const lineHeight = editorInst.getOption(MonacoEditorNs.EditorOption.lineHeight);
     editorInst.changeViewZones((accessor) => {
       for (const [line, items] of byLine) {
-        // 双层结构：dom 是 monaco wrapper（monaco 直接把 height inline 写到它上面），
-        // inner 是不受 monaco 控制的真实视觉容器 → inner.offsetHeight 才是真实内容高度。
+        // Two-layer structure: dom is the monaco wrapper (monaco writes height inline directly onto it),
+        // inner is the real visual container not controlled by monaco → inner.offsetHeight is the true content height.
         const dom = document.createElement('div');
         dom.className = zoneClassName;
 
-        // 经典 Monaco view zone 坑：editor 自带 mousedown listener 把整个 zone 区域当作
-        // "editor mouse target" 吞掉冒泡到 DOM 的事件 → zone 内 textarea 收不到 focus、button
-        // 点不响应。在 dom 容器上 stopPropagation 一组关键事件，让 monaco 不再接管 zone 内的
-        // user input。**必须是 bubble 阶段**（第三参数省略 / false）：capture 阶段拦截会在事件
-        // 到达 button/textarea 之前就阻断，React onClick / onKeyDown 根本不触发。bubble 阶段让
-        // target 上的 React handler 先 fire，再阻止冒泡到 editor。
+        // Classic Monaco view zone pitfall: the editor's built-in mousedown listener treats the whole zone area as
+        // an "editor mouse target" and swallows events bubbling to the DOM → the zone's textarea gets no focus, buttons
+        // don't respond to clicks. stopPropagation a set of key events on the dom container so monaco no longer takes over
+        // user input within the zone. **Must be the bubble phase** (third arg omitted / false): intercepting in the capture
+        // phase would block before the event reaches button/textarea, so React onClick / onKeyDown never fire. The bubble
+        // phase lets the target's React handler fire first, then stops the bubble to the editor.
         const stopAll = (e: Event): void => e.stopPropagation();
         for (const evt of stopEvents) {
           dom.addEventListener(evt, stopAll);
@@ -90,10 +91,10 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
         };
         const zoneId = accessor.addZone(zoneObj);
 
-        // 高度同步：直接 mutate zoneObj.heightInPx + layoutZone(id)。removeZone+addZone 在 textarea
-        // 拖拽 resize 时每帧调用会引起 zone 重建抖动。layoutZone 是轻量操作，先 mutate
-        // heightInPx 再 layoutZone 即可让 monaco 重新计算 viewModel whitespace。
-        // 用 inner.offsetHeight 测（dom 被 monaco 写死 height，offsetHeight 会自循环）。
+        // Height sync: directly mutate zoneObj.heightInPx + layoutZone(id). removeZone+addZone called every frame
+        // during textarea drag-resize causes zone-rebuild jitter. layoutZone is a lightweight operation; mutate
+        // heightInPx first then layoutZone to let monaco recompute the viewModel whitespace.
+        // Measure with inner.offsetHeight (dom's height is hard-set by monaco, so offsetHeight would self-loop).
         const syncHeight = (): void => {
           const next = inner.offsetHeight;
           if (next <= 0) return;
@@ -107,26 +108,27 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
             /* editor disposed */
           }
         };
-        // ResizeObserver 跟踪 inner 高度变化（read↔edit 切换、textarea resize、内嵌图片异步加载、
-        // 嵌套评论展开）。requestAnimationFrame 避开"回调里同步 layout 又触发 RO"循环。
+        // ResizeObserver tracks inner height changes (read↔edit switch, textarea resize, async loading of embedded images,
+        // nested comment expansion). requestAnimationFrame avoids the "sync layout in the callback re-triggers RO" loop.
         const ro = new ResizeObserver(() => {
           requestAnimationFrame(syncHeight);
         });
         ro.observe(inner);
-        // 多个时间点 sync 兜底覆盖布局抖动 / React 多阶段 render
+        // Sync at multiple points as a fallback covering layout jitter / React multi-phase render
         requestAnimationFrame(syncHeight);
         setTimeout(syncHeight, 50);
         setTimeout(syncHeight, 200);
 
-        // 宽度 + 位置策略（跟 Bitbucket / GitHub inline 评论对齐）：用 BoundingClientRect 拿浏览器
-        // 实际渲染坐标（clientWidth / layoutInfo.width 在 monaco inline 视图下偶发超出 editor 视觉
-        // 边界，实测评论框跨到 ChatPane 区域）。inner 从 dom 起点开始，最远延伸到 editor 视觉右边界
-        // - verticalScrollbar。dom 还没挂到 DOM 树时 rect.width=0，用 editor 左边界兜底。
+        // Width + position strategy (aligned with Bitbucket / GitHub inline comments): use BoundingClientRect to get the
+        // browser's actual render coordinates (clientWidth / layoutInfo.width occasionally exceed the editor's visual
+        // boundary in monaco inline view, observed the comment box spilling into the ChatPane area). inner starts at the
+        // dom origin and extends at most to the editor's visual right boundary - verticalScrollbar. When dom isn't yet
+        // attached to the DOM tree rect.width=0, fall back to the editor's left boundary.
         const editorDomNode = editorInst.getDomNode();
         const applyInnerLayout = (): void => {
           if (!editorDomNode) return;
           const editorRect = editorDomNode.getBoundingClientRect();
-          if (editorRect.width <= 0) return; // editor 还没 layout，等下次 trigger
+          if (editorRect.width <= 0) return; // editor not laid out yet, wait for the next trigger
           const domRect = dom.getBoundingClientRect();
           const sbW = editorInst.getLayoutInfo().verticalScrollbarWidth ?? 0;
           const innerLeft = domRect.width > 0 ? domRect.left : editorRect.left;
@@ -139,14 +141,14 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
           }
         };
         applyInnerLayout();
-        // 多个时间点兜底：切换文件 + autoEdit 跳转时 monaco 在算 diff / 文件 mount 还没完，
-        // getBoundingClientRect 给的不是稳定 layout（实测跳转新文件框宽度撑爆，resize 后恢复）。
+        // Multi-point fallback: on file switch + autoEdit jump, monaco is still computing the diff / the file mount isn't
+        // done, and getBoundingClientRect gives a non-stable layout (observed the box width blowing out when jumping to a new file, recovering after resize).
         requestAnimationFrame(applyInnerLayout);
         setTimeout(applyInnerLayout, 50);
         setTimeout(applyInnerLayout, 200);
         setTimeout(applyInnerLayout, 500);
-        // 双触发：onDidLayoutChange（几何变化）+ ResizeObserver 观察 editor DOM（窗口 / 分隔条
-        // resize），覆盖不重叠；onDidUpdateDiff（切文件后算 diff 时 layout 仍在变，算完才稳定）。
+        // Dual trigger: onDidLayoutChange (geometry change) + ResizeObserver watching the editor DOM (window / splitter
+        // resize), non-overlapping coverage; onDidUpdateDiff (after a file switch the layout still changes while the diff is computed, stabilizing only once done).
         const layoutDisp = editorInst.onDidLayoutChange(applyInnerLayout);
         const diffDisp = diffEditor.onDidUpdateDiff(() => requestAnimationFrame(applyInnerLayout));
         const editorRO = editorDomNode
@@ -154,17 +156,17 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
           : null;
         if (editorDomNode && editorRO) editorRO.observe(editorDomNode);
 
-        // 横向滚动同步：monaco view zone dom 在 .lines-content 内会跟 scrollLeft 一起左移
-        // （横滚后框被裁出 viewport）。给 inner 加 transform translateX(scrollLeft) 反向抵消，
-        // 框就 stick 在 viewport 内的相对位置不动（跟 Bitbucket / GitHub inline 评论一致）。
+        // Horizontal-scroll sync: the monaco view zone dom inside .lines-content shifts left along with scrollLeft
+        // (after horizontal scroll the box gets clipped out of the viewport). Adding transform translateX(scrollLeft)
+        // to inner cancels it out, so the box sticks at its relative position within the viewport (consistent with Bitbucket / GitHub inline comments).
         const applyScroll = (): void => {
           inner.style.transform = `translateX(${editorInst.getScrollLeft()}px)`;
         };
         applyScroll();
         const scrollDisp = editorInst.onDidScrollChange(applyScroll);
 
-        // inner 上也 stopPropagation 一份（双层防御）。**必须晚于 createRoot** —— 否则 React 18 在
-        // inner 上的 event delegation 初始化顺序受影响，导致 onClick 不 fire（取消按钮点了没反应）。
+        // Also stopPropagation on inner (two-layer defense). **Must be after createRoot** — otherwise React 18's event
+        // delegation initialization order on inner is affected, causing onClick not to fire (clicking the cancel button does nothing).
         for (const evt of stopEvents) {
           inner.addEventListener(evt, stopAll);
         }
@@ -173,8 +175,8 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
           editor: editorInst,
           zoneId,
           root,
-          // 先 disconnect ResizeObserver + dispose listener，再 unmount root，避免 unmount
-          // 引起的 DOM 高度回落触发观察回调 + layoutZone(disposed editor) 报错。
+          // Disconnect ResizeObserver + dispose listeners first, then unmount root, to avoid the DOM height collapse
+          // caused by unmount triggering the observer callback + a layoutZone(disposed editor) error.
           disposers: [
             () => ro.disconnect(),
             () => layoutDisp.dispose(),
@@ -187,8 +189,8 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
     });
   };
 
-  // 并排视图：old 侧挂原始编辑器；统一视图：原始编辑器隐藏，old 侧改挂 modified 编辑器对应行
-  // （删除行在统一视图是 modified 的 view zone，按 diff 行变更把原始行号映射到 modified afterLineNumber）。
+  // Side-by-side view: old side mounts on the original editor; unified view: the original editor is hidden, old side
+  // mounts on the modified editor's corresponding line (deleted lines are modified's view zone in the unified view, mapping the original line number to modified afterLineNumber per diff line change).
   if (renderSideBySide) {
     addZonesFor(originalEditor, oldByLine);
   } else if (oldByLine.size > 0) {
@@ -223,7 +225,7 @@ export function mountInlineZones<T>(opts: MountInlineZonesOptions<T>): () => voi
         }
       }
     }
-    // React 18+: unmount 不能在 render 阶段同步调，放微任务里
+    // React 18+: unmount can't be called synchronously in the render phase, defer it to a microtask
     queueMicrotask(() => {
       for (const z of zoneRefs) {
         try {

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/DraftZone.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/DraftZone.tsx
@@ -10,37 +10,37 @@ import { useDraftZone } from './useDraftZone';
 
 interface DraftZoneProps {
   draft: ReviewDraft;
-  /** 所属 PR 的 localId；草稿编辑框图片上传（attachmentsEnabled 时）需用它定位 PR 附件存储。 */
+  /** localId of the owning PR; the draft editor's image upload (when attachmentsEnabled) uses it to locate the PR attachment store. */
   prLocalId: string;
-  /** 平台是否支持图片附件上传（capabilities.commentAttachments）；为真才在草稿编辑框启用粘贴 / 选取上传。 */
+  /** Whether the platform supports image attachment upload (capabilities.commentAttachments); only when true does the draft editor enable paste / pick upload. */
   attachmentsEnabled?: boolean;
-  /** 评论换行策略（活动平台 commentHardBreaks）：决定预览是否启用 remark-breaks，使草稿预览 WYSIWYG。 */
+  /** Comment line-break policy (active platform commentHardBreaks): decides whether the preview enables remark-breaks, making the draft preview WYSIWYG. */
   hardBreaks: boolean;
   /**
-   * 注册 "进入编辑模式" 触发函数到外部 ref map。DiffView 调用注册的 fn 时本组件
-   * setIsEditing(true)。用 ref-based fn 而不是 props token，避免 trigger token 变化引发的
-   * unmount/mount 循环误触（详见 useDraftZone）。
+   * Register the "enter edit mode" trigger fn into an external ref map. When DiffView calls the
+   * registered fn, this component setIsEditing(true). Uses a ref-based fn instead of a props token to
+   * avoid unmount/mount cycle mis-triggers caused by trigger token changes (see useDraftZone).
    */
   registerEditTrigger?: (draftId: string, fn: (() => void) | null) => void;
-  /** 保存编辑后的 body。调用方走 IPC drafts:update。 */
+  /** Save the edited body. Caller goes through IPC drafts:update. */
   onSave: (newBody: string) => void | Promise<void>;
-  /** 删除本草稿。调用方走 IPC drafts:delete */
+  /** Delete this draft. Caller goes through IPC drafts:delete */
   onDelete: () => void | Promise<void>;
   /**
-   * 单条直接发布到远端。调用方走 drafts:publishBatch 传单元素 draftIds。
-   * 返回 ok=false 时 error 填人读错因，本组件渲染 inline 错误但不卸载 zone。
-   * 不传 = read 模式不渲染"发布"按钮。
+   * Publish a single draft directly to remote. Caller goes through drafts:publishBatch with a single-element draftIds.
+   * On ok=false, error carries a human-readable cause; this component renders an inline error but does not unmount the zone.
+   * Absent = read mode, does not render the "publish" button.
    */
   onPublish?: () => Promise<{ ok: boolean; error?: string }>;
 }
 
 /**
- * Diff 视图内联草稿编辑 zone。挂在 Monaco editor 的 view zone 里，由
- * `createRoot.render(<DraftZone ... />)` 渲染。read/edit/publish 状态机见 [useDraftZone](./useDraftZone.ts)；
- * 本组件只负责渲染。
+ * Inline draft editing zone inside the Diff view. Mounted in Monaco editor's view zone, rendered via
+ * `createRoot.render(<DraftZone ... />)`. read/edit/publish state machine see [useDraftZone](./useDraftZone.ts);
+ * this component only handles rendering.
  *
- * 视觉跟 CommentZone (远端评论 read-only) 区分：CommentZone 黄底 → 这里**蓝底 + DRAFT chip**；
- * posted 切绿底跟远端评论对齐；rejected 默认 css 隐藏（DiffView 端 .monaco-draft-zone-rejected）。
+ * Visually distinguished from CommentZone (remote comment, read-only): CommentZone yellow bg → here **blue bg + DRAFT chip**;
+ * posted switches to green bg to align with remote comments; rejected is hidden by default via css (DiffView side .monaco-draft-zone-rejected).
  */
 export function DraftZone({
   draft,
@@ -98,10 +98,10 @@ export function DraftZone({
         </span>
         {!isEditing && canEdit && (
           <div className="draft-zone-actions">
-            {/* 单条"发布"：仅 pending/edited 显示 (posted 已发完不再渲染按钮；
-                rejected 状态在 DiffView 端 CSS 隐藏整个 zone 不会走到这里)。
-                publishing 中按钮禁用，文案改"发布中…"；其它按钮也 disable 避免
-                同条草稿同时 save / delete / publish 多路并发 */}
+            {/* Single "publish": shown only for pending/edited (posted is already published so no button;
+                rejected state has its whole zone hidden by CSS on DiffView side, never reaches here).
+                While publishing the button is disabled, label changes to "publishing…"; other buttons also disable to avoid
+                concurrent save / delete / publish on the same draft */}
             {onPublish && (
               <button
                 type="button"
@@ -160,8 +160,8 @@ export function DraftZone({
             textareaRef={textareaRef}
           />
           <div className="draft-zone-edit-actions">
-            {/* 主按钮：有 onPublish 时是"发布" (先 auto-save 再 POST，跟取消的
-                auto-save 行为对齐避免双按钮冗余)；缺 onPublish 时退回"保存" */}
+            {/* Primary button: "publish" when onPublish is present (auto-save first, then POST, aligned with cancel's
+                auto-save behavior to avoid redundant dual buttons); falls back to "save" when onPublish is absent */}
             {onPublish ? (
               <button
                 type="button"

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/DraftsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/DraftsPanel.tsx
@@ -9,39 +9,39 @@ import { formatBackendError } from '../../../../../errors';
 import { useDraftsForPr } from '../../../../../stores/drafts-store';
 import { ConfirmModal } from '../../../../common';
 
-// posted 已不存在 (发布成功即删本地)，筛选项只保留 publishable / all / rejected
+// posted no longer exists (successful publish deletes the local draft), filters keep only publishable / all / rejected
 type Filter = 'all' | 'publishable' | 'rejected';
 
 interface DraftsPanelProps {
   pr: StoredPullRequest;
-  /** 点 anchor 跳 Diff 视图。父端 wire 到 pendingDiffNav (走 App 顶层) */
+  /** Click anchor to jump to Diff view. Parent wires to pendingDiffNav (goes through App top level) */
   onJumpToAnchor?: (draftId: string) => void;
-  /** 活动连接能力位；此处用 commentHardBreaks 决定草稿预览是否启用 remark-breaks。 */
+  /** Active connection capability bits; here commentHardBreaks decides whether the draft preview enables remark-breaks. */
   capabilities?: PlatformCapabilities;
-  /** 内容只读（decline / 不可参与归档 PR）：隐藏草稿的发布 / 删除操作，仅供浏览。 */
+  /** Content read-only (decline / archived PR that can't be participated in): hides draft publish / delete actions, browse only. */
   readOnly?: boolean;
 }
 
 /**
- * 草稿管理面板 (M4)。跟 CommentsPanel 同一个 tab 层级、视觉权重对齐 —— 一个看
- * 远端已发评论，一个看本地未发草稿，互补。
+ * Draft management panel (M4). Same tab level as CommentsPanel, aligned visual weight — one views
+ * remote published comments, the other views local unpublished drafts, complementary.
  *
- * 跟 DiffView 内嵌 DraftZone / PublishReviewModal 的关系：
- * - DraftZone：行内就地编辑，"看到代码 + 改"的主路径
- * - PublishReviewModal：一次性"批量发布"入口，全选默认 + 发布动作流
- * - DraftsPanel：常驻"草稿总览"，跨文件 + 跨 status 浏览 / 单条 actions
+ * Relationship with DiffView's embedded DraftZone / PublishReviewModal:
+ * - DraftZone: inline in-place editing, the main path of "see the code + edit"
+ * - PublishReviewModal: one-shot "batch publish" entry, select-all default + publish action flow
+ * - DraftsPanel: persistent "draft overview", browse across files + across status / single-item actions
  *
- * status 筛选默认落在"待发布" — 用户最关心还没发的那批；筛选切到"已发布"可
- * 检视本 PR 自己发出去的评论历史，"已拒绝"可恢复 (M4 暂未做 unreject UI)
+ * status filter defaults to "to-publish" — users care most about the not-yet-published batch; switching the filter to "published"
+ * lets you inspect this PR's own published comment history, "rejected" can be restored (M4 has no unreject UI yet)
  */
 export function DraftsPanel({ pr, onJumpToAnchor, capabilities, readOnly = false }: DraftsPanelProps) {
-  // 草稿预览换行：GitHub/Bitbucket hard-break；GitLab CommonMark 软换行。缺省回退 true。
+  // Draft preview line breaks: GitHub/Bitbucket hard-break; GitLab CommonMark soft break. Fallback true by default.
   const hardBreaks = capabilities?.commentHardBreaks ?? true;
   const { t } = useTranslation();
   const drafts = useDraftsForPr(pr.localId);
   const [filter, setFilter] = useState<Filter>('publishable');
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
-  // 多条草稿可能同时在发，用 Set 跟踪并发的 draftId 各自 disable / 文案
+  // Multiple drafts may be publishing at once; use a Set to track concurrent draftIds for per-item disable / label
   const [publishingIds, setPublishingIds] = useState<ReadonlySet<string>>(new Set());
   const [errors, setErrors] = useState<ReadonlyMap<string, string>>(new Map());
 
@@ -57,8 +57,8 @@ export function DraftsPanel({ pr, onJumpToAnchor, capabilities, readOnly = false
 
   const filtered = useMemo<ReviewDraft[]>(() => {
     const list = drafts ?? [];
-    // 排序：同文件按 startLine 升序 (跟代码自上而下阅读顺序一致)；不同文件按
-    // path 字典序 (跟文件树顺序对齐，扫起来不跳跃)
+    // Sort: within the same file by startLine ascending (matching top-to-bottom code reading order); across files by
+    // path lexicographic order (aligned with file-tree order, so scanning doesn't jump around)
     const sorted = list
       .slice()
       .sort((a, b) =>
@@ -105,9 +105,9 @@ export function DraftsPanel({ pr, onJumpToAnchor, capabilities, readOnly = false
           r?.error ? formatBackendError(r.error).title : t('draftsPanel.publishFailed'),
         );
       }
-      // 成功 → main 端直接删本地草稿 (不留 posted 历史)，broadcastDraftsChanged
-      // 让本面板重拉，被删的条目从列表里消失。远端评论由 force-refresh comments
-      // 拉回，在 CommentsPanel / DiffView CommentZone 看
+      // Success → main side deletes the local draft directly (no posted history kept), broadcastDraftsChanged
+      // makes this panel re-fetch, and the deleted item disappears from the list. The remote comment is pulled
+      // back by force-refresh comments, viewable in CommentsPanel / DiffView CommentZone
     } catch (e) {
       setError(draftId, e instanceof Error ? e.message : String(e));
     } finally {
@@ -120,8 +120,8 @@ export function DraftsPanel({ pr, onJumpToAnchor, capabilities, readOnly = false
     setConfirmDelete(null);
   };
 
-  // 草稿池正在 hydrate (首次进 PR) → 占位；fetched 后空数组才显示"无草稿"。
-  // 空态也包在 .drafts-panel 里让 flex:1 撑满横向，不变成"随内容缩"的小盒子
+  // Draft pool is hydrating (first entering the PR) → placeholder; only an empty array after fetch shows "no drafts".
+  // The empty state is also wrapped in .drafts-panel so flex:1 fills horizontally, rather than becoming a "shrink-to-content" small box
   if (drafts === null) {
     return (
       <div className="drafts-panel">
@@ -274,7 +274,7 @@ export function DraftsPanel({ pr, onJumpToAnchor, capabilities, readOnly = false
   );
 }
 
-// 状态/筛选项映射 i18n key（实际文案在组件内用 t() 解析，保持模块级表稳定）
+// Status/filter → i18n key mapping (actual text is resolved with t() inside the component, keeping the module-level table stable)
 const FILTER_LABEL_KEY: Record<Filter, string> = {
   publishable: 'draftsPanel.filterPublishable',
   all: 'draftsPanel.filterAll',

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/PublishReviewModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/PublishReviewModal.tsx
@@ -5,17 +5,17 @@ import { invoke } from '../../../../../api';
 import { formatBackendError } from '../../../../../errors';
 
 /**
- * 批量发布草稿到 Bitbucket 的确认 modal。M4 发布闭环最后一公里。
+ * Confirmation modal for batch-publishing drafts to Bitbucket. The last mile of the M4 publish loop.
  *
- * 流程：
- *   1. confirm: 列出本 PR 所有可发布草稿 (pending + edited)，用户可勾选 / 取消
- *   2. publishing: 调 drafts:publishBatch，main 端串行 POST 到 Bitbucket
- *   3. done: 显示成功 N 条 / 失败 M 条 + 每条失败明细
+ * Flow:
+ *   1. confirm: list all publishable drafts of this PR (pending + edited), user can check / uncheck
+ *   2. publishing: call drafts:publishBatch, main side serially POSTs to Bitbucket
+ *   3. done: show N succeeded / M failed + per-failure details
  *
- * - rejected 草稿不在列表里 (用户决断不发)
- * - posted 草稿不在列表里 (远端已经有，避免重复)
- * - 默认全部勾选 — 用户进 modal 已经表达"想发评论"的意图，全选符合多数场景；
- *   不想发的单条可取消
+ * - rejected drafts are not in the list (user decided not to publish)
+ * - posted drafts are not in the list (already on remote, avoid duplicates)
+ * - all checked by default — entering the modal already expresses the intent "want to publish comments", select-all fits most cases;
+ *   uncheck individual ones you don't want to publish
  */
 type Phase = 'confirm' | 'publishing' | 'done';
 
@@ -33,17 +33,17 @@ export function PublishReviewModal({
   onJumpToAnchor,
 }: {
   localId: string;
-  /** 本 PR 全部草稿；modal 自己过滤出 publishable (pending + edited) */
+  /** All drafts of this PR; the modal itself filters out publishable ones (pending + edited) */
   drafts: ReadonlyArray<ReviewDraft>;
   onClose: () => void;
   /**
-   * 用户点 anchor (path:line) 时调用。父端通常实现为：关闭 modal + 触发 Diff
-   * 跳转到该草稿位置 (复用 pendingDiffNav 链路)。不传则 anchor 不可点
+   * Called when the user clicks an anchor (path:line). Parent typically implements: close the modal + trigger Diff
+   * jump to that draft's position (reusing the pendingDiffNav link). Absent means the anchor is not clickable
    */
   onJumpToAnchor?: (draftId: string) => void;
 }) {
   const { t } = useTranslation();
-  // 列表用快照：进入 modal 时定下，避免 drafts 变动 (其它窗口编辑) 把当前选择洗掉
+  // List snapshot: fixed on entering the modal, to avoid drafts changes (edits from other windows) washing out the current selection
   const candidates = useMemo<ReviewDraft[]>(
     () => drafts.filter((d) => d.status === 'pending' || d.status === 'edited'),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -54,7 +54,7 @@ export function PublishReviewModal({
   const [results, setResults] = useState<PublishResult[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  // Esc 关闭 (publishing 阶段禁用避免误中断；done 阶段允许)
+  // Esc to close (disabled during publishing phase to avoid accidental interruption; allowed in done phase)
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape' && phase !== 'publishing') onClose();
@@ -97,8 +97,8 @@ export function PublishReviewModal({
   const okCount = results.filter((r) => r.ok).length;
   const failCount = results.length - okCount;
 
-  // 进入时本 PR 没有 publishable 草稿 → 直接显示空态 (理论上 header 按钮 disabled
-  // 时不会触发开 modal，但作 fallback)
+  // On entry this PR has no publishable drafts → show the empty state directly (in theory the header button is disabled
+  // so it won't trigger opening the modal, but kept as a fallback)
   if (candidates.length === 0) {
     return (
       <div className="modal-backdrop" onClick={onClose}>
@@ -170,8 +170,8 @@ export function PublishReviewModal({
                           onChange={() => toggle(d.id)}
                         />
                         <div className="publish-review-item-meta">
-                          {/* anchor 可点 → 关 modal + 跳 Diff；checkbox label 是 outer，
-                              这里 stopPropagation 防 click 触发勾选切换 */}
+                          {/* anchor is clickable → close modal + jump to Diff; the checkbox label is outer,
+                              stopPropagation here prevents the click from triggering a check toggle */}
                           {onJumpToAnchor ? (
                             <button
                               type="button"

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/useDraftZone.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/drafts/useDraftZone.ts
@@ -12,11 +12,11 @@ export interface UseDraftZoneParams {
 }
 
 /**
- * Diff 内联草稿 zone 的 read/edit/publish 状态机。把全部 state / ref / effect / handler 收敛于此，
- * DraftZone 组件只消费返回值做渲染。
+ * read/edit/publish state machine for the Diff inline draft zone. Converges all state / ref / effect / handler here,
+ * the DraftZone component only consumes the return value to render.
  *
- * 取消四档逻辑（runCancelLogic）被取消按钮 / unmount cleanup / Esc 三处共用，全靠 ref 读最新值，
- * 保持「三处行为完全一致」的现有约定 —— 整体留在 hook 内，调用点都指向同一函数。
+ * The four-branch cancel logic (runCancelLogic) is shared by the cancel button / unmount cleanup / Esc, all reading the latest
+ * value via refs, keeping the existing convention that "all three behave identically" — kept entirely inside the hook, with all call sites pointing to the same function.
  */
 export function useDraftZone({
   draft,
@@ -34,7 +34,7 @@ export function useDraftZone({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Ref 跟踪最新 state / props，供 unmount cleanup 闭包同步读
+  // Refs track the latest state / props, for synchronous reads inside the unmount cleanup closure
   const editingBodyRef = useRef(editingBody);
   const isEditingRef = useRef(isEditing);
   const draftBodyRef = useRef(draft.body);
@@ -48,19 +48,19 @@ export function useDraftZone({
     draftBodyRef.current = draft.body;
   }, [draft.body]);
 
-  // 显式 mutate 标记 — 区分 "用户主动操作触发 unmount" vs "切换文件触发 unmount"。
-  // 设计：mutate 入口设 true (handleSave/Cancel/Delete 各种路径)；进 edit 时重置
-  // false (new editing session 没显式意图)。**不在 finally 清** — 因为 mutate IPC
-  // 完成跟 drafts:changed 引发的 unmount 时序不可控，清得太早会让 cleanup 误判。
-  // 锁的生命周期跟随 component instance：mutate 后保留 true 直到 unmount 或下次进
-  // edit 时被重置
+  // Explicit mutate flag — distinguishes "user-initiated action triggers unmount" vs "file switch triggers unmount".
+  // Design: set true at mutate entries (handleSave/Cancel/Delete various paths); reset to false when entering edit
+  // (a new editing session has no explicit intent). **Not cleared in finally** — because the timing between mutate IPC
+  // completion and the unmount caused by drafts:changed is uncontrollable, clearing too early would make cleanup misjudge.
+  // The lock's lifecycle follows the component instance: after mutate it stays true until unmount or the next entry
+  // into edit resets it
   const isMutatingRef = useRef(false);
   useEffect(() => {
     if (isEditing) isMutatingRef.current = false;
   }, [isEditing]);
 
-  // 统一的 cancel 四档逻辑 — handleCancel / unmount cleanup / Esc 共用
-  // (避免三个地方分别实现引起行为漂移)。读 ref 拿最新值，支持 fire-and-forget
+  // Unified four-branch cancel logic — shared by handleCancel / unmount cleanup / Esc
+  // (avoids behavior drift from implementing it separately in three places). Reads refs for the latest value, supports fire-and-forget
   const runCancelLogic = (): void => {
     const editing = editingBodyRef.current.trim();
     const persisted = draftBodyRef.current.trim();
@@ -69,7 +69,7 @@ export function useDraftZone({
       return;
     }
     if (!editing) {
-      // 空 + 有 → revert (unmount 时 no-op，state 已销毁；handleCancel 时设 state)
+      // empty + has persisted → revert (no-op on unmount, state already destroyed; sets state on handleCancel)
       setEditingBody(draftBodyRef.current);
       setIsEditing(false);
       return;
@@ -83,23 +83,23 @@ export function useDraftZone({
     setIsEditing(false);
   };
 
-  // unmount cleanup — 切换文件 / PR / tab 触发。跟取消按钮共用 runCancelLogic 让
-  // 行为完全一致。isMutating=true 时跳过 (用户已经显式 mutate 接管，不需要 cleanup
-  // 兜底，避免跟 IPC 形成 race)
+  // unmount cleanup — triggered by switching file / PR / tab. Shares runCancelLogic with the cancel button so
+  // behavior is fully identical. Skipped when isMutating=true (the user has explicitly taken over via mutate, no cleanup
+  // fallback needed, avoiding a race with IPC)
   useEffect(() => {
     return () => {
       if (isMutatingRef.current) return;
       if (!isEditingRef.current) return;
       runCancelLogic();
     };
-    // 空 deps：mount/unmount 跑；runCancelLogic 内部全 ref 读，无 closure 失效问题
+    // empty deps: runs on mount/unmount; runCancelLogic reads all refs internally, no closure staleness issue
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 把 "进入编辑模式" 触发器注册到 DiffView 的 ref map。register 是稳定函数引用
-  // (DiffView 用 useCallback 包)，draft.id 不变 → effect 只在 mount/unmount 跑。
-  // 调用 fn 不引发 React state change in DiffView side → 没有 re-render → 没有
-  // unmount/mount 循环，进 edit 一次只一次
+  // Register the "enter edit mode" trigger into DiffView's ref map. register is a stable function reference
+  // (DiffView wraps it with useCallback), draft.id doesn't change → effect only runs on mount/unmount.
+  // Calling fn does not cause a React state change on the DiffView side → no re-render → no
+  // unmount/mount cycle, entering edit happens exactly once
   useEffect(() => {
     registerEditTrigger?.(draft.id, () => {
       setIsEditing(true);
@@ -108,12 +108,12 @@ export function useDraftZone({
     return () => registerEditTrigger?.(draft.id, null);
   }, [draft.id, registerEditTrigger]);
 
-  // draft.body 外部变化 (e.g., 队列写回) + 当前非 editing → 同步 editingBody
+  // draft.body changed externally (e.g., queue write-back) + currently not editing → sync editingBody
   useEffect(() => {
     if (!isEditing) setEditingBody(draft.body);
   }, [draft.body, isEditing]);
 
-  // 进入 edit 时 focus + 光标到末尾
+  // On entering edit, focus + move cursor to end
   useEffect(() => {
     if (isEditing && textareaRef.current) {
       const el = textareaRef.current;
@@ -122,11 +122,11 @@ export function useDraftZone({
     }
   }, [isEditing]);
 
-  // textarea 的 React onKeyDown 在 React 18 root delegation 下走 bubble 阶段，
-  // monaco 在 editor container 上的 capture-stage keydown listener 可能在事件
-  // 冒泡前就 stopPropagation 吞掉 Esc，导致 textarea 的 onKeyDown 永远不触发。
-  // 兜底：window 顶层 capture listener，textarea focus 时按 Esc 走 runCancelLogic
-  // (跟取消按钮 / unmount cleanup 共用) + 设 isMutatingRef=true 让 cleanup 跳过
+  // textarea's React onKeyDown runs in the bubble phase under React 18 root delegation,
+  // and monaco's capture-stage keydown listener on the editor container may stopPropagation and swallow Esc
+  // before the event bubbles, so textarea's onKeyDown never fires.
+  // Fallback: a window-level capture listener, when textarea is focused pressing Esc runs runCancelLogic
+  // (shared with the cancel button / unmount cleanup) + sets isMutatingRef=true so cleanup skips
   useEffect(() => {
     if (!isEditing) return;
     const onKey = (e: KeyboardEvent): void => {
@@ -139,23 +139,23 @@ export function useDraftZone({
     };
     window.addEventListener('keydown', onKey, true);
     return () => window.removeEventListener('keydown', onKey, true);
-    // runCancelLogic 是局部 fn，不放 deps；isEditing 切回时移除 listener
+    // runCancelLogic is a local fn, not in deps; the listener is removed when isEditing switches back
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditing]);
 
   const status = draft.status;
-  // posted 不应该再被编辑；UI 上隐藏编辑/删除按钮，整体灰显
+  // posted should no longer be editable; UI hides edit/delete buttons and greys the whole thing out
   const canEdit = status !== 'posted';
 
   const trimmedEditing = editingBody.trim();
-  // 评论不能为空：trim 后无字符不允许保存。提交按钮 disabled + 按钮 title 解释
+  // Comment cannot be empty: no characters after trim disallows saving. Submit button disabled + button title explains
   const canSave = trimmedEditing.length > 0;
 
   const handleSave = async (): Promise<void> => {
     if (saving) return;
-    if (!canSave) return; // 防御：除按钮 disabled 外双保险
+    if (!canSave) return; // defensive: double safeguard beyond the button being disabled
     if (trimmedEditing === draft.body.trim()) {
-      // 没改 → 退回 read 不调 IPC
+      // unchanged → fall back to read without calling IPC
       setIsEditing(false);
       return;
     }
@@ -163,16 +163,16 @@ export function useDraftZone({
     setSaving(true);
     try {
       await onSave(editingBody);
-      // 等 store 事件回来后 draft.body 更新，但乐观先退出 edit；体感更顺
+      // draft.body updates after the store event comes back, but optimistically exit edit first; feels smoother
       setIsEditing(false);
     } finally {
       setSaving(false);
     }
   };
 
-  // 单条直接发布。仅 pending/edited 可发；body 空也不发 (Bitbucket 拒绝空评论)。
-  // 不弹 confirm — 单条评论的"发布"心智跟"批量评审"不同，是即时操作；要二次
-  // 确认放在批量入口的 PublishReviewModal 那一层做就够了
+  // Publish a single draft directly. Only pending/edited are publishable; empty body is not published either (Bitbucket rejects empty comments).
+  // No confirm popup — the "publish" mental model for a single comment differs from "batch review", it's an instant action; the
+  // second confirmation is enough done at the PublishReviewModal layer, the batch entry
   const handlePublish = async (): Promise<void> => {
     if (!onPublish || publishing) return;
     if (status === 'posted' || status === 'rejected') return;
@@ -187,8 +187,8 @@ export function useDraftZone({
           res.error ? formatBackendError(res.error).title : t('draftZone.publishFailed'),
         );
       }
-      // 成功 → drafts-store 广播让 status 切到 'posted'，组件自动 re-render 显示
-      // posted chip + 远端 id。无需手动 setIsEditing 之类，draft prop 流推回
+      // Success → drafts-store broadcast switches status to 'posted', the component auto re-renders to show
+      // the posted chip + remote id. No manual setIsEditing etc. needed, the draft prop flow pushes it back
     } catch (e) {
       setPublishError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -196,19 +196,19 @@ export function useDraftZone({
     }
   };
 
-  // edit 模式的"发布" — 先 save 当前 textarea 内容到本地，再调 publish。
-  // 设计动机：取消按钮已经有 dirty auto-save 语义，独立的"保存"按钮反而冗余；
-  // 用户在 edit 改完最自然的下一步是发布，合并一次点击。
-  // - 保存失败 (本地写盘几乎不会) → 仍尝试发布；publish 端读盘拿到的是 main 上
-  //   一次成功的 body，对用户没有静默错误风险
-  // - 发布失败 (Bitbucket 4xx) → 留在 edit 让用户改 body 重试，inline error 提示
+  // "publish" in edit mode — save the current textarea content locally first, then call publish.
+  // Design motivation: the cancel button already has dirty auto-save semantics, a standalone "save" button is redundant;
+  // after editing, the most natural next step is to publish, so merge into one click.
+  // - Save failure (local disk write almost never fails) → still attempt publish; what the publish side reads from disk is the
+  //   last successfully saved body on main, no silent-error risk to the user
+  // - Publish failure (Bitbucket 4xx) → stay in edit so the user can edit body and retry, with an inline error hint
   const handlePublishFromEdit = async (): Promise<void> => {
     if (!onPublish || publishing) return;
     if (!canSave) return;
     isMutatingRef.current = true;
     setPublishError(null);
-    // 先持久化本次 editing 内容 — onPublish 通过 main store 读盘拿 body，必须
-    // 保证盘上是用户刚改的最新版本
+    // Persist this editing content first — onPublish reads the body from disk via the main store, so we must
+    // ensure disk holds the latest version the user just edited
     if (editingBody !== draft.body) {
       setSaving(true);
       try {
@@ -235,10 +235,10 @@ export function useDraftZone({
   };
 
   const handleCancel = async (): Promise<void> => {
-    // 取消复用 runCancelLogic (跟 unmount cleanup 共用)。区别：handleCancel 主动
-    // 设 isMutatingRef=true (用户显式操作)，让 cleanup 知道意图已被接管
+    // Cancel reuses runCancelLogic (shared with unmount cleanup). Difference: handleCancel actively
+    // sets isMutatingRef=true (explicit user action), letting cleanup know the intent has been taken over
     isMutatingRef.current = true;
-    // 内部 dirty 分支需要 await save 才退 edit，单独走一遍含 await 的版本：
+    // The internal dirty branch needs to await save before exiting edit, so run a separate awaited version:
     const editingTrim = editingBody.trim();
     const persistedTrim = draft.body.trim();
     if (!editingTrim && !persistedTrim) {
@@ -264,8 +264,8 @@ export function useDraftZone({
   };
 
   const handleDelete = (): void => {
-    // body 非空（含编辑中的草稿）→ 弹 ConfirmModal 二次确认；空草稿直接删。
-    // edit 模式下用 editingBody 判（用户可能在 textarea 输入很多还没保存就点删除）
+    // body non-empty (including a draft being edited) → pop ConfirmModal for a second confirmation; empty draft deletes directly.
+    // In edit mode judge by editingBody (the user may have typed a lot in the textarea unsaved before clicking delete)
     const currentBody = (isEditing ? editingBody : draft.body).trim();
     if (currentBody) {
       setConfirmDelete(true);
@@ -284,7 +284,7 @@ export function useDraftZone({
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     if (e.nativeEvent.isComposing) return;
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-      // Cmd/Ctrl+Enter 优先走"发布" (跟新的主按钮一致)；onPublish 缺失场景退回保存
+      // Cmd/Ctrl+Enter prefers "publish" (consistent with the new primary button); falls back to save when onPublish is absent
       e.preventDefault();
       if (onPublish) {
         void handlePublishFromEdit();
@@ -297,12 +297,12 @@ export function useDraftZone({
     }
   };
 
-  // 取消按钮动态文案：textarea 有内容 → "暂存"，明示点击不丢内容；textarea
-  // 完全空 → "取消"，对应"退出 edit 不留草稿"的语义 (runCancelLogic 此时会删
-  // 真空草稿 / revert)。
-  // 不再用"dirty (editing != persisted)"作判据 — 用户进 edit 看到已存的旧内容
-  // 没改也"有文字"，按用户心智应该是暂存 (即使内部走 no-op 直接退出 edit)
-  // textarea 有内容 → 暂存语义；空 → 取消语义。stash 标志驱动按钮文案与 title
+  // Cancel button dynamic label: textarea has content → "stash", signaling the click won't lose content; textarea
+  // completely empty → "cancel", corresponding to the "exit edit without leaving a draft" semantics (runCancelLogic then deletes
+  // the truly empty draft / reverts).
+  // No longer uses "dirty (editing != persisted)" as the criterion — a user entering edit and seeing existing saved content
+  // without changing it still "has text", and per the user's mental model this should be stash (even if internally it's a no-op exit of edit)
+  // textarea has content → stash semantics; empty → cancel semantics. The stash flag drives the button label and title
   const isStash = trimmedEditing.length > 0;
   const cancelLabel = isStash ? t('draftZone.stash') : t('common.cancel');
 

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/CommentMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/CommentMarkdown.tsx
@@ -6,12 +6,12 @@ import { remarkEmojiShortcodes } from '../../../../../lib/remark-emoji';
 import { transformBitbucketUrl } from '../../../../common';
 
 /**
- * 评论正文 markdown 渲染样板：评论/活动 tab 与 diff 行内评论 zone 共用同一套
- * remark / rehype / urlTransform 配置，仅 `components`（各自的 img / a / mermaid 覆盖）与外层
- * `className`（`pr-comment-body` / `comment-zone-body`）由调用方传入，互不收敛。
+ * Comment body markdown rendering boilerplate: the comments/activity tab and the diff inline comment zone share the same
+ * remark / rehype / urlTransform config, only `components` (each's img / a / mermaid overrides) and the outer
+ * `className` (`pr-comment-body` / `comment-zone-body`) are passed in by the caller, kept independent.
  *
- * hardBreaks（Bitbucket / GitHub）挂 remarkBreaks 让单 `\n` → `<br>`；GitLab 走标准 CommonMark
- * （单 `\n` = 空格）不挂，与各自 web 渲染对齐。
+ * hardBreaks (Bitbucket / GitHub) attaches remarkBreaks to turn a single `\n` → `<br>`; GitLab uses standard CommonMark
+ * (single `\n` = space) and doesn't attach it, aligned with each's web rendering.
  */
 export function CommentMarkdown({
   body,

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/MentionTextarea.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/MentionTextarea.tsx
@@ -3,23 +3,23 @@ import { useTranslation } from 'react-i18next';
 import type { PlatformUser } from '@meebox/shared';
 import { ImageIcon } from '../../../../common';
 
-/** 弹出候选最多展示条数（候选源本就是 PR 参与者的有界集合，再截断以免列表过长）。 */
+/** Max number of suggestions shown in the popup (the source is already a bounded set of PR participants; truncate further to keep the list from growing too long). */
 const MAX_SUGGESTIONS = 8;
 
 interface MentionMenu {
-  /** `@` 之后已输入的查询串（不含 `@`）。 */
+  /** Query string typed after `@` (excluding `@`). */
   query: string;
-  /** `@` 在 value 中的下标（替换插入时的起点）。 */
+  /** Index of `@` in value (start point for replacement insertion). */
   at: number;
-  /** 过滤后的候选。 */
+  /** Filtered suggestions. */
   items: PlatformUser[];
-  /** 当前高亮项下标。 */
+  /** Index of the currently highlighted item. */
   index: number;
 }
 
 /**
- * 解析光标前文本里正在输入的 `@提及` token：返回 `@` 位置与查询串，否则 null。
- * 触发条件：`@` 紧跟在行首 / 空白 / 左括号之后，其后是「非空白非 @」串（用户名允许 . - _）。
+ * Parse the `@mention` token being typed in the text before the cursor: return the `@` position and query string, otherwise null.
+ * Trigger condition: `@` immediately follows the line start / whitespace / an opening paren, followed by a "non-whitespace non-@" string (usernames allow . - _).
  */
 function parseMention(value: string, caret: number): { at: number; query: string } | null {
   const before = value.slice(0, caret);
@@ -30,12 +30,12 @@ function parseMention(value: string, caret: number): { at: number; query: string
 }
 
 /**
- * 评论编辑用 textarea，叠加 `@提及` 自动补全。候选由调用方传入（PR 参与者 + 评论作者等**已加载**的
- * 有界集合，不向远端枚举全员，见 docs/arch/01-platform/01-adapter）；输入 `@` 后按查询串就地过滤、↑↓ 选择、Enter/Tab 确认、
- * Esc 关闭。补全仅为便利——用户仍可自由手打任意 `@name`，平台据文本自行解析通知。
+ * Comment-editing textarea overlaid with `@mention` autocomplete. Suggestions are passed in by the caller (a bounded set of **already loaded**
+ * PR participants + comment authors etc., not an enumeration of all remote members, see docs/arch/01-platform/01-adapter); after typing `@` filter in place by the query string, ↑↓ to select, Enter/Tab to confirm,
+ * Esc to close. Autocomplete is only a convenience — users can still freely type any `@name` by hand, and the platform parses notifications from the text itself.
  *
- * 弹层打开时拦截 ↑↓/Enter/Tab/Esc 用于候选导航，其余按键（含 Cmd/Ctrl+Enter 发送、Esc 取消）冒泡给
- * 调用方的 onKeyDown；弹层关闭时所有按键都交给 onKeyDown。
+ * While the popup is open, ↑↓/Enter/Tab/Esc are intercepted for suggestion navigation; other keys (including Cmd/Ctrl+Enter to send, Esc to cancel) bubble up to
+ * the caller's onKeyDown; while the popup is closed all keys go to onKeyDown.
  */
 export function MentionTextarea({
   value,
@@ -56,8 +56,8 @@ export function MentionTextarea({
   candidates: PlatformUser[];
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   /**
-   * 粘贴图片时的上传回调：上传成功返回可插入的 markdown（否则 null）。提供时启用图片粘贴上传
-   * （平台 commentAttachments 能力为真才由调用方传入）。上传期间禁用输入，避免 value 漂移。
+   * Upload callback for pasted images: returns insertable markdown on success (otherwise null). When provided, enables image paste upload
+   * (the caller only passes it when the platform's commentAttachments capability is true). Input is disabled during upload to avoid value drift.
    */
   onUpload?: (file: File) => Promise<string | null>;
   placeholder?: string;
@@ -67,8 +67,8 @@ export function MentionTextarea({
   autoFocus?: boolean;
   ariaLabel?: string;
   /**
-   * 可选：把内部 textarea 元素回传给调用方 ref（与组件内部 ref 并存）。供调用方做外部 focus /
-   * 焦点判定（如 DraftZone 进入编辑态聚焦、Esc 命中判定）。不传则仅组件内部使用。
+   * Optional: pass the internal textarea element back to the caller's ref (coexists with the component's internal ref). Lets the caller do external focus /
+   * focus checks (e.g. DraftZone focusing on entering edit mode, Esc hit testing). If omitted, used only internally by the component.
    */
   textareaRef?: React.MutableRefObject<HTMLTextAreaElement | null>;
 }) {
@@ -79,7 +79,7 @@ export function MentionTextarea({
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
-  // 候选去重（按 name），保序：调用方可能混入重复参与者 / 评论作者。
+  // Dedupe suggestions (by name), preserving order: the caller may mix in duplicate participants / comment authors.
   const pool = useMemo(() => {
     const seen = new Set<string>();
     const out: PlatformUser[] = [];
@@ -120,7 +120,7 @@ export function MentionTextarea({
     const next = value.slice(0, menu.at) + insert + value.slice(end);
     onChange(next);
     setMenu(null);
-    // 插入后把光标放到补全文本之后
+    // After insertion, place the cursor after the completed text
     const caret = menu.at + insert.length;
     requestAnimationFrame(() => {
       const el = ref.current;
@@ -158,7 +158,7 @@ export function MentionTextarea({
     onKeyDown?.(e);
   };
 
-  // 上传一张图片并把返回的 markdown 插入当前光标处（无焦点时插到末尾）。粘贴 / 点附件按钮共用。
+  // Upload one image and insert the returned markdown at the current cursor (append to end when unfocused). Shared by paste / clicking the attach button.
   const uploadAndInsert = (file: File): void => {
     if (!onUpload || uploading) return;
     const at = ref.current?.selectionStart ?? value.length;
@@ -179,7 +179,7 @@ export function MentionTextarea({
         });
       })
       .catch((e: unknown) => {
-        // 上传失败（平台拒绝 / 网络等）：就地提示，不让 rejection 逃逸成未处理异常。
+        // Upload failed (platform rejection / network etc.): show inline, don't let the rejection escape as an unhandled exception.
         setUploadError(e instanceof Error ? e.message : String(e));
       })
       .finally(() => setUploading(false));
@@ -199,7 +199,7 @@ export function MentionTextarea({
   const pickFile = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const file = e.target.files?.[0];
     if (file) uploadAndInsert(file);
-    e.target.value = ''; // 复位：同一文件可再次选取触发 change
+    e.target.value = ''; // Reset: allow the same file to be selected again to trigger change
   };
 
   return (
@@ -271,7 +271,7 @@ export function MentionTextarea({
                 role="option"
                 aria-selected={i === menu.index}
                 className={`mention-option${i === menu.index ? ' mention-option-active' : ''}`}
-                // mousedown 而非 click：抢在 textarea blur（关闭弹层）之前选中
+                // mousedown rather than click: select before the textarea blur (which closes the popup)
                 onMouseDown={(e) => {
                   e.preventDefault();
                   select(u);

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/ReactionBar.tsx
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/ReactionBar.tsx
@@ -10,13 +10,13 @@ import {
 import { SmilePlusIcon } from '../../../../common';
 import { invoke } from '../../../../../api';
 
-/** 弹层估算尺寸（用于自适应翻转 / 视口夹取的占位计算；实际尺寸由内容决定）。 */
+/** Estimated popup size (used for adaptive flip / viewport-clamp placeholder calculations; actual size is determined by content). */
 const MENU_SIZE = {
   fixed: { w: 264, h: 48 },
   free: { w: 244, h: 232 },
 } as const;
 
-/** 据触发按钮位置 + 视口空间算弹层 fixed 坐标：下方空间不足且上方更宽裕则上翻；水平按视口夹取。 */
+/** Compute the popup's fixed coordinates from the trigger button position + viewport space: flip up when there's insufficient space below and more room above; clamp horizontally to the viewport. */
 function computeMenuPos(rect: DOMRect, mode: 'fixed' | 'free'): { top: number; left: number } {
   const margin = 6;
   const { w, h } = MENU_SIZE[mode];
@@ -28,8 +28,8 @@ function computeMenuPos(rect: DOMRect, mode: 'fixed' | 'free'): { top: number; l
 }
 
 /**
- * 评论 emoji 反应的共享状态 + 切换逻辑。切换经 `comments:toggleReaction` 写远端，成功后 main 广播
- * comments:changed → 评论列表重拉刷新（不维护本地乐观态，与编辑/删除一致）。busy 期间禁用避免重复点击。
+ * Shared state + toggle logic for comment emoji reactions. Toggling writes remotely via `comments:toggleReaction`; on success main broadcasts
+ * comments:changed → the comment list refetches and refreshes (no local optimistic state, consistent with edit/delete). Disabled during busy to avoid duplicate clicks.
  */
 export function useReactions(
   prLocalId: string,
@@ -38,7 +38,7 @@ export function useReactions(
 ): { reactions: PrReaction[]; busy: boolean; toggle: (emoji: string, add: boolean) => void } {
   const [busy, setBusy] = useState(false);
   const reactions = comment.reactions ?? [];
-  // GitHub 据 kind 选 issue / review 反应端点；其余平台忽略。anchor 兜底（旧数据无 kind）。
+  // GitHub picks the issue / review reaction endpoint by kind; other platforms ignore it. anchor is the fallback (old data has no kind).
   const kind: 'summary' | 'inline' = comment.kind ?? (comment.anchor ? 'inline' : 'summary');
   const toggle = useCallback(
     (emoji: string, add: boolean): void => {
@@ -52,7 +52,7 @@ export function useReactions(
         add,
       })
         .catch(() => {
-          // 失败静默：列表不会因 comments:changed 刷新出新反应，状态保持原样
+          // Silent on failure: the list won't refresh a new reaction via comments:changed, state stays as-is
         })
         .finally(() => setBusy(false));
     },
@@ -61,7 +61,7 @@ export function useReactions(
   return { reactions, busy, toggle };
 }
 
-/** 已有反应的展示条：emoji + 计数，本人反应高亮，点击切换。无反应则不渲染。 */
+/** Display bar for existing reactions: emoji + count, own reactions highlighted, click to toggle. Not rendered when there are no reactions. */
 export function ReactionChips({
   reactions,
   busy,
@@ -95,8 +95,8 @@ export function ReactionChips({
 }
 
 /**
- * 「加反应」按钮 + 弹出选择器。放在评论操作按钮行内（Reply/Edit 之后）。点击切换弹层，点击弹层外部 /
- * Esc 收起（非模态）。fixed 模式（GitHub）列固定 8 种；free 模式（GitLab/Bitbucket）列精选集 + 搜索。
+ * "Add reaction" button + popup picker. Placed inline in the comment action button row (after Reply/Edit). Click to toggle the popup, click outside the popup /
+ * Esc to dismiss (non-modal). fixed mode (GitHub) lists a fixed 8; free mode (GitLab/Bitbucket) lists a curated set + search.
  */
 export function ReactionAddButton({
   reactions,
@@ -115,7 +115,7 @@ export function ReactionAddButton({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
-  // 据触发按钮位置定位弹层；开启时及滚动 / 缩放时重算（弹层走 portal + fixed，故跟随而不被裁切）。
+  // Position the popup by the trigger button; recompute on open and on scroll / resize (the popup uses portal + fixed, so it follows without being clipped).
   useLayoutEffect(() => {
     if (!open) return;
     const place = (): void => {
@@ -131,7 +131,7 @@ export function ReactionAddButton({
     };
   }, [open, mode]);
 
-  // 点击弹层 / 触发按钮以外 / Esc 收起（非模态：不加遮罩、不拦其它交互）。
+  // Click outside the popup / trigger button, or Esc, dismisses (non-modal: no overlay, doesn't block other interactions).
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent): void => {
@@ -201,7 +201,7 @@ export function ReactionAddButton({
   );
 }
 
-/** free 模式选择器：搜索框 + 精选 emoji 网格（按关键词 / shortcode 过滤）。 */
+/** free mode picker: search box + curated emoji grid (filter by keyword / shortcode). */
 function FreeReactionPicker({
   busy,
   mineOf,
@@ -213,7 +213,7 @@ function FreeReactionPicker({
 }) {
   const { t } = useTranslation();
   const [q, setQ] = useState('');
-  // 空查询回精选默认集；否则在全量 gemoji 词表搜索（截断 60）。
+  // Empty query returns the curated default set; otherwise search the full gemoji vocabulary (truncated to 60).
   const items = searchReactionEmojis(q);
   return (
     <div className="pr-reaction-picker pr-reaction-picker-free" role="menu">

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/uploadCommentImage.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/uploadCommentImage.ts
@@ -1,8 +1,8 @@
 import { invoke } from '../../../../../api';
 
 /**
- * 把粘贴 / 选取的图片 File 经 IPC 上传到当前 PR 的附件存储，返回可插入正文的 markdown
- * （上传失败 / 平台不支持回 null）。评论回复 / 新建评论 / 草稿编辑共用，避免各处重复实现。
+ * Upload a pasted / selected image File to the current PR's attachment storage via IPC, returning body-insertable markdown
+ * (returns null on upload failure / platform not supported). Shared by comment reply / new comment / draft editing to avoid reimplementing everywhere.
  */
 export async function uploadCommentImage(prLocalId: string, file: File): Promise<string | null> {
   const bytes = await file.arrayBuffer();

--- a/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/useCommentThread.ts
+++ b/apps/desktop/src/renderer/src/components/features/pr/tabs/shared/useCommentThread.ts
@@ -3,13 +3,13 @@ import type { PrComment } from '@meebox/shared';
 import { invoke } from '../../../../../api';
 
 /**
- * 单条评论的「回复 / 编辑 / 删除」交互状态机。评论/活动 tab 的 CommentItem 与 diff 行内
- * 评论 zone 的 CommentNode 共用同一份逻辑（IPC 调用、状态转移、权限读取完全一致），仅外壳
- * （CSS 类 / i18n 文案 / 版式）各异。
+ * Interaction state machine for a single comment's "reply / edit / delete". The comment/activity tab's CommentItem and the diff inline
+ * comment zone's CommentNode share the same logic (IPC calls, state transitions, permission reads are identical), differing only in the shell
+ * (CSS classes / i18n text / layout).
  *
- * canEdit / canDelete 由 main 端预判（annotateOwnership），renderer 直读 flag，不再自己比对
- * author / version / replies。删除成功后 main 端清 cache + 广播 comments:changed，上层面板/zone
- * 重拉评论，这条自然从列表消失，无需本地维护。
+ * canEdit / canDelete are predetermined by main (annotateOwnership); the renderer reads the flag directly, no longer comparing
+ * author / version / replies itself. After a successful delete, main clears the cache + broadcasts comments:changed, the upper panel/zone
+ * refetches comments, this one naturally disappears from the list, no local maintenance needed.
  */
 export interface CommentThread {
   replyOpen: boolean;
@@ -47,7 +47,7 @@ export function useCommentThread(prLocalId: string, comment: PrComment): Comment
         commentId: comment.remoteId,
         version: comment.version,
       });
-      // 成功 → main 端清 cache + 广播 comments:changed → 上层重拉，这条评论自然消失
+      // Success → main clears the cache + broadcasts comments:changed → upper layer refetches, this comment naturally disappears
     } catch (e) {
       setDeleteError(e instanceof Error ? e.message : String(e));
       setDeleting(false);

--- a/apps/desktop/src/renderer/src/components/features/settings/ConnectionForm.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/ConnectionForm.tsx
@@ -6,10 +6,10 @@ import { invoke } from '../../../api';
 import { formatBackendError } from '../../../errors';
 import { EyeIcon, EyeOffIcon } from '../../common';
 
-// 连接编辑用的扁平草稿（Connection 是嵌套的 auth/clone，拍平后表单好写），存盘前还原。
-// 设置页 ConnectionEditorModal 与首启向导 PlatformStep 共用同一份草稿形状 + 表单。
+// Flat draft for connection editing (Connection is nested auth/clone; flattening makes the form easier), restored before saving.
+// The settings-page ConnectionEditorModal and the first-launch wizard PlatformStep share the same draft shape + form.
 export type ConnEntry = Config['connections'][number];
-/** 当前支持配置的平台 kind */
+/** Platform kinds currently supported for configuration */
 export type ConnKind = 'github' | 'bitbucket-server' | 'gitlab';
 export type ConnDraft = {
   id: string;
@@ -32,7 +32,7 @@ export function toConnDraft(c: ConnEntry): ConnDraft {
 }
 
 export function fromConnDraft(d: ConnDraft): ConnEntry {
-  // GitHub / GitLab 的 Base URL 可留空 → 默认官方 endpoint（GHE / 自建实例才需手填）。
+  // Base URL for GitHub / GitLab may be left empty → default official endpoint (only GHE / self-hosted instances need manual entry).
   const trimmed = d.base_url.trim();
   const base_url =
     trimmed === '' && d.kind === 'github'
@@ -54,7 +54,7 @@ export function fromConnDraft(d: ConnDraft): ConnEntry {
       : { ...common, kind: 'bitbucket-server' as const };
 }
 
-/** 各平台的字段文案（名称 / Base URL / 令牌 占位） */
+/** Field copy for each platform (name / Base URL / token placeholders) */
 function kindHints(
   t: TFunction,
 ): Record<ConnKind, { name: string; baseUrl: string; token: string }> {
@@ -77,22 +77,22 @@ function kindHints(
   };
 }
 
-/** Base URL 形如 http(s)://… 才算合法；GitHub / GitLab 允许留空（默认官方 endpoint）。 */
+/** Base URL is valid only when shaped like http(s)://…; GitHub / GitLab may be left empty (default official endpoint). */
 export function connUrlValid(d: ConnDraft): boolean {
   const u = d.base_url.trim();
   if ((d.kind === 'github' || d.kind === 'gitlab') && u === '') return true;
   return /^https?:\/\/.+/i.test(u);
 }
-/** 名称 + 合法 URL + token 三者齐全才允许保存 */
+/** Saving is allowed only when name + valid URL + token are all present */
 export function connDraftCanSave(d: ConnDraft): boolean {
   return d.display_name.trim() !== '' && connUrlValid(d) && d.token.trim() !== '';
 }
 
 /**
- * 连接配置受控表单（名称 / Base URL / PAT / Clone 协议 + 「测试连接」）。
- * 只负责字段渲染与即时连通性测试；保存 / 取消等动作由外层（模态框 / 向导）提供。
+ * Controlled connection-config form (name / Base URL / PAT / Clone protocol + "test connection").
+ * Only handles field rendering and live connectivity testing; save / cancel actions are provided by the outer layer (modal / wizard).
  *
- * autoFocus 默认开（模态打开聚焦名称）；嵌在向导里时按需关闭避免抢焦点。
+ * autoFocus defaults on (focuses the name field when the modal opens); turn it off as needed when embedded in the wizard to avoid stealing focus.
  */
 export function ConnectionForm({
   draft,
@@ -110,7 +110,7 @@ export function ConnectionForm({
 
   const update = <K extends keyof ConnDraft>(field: K, value: ConnDraft[K]): void => {
     onChange({ ...draft, [field]: value });
-    setTestResult(null); // 改字段清掉旧测试结果，避免误导
+    setTestResult(null); // clear the old test result on field change to avoid misleading
   };
 
   const urlValid = connUrlValid(draft);
@@ -216,7 +216,7 @@ export function ConnectionForm({
           </select>
         </div>
       </div>
-      {/* 测试连接：独立一行，左按钮右结果。保存 / 取消 由外层决定布局 */}
+      {/* Test connection: own row, button on the left, result on the right. Save / cancel layout is decided by the outer layer */}
       <div className="settings-actions" style={{ marginTop: 12, alignItems: 'center' }}>
         <button
           type="button"

--- a/apps/desktop/src/renderer/src/components/features/settings/LlmProfileForm.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/LlmProfileForm.tsx
@@ -8,25 +8,25 @@ export interface ProviderMeta {
   value: LlmProvider;
   label: string;
   hint: string;
-  /** Model 字段示例值 / placeholder */
+  /** Example value / placeholder for the Model field */
   modelExample: string;
-  /** Base URL 字段的默认 endpoint：作占位提示；用户填了即透传给 pr-agent，留空则由下游回落到等同此处的默认 endpoint */
+  /** Default endpoint for the Base URL field: used as a placeholder hint; if the user fills it in it's passed through to pr-agent, if left empty the downstream falls back to a default endpoint equivalent to this one */
   defaultBaseUrl: string;
-  /** API Key 字段是否必填 */
+  /** Whether the API Key field is required */
   needsKey: boolean;
 }
 
-// 顺序：海外通用 (OpenAI / OpenAI 兼容 / Anthropic) → 国内三家 (DeepSeek / 阿里
-// 百炼 / 火山方舟) → 兜底 (OpenAI 兼容) → 本地 CLI，方便用户按主流程扫读
+// Order: overseas general (OpenAI / OpenAI-compatible / Anthropic) → three domestic providers (DeepSeek / Alibaba
+// DashScope / Volcengine Ark) → fallback (OpenAI-compatible) → local CLI, so users can scan along the main flow
 //
-// label / hint 用 getter 经 i18n.t 惰性取值：保持数组形状不变（消费方直接读 .label 等），
-// 同时让文案随当前语言解析（品牌名等无对应 key 时退回字面量）。modelExample 是纯模型名示例
-// （各语言相同、不翻译），作静态字面量、不进 i18n。
+// label / hint use getters that resolve lazily via i18n.t: keeps the array shape unchanged (consumers read .label etc. directly),
+// while letting the copy resolve with the current language (fall back to the literal when a brand name etc. has no matching key). modelExample is a plain model-name example
+// (same across languages, not translated), a static literal, not in i18n.
 function provider(
-  // modelExample 是纯模型名示例（各语言相同、不翻译），作静态字面量传入、**不进 i18n**；
-  // label / hint 才走 i18n（label 为品牌名时给字面量、省略 key）。
+  // modelExample is a plain model-name example (same across languages, not translated), passed in as a static literal, **not in i18n**;
+  // only label / hint go through i18n (give a literal for label when it's a brand name, omitting the key).
   meta: Omit<ProviderMeta, 'label' | 'hint'> & {
-    /** label 无 i18n key（品牌名）时给字面量；有 key 时省略 */
+    /** Give a literal for label when there's no i18n key (brand name); omit when a key exists */
     label?: string;
   },
 ): ProviderMeta {
@@ -76,16 +76,16 @@ export const LLM_PROVIDERS: ReadonlyArray<ProviderMeta> = [
     needsKey: true,
     modelExample: 'ep-20240xxxxxx-xxxxx / doubao-pro-32k / doubao-1-5-pro-256k',
   }),
-  // 「OpenAI 兼容」：兜底通用项，主流程让用户先扫读具名 provider；本地 Ollama 也走它
-  // （Base URL 填 http://localhost:11434/v1，密钥留空）。
+  // "OpenAI-compatible": the fallback general option; the main flow lets users scan the named providers first; local Ollama also uses it
+  // (fill Base URL with http://localhost:11434/v1, leave the key empty).
   provider({
     value: 'openai-compatible',
     defaultBaseUrl: '',
     needsKey: true,
     modelExample: 'gpt-4o-mini / qwen2.5-72b-instruct',
   }),
-  // 「本地 CLI」放最后：进阶项，转交本机命令行工具代调模型，不直连 API。
-  // modelExample 不展示（model 输入框对 cli 用 cliCommandPlaceholder），置空。
+  // "Local CLI" goes last: an advanced option that delegates model calls to a local command-line tool instead of connecting to the API directly.
+  // modelExample is not shown (the model input uses cliCommandPlaceholder for cli), left empty.
   provider({
     value: 'cli',
     defaultBaseUrl: '',
@@ -110,19 +110,19 @@ export interface ProfileErrors {
 }
 
 /**
- * 名称 slug 规则：1-32 字符，首位字母数字，其余可含 `-` / `_`。
- * 避免空格 / 中文符号 / 大写形态差异 / 路径分隔符造成日志或文件命中歧义。
+ * Name slug rule: 1-32 chars, first char alphanumeric, the rest may contain `-` / `_`.
+ * Avoids ambiguity in logs or file matching from spaces / CJK symbols / case-form differences / path separators.
  */
 const LABEL_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$/;
 
 /**
- * 按 provider 元信息判定 profile 哪些字段必填：
- *   - label 必填，且必须符合 slug 规则
- *   - model 永远必填（pr-agent 必须知道用哪个模型）
- *   - api_key：needsKey=true 的 provider 必填（本地 CLI / 本地服务不需要）
- *   - base_url：没有默认值的 provider 必填（仅 openai-compatible）
+ * Determine which profile fields are required based on provider metadata:
+ *   - label required, and must conform to the slug rule
+ *   - model always required (pr-agent must know which model to use)
+ *   - api_key: required for providers with needsKey=true (local CLI / local services don't need it)
+ *   - base_url: required for providers without a default value (only openai-compatible)
  *
- * existing 传入用于唯一性校验（编辑时排除自身 id）。
+ * existing is passed in for uniqueness validation (excludes its own id when editing).
  */
 export function validateProfile(p: LlmProfile, existing: LlmProfile[]): ProfileErrors {
   const errors: ProfileErrors = {};
@@ -138,9 +138,9 @@ export function validateProfile(p: LlmProfile, existing: LlmProfile[]): ProfileE
     if (dup) errors.label = i18n.t('llmProfileForm.errorLabelDuplicate');
   }
 
-  // cli：model 字段填的是本机命令名，无 base_url / api_key 概念。隐藏校验——只放行已适配的
-  // 命令（claude / codex，与 sitecustomize 的 _CLI_SPECS 同步），其余命令运行时无对应规格、跑不通。
-  // 提示不点名受支持的命令（保持隐晦），仅给通用的「不受支持」反馈。
+  // cli: the model field holds a local command name, with no base_url / api_key concept. Hidden validation—only allows
+  // adapted commands (claude / codex, kept in sync with sitecustomize's _CLI_SPECS); other commands have no matching spec at runtime and won't run.
+  // The hint doesn't name the supported commands (keeps it opaque), only gives generic "unsupported" feedback.
   if (p.provider === 'cli') {
     const cmd = p.model.trim().toLowerCase();
     if (!cmd) errors.model = i18n.t('llmProfileForm.errorRequired');
@@ -165,11 +165,11 @@ export function newProfileId(): string {
 }
 
 /**
- * LLM 预设受控表单（名称 / Provider / Model / Base URL / API Key + provider 提示）。
- * 字段级 touched 校验：只对碰过（失焦）的字段亮错，避免刚打开一片红。
+ * Controlled LLM profile form (name / Provider / Model / Base URL / API Key + provider hint).
+ * Field-level touched validation: only shows errors on fields that have been touched (blurred), avoiding an all-red state right after opening.
  *
- * 外层（设置页子模态 / 向导 LLM 步）通过 `forceShowErrors` 在点保存时一次性暴露
- * 所有必填项；通过 onValidityChange 上报当前是否全部合法。
+ * The outer layer (settings-page sub-modal / wizard LLM step) uses `forceShowErrors` to expose
+ * all required fields at once when Save is clicked; reports whether everything is currently valid via onValidityChange.
  */
 export function LlmProfileForm({
   draft,
@@ -184,7 +184,7 @@ export function LlmProfileForm({
   onChange: (draft: LlmProfile) => void;
   forceShowErrors?: boolean;
   onValidityChange?: (valid: boolean) => void;
-  /** 由外部（如向导左侧列表）控制 provider 时，隐藏表单内的 Provider 下拉 */
+  /** When provider is controlled externally (e.g. the wizard's left-side list), hide the in-form Provider dropdown */
   hideProvider?: boolean;
 }) {
   const { t } = useTranslation();
@@ -208,7 +208,7 @@ export function LlmProfileForm({
     onChange(next);
     onValidityChange?.(Object.keys(validateProfile(next, existing)).length === 0);
   };
-  // Base URL placeholder：有默认 endpoint 时直接展示该 URL；没有默认值时给示例 + 必填提示
+  // Base URL placeholder: show the URL directly when there's a default endpoint; give an example + required hint when there's no default
   const baseUrlPlaceholder = providerMeta.defaultBaseUrl || 'https://your-endpoint.example.com/v1';
 
   return (
@@ -265,7 +265,7 @@ export function LlmProfileForm({
             }
           />
         </div>
-        {/* cli 模式不直连 API：没有 Base URL / API Key 概念，整组隐藏 */}
+        {/* cli mode doesn't connect to the API directly: no Base URL / API Key concept, hide the whole group */}
         {!isCli && (
           <>
             <div className="modal-kv-key">

--- a/apps/desktop/src/renderer/src/components/features/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/SettingsModal.tsx
@@ -44,8 +44,8 @@ export type SettingsCategory =
   | 'about';
 
 /**
- * 配置分区导航元数据（左侧栏）。新增配置分区在此登记一项，并在右侧面板的 switch
- * 中渲染对应 section —— 分区结构为后续扩展（主题 / 编辑器 / 上下文窗口等）预留。
+ * Settings-section nav metadata (left sidebar). Register a new settings section here and render
+ * the corresponding section in the right panel's switch — the section structure is reserved for future extensions (theme / editor / context window etc.).
  */
 const SETTINGS_CATEGORIES: ReadonlyArray<{
   id: SettingsCategory;
@@ -65,33 +65,33 @@ interface SettingsModalProps {
   info: AppInfo;
   paths: AppPaths;
   config: Config;
-  /** LLM 配置改动后通知父级同步状态（StatusBar chip 等） */
+  /** Notify the parent to sync state (StatusBar chip etc.) after LLM config changes */
   onLlmChange?: (llm: Config['llm']) => void;
   onProxyChange?: (proxy: Config['proxy']) => void;
-  /** UI 语言即时切换后通知父级同步 boot.config.language（与写盘/实时切换解耦的状态同步） */
+  /** Notify the parent to sync boot.config.language after an instant UI-language switch (state sync decoupled from write-to-disk / live switching) */
   onLanguageChange?: (language: SupportedLanguage) => void;
-  /** 外观（全局主题 + 等宽字体 + 字号）即时改动后通知父级同步 boot.config.appearance */
+  /** Notify the parent to sync boot.config.appearance after an instant appearance change (global theme + monospace font + font size) */
   onEditorAppearanceChange?: (appearance: {
     editor_theme: EditorTheme;
     editor_font_family: string;
     editor_font_size: number;
   }) => void;
   /**
-   * 连接改动（含切换活动连接）保存成功后通知父级。父级需重拉 config + 连接摘要 + PR 列表：
-   * 活动连接变化后，main 端 app:connections 只返回新活动连接的摘要、prs:list 只返回其 PR，
-   * 不刷新的话 App 的 boot.connections / 列表会过期（丢 capabilities/user、PR 对不上）。
+   * Notify the parent after a connection change (including switching the active connection) is saved successfully. The parent needs to re-fetch config + connection summary + PR list:
+   * after the active connection changes, the main side's app:connections only returns the new active connection's summary and prs:list only returns its PRs,
+   * without refreshing, the App's boot.connections / list goes stale (loses capabilities/user, PRs don't match).
    */
   onConnectionsChange?: () => void | Promise<void>;
-  /** 整体保存成功后回传写盘后的权威 config，父级据此同步 boot.config（再次打开设置页显示最新值）。 */
+  /** After a full save succeeds, pass back the authoritative config after write-to-disk; the parent syncs boot.config from it (so reopening settings shows the latest values). */
   onConfigPersisted?: (config: Config) => void;
-  /** 打开时的初始分区（命令面板「打开关于」等深链用）；缺省 'general'。 */
+  /** Initial section on open (used by deep links like the command palette's "open About"); defaults to 'general'. */
   initialCategory?: SettingsCategory;
   onClose: () => void;
 }
 
 /**
- * 设置面板（容器）：布局编排 + 装配各分区。草稿 / 保存状态机归 useSettingsDraft，
- * 各设置分区拆到 sections/，连接 / 代理 / LLM 编辑器拆到 editors/，通用模态壳用 common/Modal。
+ * Settings panel (container): layout orchestration + assembling the sections. The draft / save state machine belongs to useSettingsDraft,
+ * each settings section is split into sections/, the connection / proxy / LLM editors into editors/, and the generic modal shell uses common/Modal.
  */
 export function SettingsModal({
   info,
@@ -108,7 +108,7 @@ export function SettingsModal({
 }: SettingsModalProps) {
   const { t } = useTranslation();
   const [category, setCategory] = useState<SettingsCategory>(initialCategory ?? 'general');
-  // 已挂载时再次以新初始分区打开（命令面板深链）：切到目标分区；用户在面板内手动导航仍走 setCategory。
+  // Reopening with a new initial section while already mounted (command-palette deep link): switch to the target section; manual navigation within the panel still goes through setCategory.
   useEffect(() => {
     if (initialCategory) setCategory(initialCategory);
   }, [initialCategory]);
@@ -121,7 +121,7 @@ export function SettingsModal({
     onConfigPersisted,
     onClose,
   });
-  // 外观类即时生效设置（语言 / 主题 / 编辑器外观）：与整体保存事务正交，独立 hook 管理。
+  // Appearance-type instantly-applied settings (language / theme / editor appearance): orthogonal to the full-save transaction, managed by a separate hook.
   const a = useAppearanceDraft({
     config,
     onLanguageChange,
@@ -133,7 +133,7 @@ export function SettingsModal({
       <Modal
         size="lg"
         onClose={onClose}
-        // 有未保存草稿时点背景误关会丢配置：设置页禁用背景点击关闭，仅右上角关闭键（或保存成功）退出。
+        // Accidentally closing via a backdrop click with an unsaved draft loses config: the settings page disables backdrop-click close, exit only via the top-right close button (or a successful save).
         closeOnBackdrop={false}
         title={t('settings.title')}
         headerClose="icon"
@@ -217,7 +217,7 @@ export function SettingsModal({
                 />
               </>
             )}
-            {/* 模型：仅 LLM 连接 + 上下文长度。 */}
+            {/* Model: only LLM connections + context length. */}
             {category === 'model' && (
               <>
                 <LlmSection
@@ -233,7 +233,7 @@ export function SettingsModal({
                 />
               </>
             )}
-            {/* 智能体：记忆目录 + 策略 + 评审并发。 */}
+            {/* Agent: memory directory + strategy + review concurrency. */}
             {category === 'agent' && (
               <>
                 <AgentDirSection

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/ConnectionEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/ConnectionEditorModal.tsx
@@ -18,11 +18,11 @@ export function ConnectionEditorModal({
   const { t } = useTranslation();
   const { mode, draft } = state;
   const canSave = connDraftCanSave(draft);
-  // 退出校验：记下打开时的草稿快照，与当前比对判断是否有未提交改动
+  // Exit validation: snapshot the draft on open, compare against current to detect uncommitted changes
   const initialDraft = useRef(JSON.stringify(draft));
   const dirty = JSON.stringify(draft) !== initialDraft.current;
   const [confirmDiscard, setConfirmDiscard] = useState(false);
-  // 关闭（背景点击 / 关闭键 / 取消按钮）统一走这里：有改动则先拦截确认
+  // Closing (backdrop click / close key / cancel button) all routes through here: intercept with a confirm if dirty
   const requestClose = (): void => {
     if (dirty) setConfirmDiscard(true);
     else onCancel();
@@ -37,8 +37,8 @@ export function ConnectionEditorModal({
           mode === 'add' ? t('settings.addConnectionTitle') : t('settings.editConnectionTitle')
         }
       >
-        {/* 左右两栏：左选集成平台（复用向导布局），右填连接表单。
-          平台选择仅新增时可改；编辑既有连接只读（base_url / token 语义随平台而异）。 */}
+        {/* Two columns: left picks the integration platform (reuses wizard layout), right fills the connection form.
+          Platform selection is editable only when adding; editing an existing connection is read-only (base_url / token semantics vary by platform). */}
         <div className="config-pick-grid">
           <PlatformPicker
             value={draft.kind}

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/LlmEditorModal.tsx
@@ -20,7 +20,7 @@ export function LlmEditorModal({
 }) {
   const { t } = useTranslation();
   const { mode, draft } = state;
-  // 点保存才把所有必填项暴露出来（LlmProfileForm 内部按 touched 渐进显示）
+  // Only reveal all required fields when Save is clicked (LlmProfileForm shows them progressively by touched)
   const [forceShowErrors, setForceShowErrors] = useState(false);
   const isValid = Object.keys(validateProfile(draft, existing)).length === 0;
   const trySave = (): void => {
@@ -30,11 +30,11 @@ export function LlmEditorModal({
     }
     onSave();
   };
-  // 退出校验：记下打开时的草稿快照，与当前比对判断是否有未提交改动
+  // Exit validation: snapshot the draft on open, compare against current to detect uncommitted changes
   const initialDraft = useRef(JSON.stringify(draft));
   const dirty = JSON.stringify(draft) !== initialDraft.current;
   const [confirmDiscard, setConfirmDiscard] = useState(false);
-  // 关闭（背景点击 / 关闭键 / 取消按钮）统一走这里：有改动则先拦截确认
+  // Closing (backdrop click / close key / cancel button) all routes through here: intercept with a confirm if dirty
   const requestClose = (): void => {
     if (dirty) setConfirmDiscard(true);
     else onCancel();
@@ -47,8 +47,8 @@ export function LlmEditorModal({
         onClose={requestClose}
         title={mode === 'add' ? t('settings.addLlmTitle') : t('settings.editLlmTitle')}
       >
-        {/* 左右两栏：左选 provider（复用向导布局），右填该 provider 的配置（隐藏表单内冗余的 provider 下拉）。
-            固定高度：两栏各自在其内滚动，切换 provider 时模态高度恒定、不抖动。 */}
+        {/* Two columns: left picks the provider (reuses wizard layout), right fills that provider's config (hides the form's redundant provider dropdown).
+            Fixed height: each column scrolls within itself, so the modal height stays constant and doesn't jitter when switching provider. */}
         <div className="config-pick-grid config-pick-grid-fixed">
           <LlmProviderPicker
             value={draft.provider}

--- a/apps/desktop/src/renderer/src/components/features/settings/editors/ProxyEditorModal.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/editors/ProxyEditorModal.tsx
@@ -22,7 +22,7 @@ export function ProxyEditorModal({
     result: { ok: boolean; reason?: string } | null;
   }>({ testing: false, result: null });
   const [pwVisible, setPwVisible] = useState(false);
-  // 改任意字段都清掉上次测试结果（避免误导）
+  // Changing any field clears the previous test result (to avoid misleading)
   const patch = (p: Partial<Config['proxy']>): void => {
     onChange({ ...draft, ...p });
     setTest({ testing: false, result: null });
@@ -49,7 +49,7 @@ export function ProxyEditorModal({
       </label>
       {draft.enabled && (
         <>
-          {/* 字段名放输入框前（modal-kv 网格）；用户名 / 密码分上下两行，均可选 */}
+          {/* Field names precede the inputs (modal-kv grid); username / password on separate rows, both optional */}
           <div className="modal-kv" style={{ marginTop: 10, alignItems: 'center' }}>
             <div className="modal-kv-key">{t('settings.proxyHost')}</div>
             <div className="modal-kv-val">

--- a/apps/desktop/src/renderer/src/components/features/settings/elements/UpdateCheckButton.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/elements/UpdateCheckButton.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { UpdateCheckResult } from '@meebox/shared';
 import { invoke } from '../../../../api';
 
-/** 「检查更新」按钮（运行环境段）：手动查 GitHub 最新版，自管 loading + 结果展示。 */
+/** "Check for updates" button (runtime environment section): manually queries the latest GitHub release, self-manages loading + result display. */
 export function UpdateCheckButton({ enabled }: { enabled: boolean }) {
   const { t } = useTranslation();
   const [checking, setChecking] = useState(false);

--- a/apps/desktop/src/renderer/src/components/features/settings/hooks/useAppearanceDraft.ts
+++ b/apps/desktop/src/renderer/src/components/features/settings/hooks/useAppearanceDraft.ts
@@ -17,36 +17,36 @@ interface UseAppearanceDraftParams {
 }
 
 /**
- * 外观类「即时生效」设置：UI 语言 / 全局主题 + 编辑器字体（Monaco 主题即全局主题，另含等宽字体 + 字号）。
- * 与 useSettingsDraft 的「草稿 → 整体保存」事务相互正交 —— 这里每项改即生效：实时应用到运行时
- * （store / data-theme / chrome / CSS 变量）+ 持久化（localStorage + 写盘）+ 同步父级，不进 base/saveAll。
- * 写盘失败不回滚 UI（已切），仅经 error 提示；下次启动按 localStorage 兜底。主题切换的 data-theme /
- * chrome 派生由 App 的 useGlobalTheme 订阅 store 变化驱动（见 hooks/useTheme）。
+ * Appearance "instant-effect" settings: UI language / global theme + editor font (Monaco theme is the global theme, plus monospace font + size).
+ * Orthogonal to useSettingsDraft's "draft → save-all" transaction —— here each change takes effect immediately: applied to the runtime in real time
+ * (store / data-theme / chrome / CSS variables) + persisted (localStorage + written to disk) + synced to parent, not part of base/saveAll.
+ * Write-to-disk failure does not roll back the UI (already switched), only surfaces via error; next startup falls back to localStorage. The data-theme /
+ * chrome derivation of theme switching is driven by App's useGlobalTheme subscribing to store changes (see hooks/useTheme).
  */
 export function useAppearanceDraft({
   config,
   onLanguageChange,
   onEditorAppearanceChange,
 }: UseAppearanceDraftParams) {
-  // 即时生效项写盘失败的错误（与整体保存的 saveError 分开，由 SettingsModal 合并展示）
+  // Error from write-to-disk failure of instant-effect items (kept separate from save-all's saveError, merged for display by SettingsModal)
   const [error, setError] = useState<string | null>(null);
 
-  // UI 语言：即时生效项（不走全局保存）
+  // UI language: instant-effect item (does not go through save-all)
   const [language, setLanguage] = useState<SupportedLanguage>(() => resolveUiLanguage(config.language));
   const handleLanguageChange = (next: SupportedLanguage): void => {
     if (next === language) return;
     setLanguage(next);
-    void i18n.changeLanguage(next); // 渲染层实时切换
-    persistLanguage(next); // localStorage 缓存，下次启动同步命中
-    onLanguageChange?.(next); // 同步父级 boot.config.language
+    void i18n.changeLanguage(next); // switch the renderer layer in real time
+    persistLanguage(next); // localStorage cache, hit synchronously on next startup
+    onLanguageChange?.(next); // sync parent boot.config.language
     invoke('config:setLanguage', { language: next }).catch((e: unknown) => {
-      // 写盘 / 主进程切换失败不回滚 UI（已切），仅提示；下次启动按 localStorage 兜底
+      // Write-to-disk / main-process switch failure does not roll back the UI (already switched), only surfaces; next startup falls back to localStorage
       setError(e instanceof Error ? e.message : String(e));
     });
   };
 
-  // 全局主题（Monaco 主题 + 等宽字体）：即时生效项。主题为离散选择 → 改即写盘；字体为文本输入 →
-  // onChange 仅实时预览（写 store + CSS + 同步父级），onBlur 才写盘，避免逐字符落盘。
+  // Global theme (Monaco theme + monospace font): instant-effect items. Theme is a discrete choice → written to disk on change; font is text input →
+  // onChange only previews in real time (writes store + CSS + syncs parent), onBlur writes to disk, avoiding per-character disk writes.
   const [editorTheme, setEditorTheme] = useState<EditorTheme>(config.appearance.editor_theme);
   const [editorFontFamily, setEditorFontFamily] = useState<string>(
     config.appearance.editor_font_family,
@@ -54,7 +54,7 @@ export function useAppearanceDraft({
   const [editorFontSize, setEditorFontSizeState] = useState<number>(
     config.appearance.editor_font_size,
   );
-  // 实时应用到运行时：写共享 store（Monaco 组件读）+ 字体 CSS 变量（全应用 $font-mono）+ 同步父级。
+  // Apply to runtime in real time: write shared store (read by Monaco component) + font CSS variable (app-wide $font-mono) + sync parent.
   const applyEditorAppearance = (nextTheme: EditorTheme, nextFont: string, nextSize: number): void => {
     setEditorAppearance({ editorTheme: nextTheme, fontFamily: nextFont, fontSize: nextSize });
     applyEditorFontFamily(nextFont);
@@ -79,12 +79,12 @@ export function useAppearanceDraft({
   };
   const handleEditorFontChange = (next: string): void => {
     setEditorFontFamily(next);
-    applyEditorAppearance(editorTheme, next, editorFontSize); // 实时预览，不写盘
+    applyEditorAppearance(editorTheme, next, editorFontSize); // real-time preview, not written to disk
   };
   const commitEditorFont = (): void => {
-    persistEditorAppearance(editorTheme, editorFontFamily, editorFontSize); // 失焦才写盘
+    persistEditorAppearance(editorTheme, editorFontFamily, editorFontSize); // written to disk only on blur
   };
-  // 字号为离散下拉 → 改即生效并写盘；clamp 防越界（异常 / config 手改超范围）。
+  // Font size is a discrete dropdown → takes effect and written to disk on change; clamp guards against out-of-range (anomaly / manually edited config out of range).
   const handleEditorFontSizeChange = (next: number): void => {
     const clamped = Math.min(EDITOR_FONT_SIZE_MAX, Math.max(EDITOR_FONT_SIZE_MIN, Math.round(next)));
     if (clamped === editorFontSize) return;
@@ -94,10 +94,10 @@ export function useAppearanceDraft({
   };
 
   return {
-    // 语言
+    // language
     language,
     handleLanguageChange,
-    // 全局主题 + 编辑器字体
+    // global theme + editor font
     editorTheme,
     editorFontFamily,
     editorFontSize,
@@ -105,7 +105,7 @@ export function useAppearanceDraft({
     handleEditorFontChange,
     commitEditorFont,
     handleEditorFontSizeChange,
-    // 即时生效项写盘错误
+    // write-to-disk error of instant-effect items
     error,
   };
 }

--- a/apps/desktop/src/renderer/src/components/features/settings/hooks/useSettingsDraft.ts
+++ b/apps/desktop/src/renderer/src/components/features/settings/hooks/useSettingsDraft.ts
@@ -11,16 +11,16 @@ interface UseSettingsDraftParams {
   onLlmChange?: (llm: Config['llm']) => void;
   onProxyChange?: (proxy: Config['proxy']) => void;
   onConnectionsChange?: () => void | Promise<void>;
-  /** 整体保存成功后回传写盘后的权威 config，供父级同步 boot.config（再次打开设置页显示最新值）。 */
+  /** After a successful save-all, passes back the authoritative written config so the parent can sync boot.config (reopening the settings page shows the latest values). */
   onConfigPersisted?: (config: Config) => void;
   onClose: () => void;
 }
 
 /**
- * SettingsModal 的「草稿 → 整体保存」状态机：所有编辑只改本地 state，点底栏「保存」才整体写盘 +
- * 生效；连接 / LLM 改动额外自动写入 config.yaml（防丢失）但不应用到运行时。对外暴露各分区所需的
- * 语义化 state 与 setter（编辑即标脏），以及编辑器弹窗状态与 saveAll。即时生效的外观类设置
- * （语言 / 主题 / 编辑器外观）与本事务正交，拆到 useAppearanceDraft。
+ * SettingsModal's "draft → save-all" state machine: all edits only change local state; clicking the footer "Save" writes to disk +
+ * takes effect as a whole; connection / LLM changes are additionally auto-written to config.yaml (to prevent loss) but not applied to the runtime. Exposes the
+ * semantic state and setters each section needs (editing marks dirty), plus editor popup state and saveAll. Instant-effect appearance settings
+ * (language / theme / editor appearance) are orthogonal to this transaction and split out into useAppearanceDraft.
  */
 export function useSettingsDraft({
   config,
@@ -35,13 +35,13 @@ export function useSettingsDraft({
   const [opening, setOpening] = useState(false);
   const [openError, setOpenError] = useState<string | null>(null);
 
-  // 草稿 → 整体保存：所有编辑只改本地 state，点底栏"保存"才整体写盘 + 生效
+  // draft → save-all: all edits only change local state; clicking the footer "Save" writes to disk + takes effect as a whole
   const [reposDirInput, setReposDirInput] = useState(config.workspace.repos_dir);
-  // Agent 其余字段（max_steps / summary_max_chars / autopilot）在 UI 不编辑，仅持有以便保存时
-  // 原样回传、不被覆盖成默认值；目录经 agentDirInput、策略开关经 autoFollowup 可编辑。
+  // Agent's other fields (max_steps / summary_max_chars / autopilot) are not edited in the UI, only held so that on save they are
+  // passed back as-is and not overwritten with defaults; dir is editable via agentDirInput, strategy toggles via autoFollowup.
   const [agent] = useState<Config['agent']>(config.agent);
   const [agentDirInput, setAgentDirInput] = useState(config.agent.dir);
-  // Agent 策略（自动追问开关 + 追问数量上限 + 代码建议数量上限）。随 config:setAgent 一并保存。
+  // Agent strategy (auto-followup toggle + followup count cap + code-suggestion count cap). Saved together with config:setAgent.
   const [autoFollowup, setAutoFollowupState] = useState(config.agent.strategy.auto_followup);
   const [maxFollowupAsks, setMaxFollowupAsksState] = useState(
     config.agent.strategy.max_followup_asks,
@@ -55,18 +55,18 @@ export function useSettingsDraft({
   const [llmEditor, setLlmEditor] = useState<{ mode: 'add' | 'edit'; draft: LlmProfile } | null>(
     null,
   );
-  // 消息通知（总开关 + 分类型系统通知 + dock 角标）。随 config:setNotifications 保存。
+  // Message notifications (master toggle + per-type system notifications + dock badge). Saved with config:setNotifications.
   const [notifications, setNotificationsState] = useState<Config['notifications']>(
     config.notifications,
   );
   const [proxy, setProxy] = useState<Config['proxy']>(config.proxy);
-  // 代理在独立模态框里编辑：null=关闭，非 null=正在编辑的草稿；保存回 proxy，底栏「保存」才写盘。
+  // Proxy is edited in a separate modal: null=closed, non-null=draft being edited; saved back to proxy, written to disk only on footer "Save".
   const [proxyEditor, setProxyEditor] = useState<Config['proxy'] | null>(null);
 
-  // 本地 API 服务监听（开关 / host / port 随整体保存；token 经 generateServiceToken 立即写盘）。
+  // Local API service listener (toggle / host / port follow save-all; token written to disk immediately via generateServiceToken).
   const [service, setServiceState] = useState<Config['service']>(config.service);
 
-  // 连接：多条可配置 + 单选启用；编辑只改本地 state，整体保存才写盘 + 热重建
+  // Connections: multiple configurable + single-select enabled; editing only changes local state, save-all writes to disk + hot-rebuilds
   const [connections, setConnections] = useState<Config['connections']>(config.connections);
   const [activeConnId, setActiveConnId] = useState<string>(config.active_connection_id);
   const [connEditor, setConnEditor] = useState<{ mode: 'add' | 'edit'; draft: ConnDraft } | null>(
@@ -74,7 +74,7 @@ export function useSettingsDraft({
   );
   const [connDeleteId, setConnDeleteId] = useState<string | null>(null);
 
-  // 保存基线：保存成功后更新，用于 changed 判定（禁用保存按钮）
+  // Save baseline: updated after a successful save, used for changed detection (to disable the save button)
   const [base, setBase] = useState(() => ({
     reposDir: config.workspace.repos_dir,
     agentDir: config.agent.dir,
@@ -113,7 +113,7 @@ export function useSettingsDraft({
     }
   };
 
-  // 连接 / LLM 编辑：改本地 state + 自动写入 config.yaml（防丢失），但不应用到运行时
+  // Connection / LLM editing: change local state + auto-write to config.yaml (to prevent loss), but not applied to the runtime
   const autosaveDraft = (
     nextConnections: Config['connections'],
     activeId: string,
@@ -124,11 +124,11 @@ export function useSettingsDraft({
       active_connection_id: activeId,
       llm: nextLlm,
     }).catch(() => {
-      /* 自动保存失败不打断编辑；点底栏保存时会再写一次 */
+      /* Autosave failure does not interrupt editing; it will be written again on footer save */
     });
   };
 
-  // ── LLM 配置 ──
+  // ── LLM config ──
   const persistLlm = (next: Config['llm']): void => {
     setLlm(next);
     setSaved(false);
@@ -174,13 +174,13 @@ export function useSettingsDraft({
     if (llm.active_id === id) return;
     persistLlm({ ...llm, active_id: id });
   };
-  // 上下文长度归属 llm（随 config:setLlm 一并保存）；编辑即走 persistLlm（标脏 + 草稿写盘）。
+  // Context length belongs to llm (saved together with config:setLlm); editing goes through persistLlm (mark dirty + draft write-to-disk).
   const setLlmContextTokens = (tokens: number): void => {
     if (llm.context_tokens === tokens) return;
     persistLlm({ ...llm, context_tokens: tokens });
   };
 
-  // ── 连接 ──
+  // ── Connections ──
   const persistConnections = (next: Config['connections'], activeId: string): void => {
     setConnections(next);
     setActiveConnId(activeId);
@@ -210,14 +210,14 @@ export function useSettingsDraft({
     const conn = fromConnDraft(draft);
     const next =
       mode === 'add' ? [...connections, conn] : connections.map((c) => (c.id === conn.id ? conn : c));
-    // 新增首条自动设为启用
+    // The first added one is automatically set as enabled
     const activeId = mode === 'add' && !activeConnId ? conn.id : activeConnId;
     persistConnections(next, activeId);
     setConnEditor(null);
   };
   const deleteConn = (id: string): void => {
     const next = connections.filter((c) => c.id !== id);
-    // 删的是当前启用 → 启用回退到剩下第一条（无则空串，不轮询任何连接）
+    // Deleting the currently enabled one → enabled falls back to the first remaining (empty string if none, polls no connection)
     const activeId = activeConnId === id ? (next[0]?.id ?? '') : activeConnId;
     persistConnections(next, activeId);
   };
@@ -226,7 +226,7 @@ export function useSettingsDraft({
     persistConnections(connections, id);
   };
 
-  // ── 代理 ──
+  // ── Proxy ──
   const saveProxyEditor = (): void => {
     if (!proxyEditor) return;
     setProxy(proxyEditor);
@@ -234,7 +234,7 @@ export function useSettingsDraft({
     setSaved(false);
   };
 
-  // ── 目录 / 轮询的语义化 setter（编辑即标脏）──
+  // ── Semantic setters for directory / polling (editing marks dirty) ──
   const setPoller = (seconds: number): void => {
     setPollerInput(String(seconds));
     setSaved(false);
@@ -251,8 +251,8 @@ export function useSettingsDraft({
     setServiceState(next);
     setSaved(false);
   };
-  // token 重新生成只更新草稿并标脏（不落盘、不同步基线）：与 host / port 一致走草稿制，随底栏「保存」
-  // 经 config:setService 生效；不保存则丢弃、保留原 token。functional update 避开与开关切换的竞态。
+  // Token regeneration only updates the draft and marks dirty (not written to disk, does not sync baseline): like host / port, follows the draft model, takes effect
+  // via config:setService on footer "Save"; if not saved it is discarded, keeping the original token. functional update avoids a race with toggle switching.
   const regenerateServiceToken = async (): Promise<void> => {
     try {
       const { token } = await invoke('config:generateServiceToken', undefined);
@@ -297,7 +297,7 @@ export function useSettingsDraft({
     if (r.path) setReposDir(r.path);
   };
 
-  // ── 变更检测（对比基线）+ 整体保存 ──
+  // ── Change detection (compare against baseline) + save-all ──
   const reposDirChanged = reposDirInput.trim() !== base.reposDir;
   const agentChanged =
     agentDirInput.trim() !== base.agentDir ||
@@ -340,7 +340,7 @@ export function useSettingsDraft({
         await invoke('config:setMaxConcurrency', { max_concurrency: maxConcurrencyInput });
       }
       if (agentChanged) {
-        // UI 编辑 dir + 策略开关；其余字段从已加载的 config 原样保留，避免被覆盖成默认值。
+        // UI edits dir + strategy toggles; other fields are kept as-is from the loaded config to avoid being overwritten with defaults.
         await invoke('config:setAgent', {
           agent: {
             ...agent,
@@ -367,7 +367,7 @@ export function useSettingsDraft({
       }
       if (serviceChanged) {
         const host = service.host.trim();
-        // 简单合法性校验：非空、无空白 / 协议 / 斜杠（端口单列）；放过 IPv4 / 主机名 / 0.0.0.0 / ::1。
+        // Simple validation: non-empty, no whitespace / protocol / slash (port is separate); allows IPv4 / hostname / 0.0.0.0 / ::1.
         if (!host || !/^[A-Za-z0-9.:-]+$/.test(host)) {
           throw new Error(t('settings.serviceHostInvalidError'));
         }
@@ -383,8 +383,8 @@ export function useSettingsDraft({
       if (reposDirChanged && reposDirInput.trim()) {
         await invoke('config:setReposDir', { reposDir: reposDirInput.trim() });
       }
-      // 回读写盘后的权威配置同步父级 boot.config：否则 agent / poller / 并发 等无即时回调的项，
-      // 再次打开设置页仍读旧的 boot.config（行为已生效但 UI 显示陈旧）。含 main 端 clamp 后的值。
+      // Read back the authoritative written config to sync the parent's boot.config: otherwise items without an immediate callback like agent / poller / concurrency
+      // would still read the stale boot.config when reopening the settings page (behavior has taken effect but the UI shows stale values). Includes main-side clamped values.
       onConfigPersisted?.(await invoke('config:read', undefined));
       setBase({
         reposDir: reposDirInput.trim(),
@@ -402,7 +402,7 @@ export function useSettingsDraft({
         activeConnId,
       });
       setSaved(true);
-      // 保存成功后自动关闭设置面板（失败则保持打开并展示 saveError）
+      // Automatically close the settings panel after a successful save (on failure, keep it open and show saveError)
       onClose();
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : String(e));
@@ -412,7 +412,7 @@ export function useSettingsDraft({
   };
 
   return {
-    // 连接
+    // connections
     connections,
     activeConnId,
     connEditor,
@@ -435,19 +435,19 @@ export function useSettingsDraft({
     deleteProfile,
     setActiveLlm,
     setLlmContextTokens,
-    // 代理
+    // proxy
     proxy,
     proxyEditor,
     setProxyEditor,
     saveProxyEditor,
-    // 通知
+    // notifications
     notifications,
     setNotifications,
-    // 本地 API 服务监听
+    // local API service listener
     service,
     setService,
     regenerateServiceToken,
-    // 轮询 / 并发 / 目录
+    // polling / concurrency / directories
     pollerInput,
     setPoller,
     maxConcurrencyInput,
@@ -465,7 +465,7 @@ export function useSettingsDraft({
     setReposDir,
     pickReposDir,
     totalBytes,
-    // 保存 / 配置文件
+    // save / config file
     opening,
     openError,
     openConfigFile,

--- a/apps/desktop/src/renderer/src/components/features/settings/index.ts
+++ b/apps/desktop/src/renderer/src/components/features/settings/index.ts
@@ -1,5 +1,5 @@
-// features/settings 对外公共 API：设置面板 + 连接 / LLM 表单（onboarding 复用）。
-// 内部模块（sections / editors / hooks 等）相互引用走相对路径。状态栏 chip 走 statusbar/* 子路径。
+// features/settings public API: settings panel + connection / LLM forms (reused by onboarding).
+// Internal modules (sections / editors / hooks etc.) reference each other via relative paths. Status-bar chips go through the statusbar/* subpath.
 export { SettingsModal, type SettingsCategory } from './SettingsModal';
 export {
   ConnectionForm,

--- a/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/pickers/LlmProviderPicker.tsx
@@ -4,8 +4,8 @@ import { LlmProviderIcon } from '../../../common';
 import { LLM_PROVIDERS } from '../LlmProfileForm';
 
 /**
- * LLM provider 选择列表（左侧栏）：品牌图标 + 名称，单选高亮。
- * 首启向导 LLM 步与设置面板「LLM」子模态共用同一视觉（配置选择器左右布局，见 config-picker.scss）。
+ * LLM provider picker list (left column): brand icon + name, single-select highlight.
+ * The first-run wizard's LLM step and the settings panel's "LLM" sub-modal share the same visuals (config picker left/right layout, see config-picker.scss).
  */
 export function LlmProviderPicker({
   value,

--- a/apps/desktop/src/renderer/src/components/features/settings/pickers/PlatformPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/pickers/PlatformPicker.tsx
@@ -3,11 +3,11 @@ import { PLATFORM_META } from '../../../common';
 import type { ConnKind } from '../ConnectionForm';
 
 /**
- * 集成平台选择列表（左侧栏）：图标 + 名称 + 副标题，单选高亮。
- * 首启向导平台步与设置面板「连接」子模态共用同一视觉（配置选择器左右布局，见 config-picker.scss）。
+ * Integration platform picker list (left column): icon + name + subtitle, single-select highlight.
+ * The first-run wizard's platform step and the settings panel's "connections" sub-modal share the same visuals (config picker left/right layout, see config-picker.scss).
  *
- * readOnly：编辑既有连接时不允许切平台（base_url / token 语义随平台而异）——当前项保持高亮、
- * 其余置灰，整列禁用交互。
+ * readOnly: switching platform is not allowed when editing an existing connection (base_url / token semantics vary by platform) —— the current item stays highlighted,
+ * the rest are dimmed, and the whole list disables interaction.
  */
 export function PlatformPicker({
   value,
@@ -25,7 +25,7 @@ export function PlatformPicker({
     <div className="config-pick-list" role="radiogroup" aria-label={ariaLabel}>
       {PLATFORM_META.map((p) => {
         const selected = p.kind === value;
-        // 可点选：平台已实现且非只读。置灰：未实现平台，或只读态下的非当前项。
+        // Clickable: platform is implemented and not read-only. Dimmed: unimplemented platform, or non-current item in read-only state.
         const interactive = p.available && !readOnly;
         const dim = !p.available || (readOnly && !selected);
         return (

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/AgentDirSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/AgentDirSection.tsx
@@ -14,11 +14,12 @@ export function AgentDirSection({
   const { t } = useTranslation();
   return (
     <section className="modal-section">
-      {/* 标题行：左侧标题 + 右侧蓝色「打开当前目录」按钮（在系统文件管理器打开生效的 Agent 目录，
-          便于直接查看 / 编辑文件）。放在标题行而非配置行，避免与下方的目录选择按钮混淆。 */}
+      {/* Header row: title on the left + blue "open current directory" button on the right (opens the
+          active Agent directory in the system file manager for direct viewing / editing). Placed in the
+          header row rather than the config row to avoid confusion with the directory picker button below. */}
       <div className="modal-section-head">
         <h4>{t('settings.agentDirTitle')}</h4>
-        {/* 文案按钮（非图标）：与下方的目录「选择」图标按钮区分开，避免混淆。 */}
+        {/* Text button (not an icon): distinguished from the directory "pick" icon button below to avoid confusion. */}
         <button
           type="button"
           className="btn btn-primary btn-sm"

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/AgentStrategySection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/AgentStrategySection.tsx
@@ -1,15 +1,17 @@
 import { useTranslation } from 'react-i18next';
 import { Switch } from '../../../common';
 
-// 自动追问数量上限可选档位（1~5）。开关已独立控制启停，故不给 0（0 在 schema 等同关闭，仅手改 config 可达）。
+// Selectable tiers for the max follow-up asks (1~5). The switch controls enable/disable independently, so 0 is not offered (0 equals off in the schema, reachable only by hand-editing config).
 const MAX_FOLLOWUP_ASKS_OPTIONS = [1, 2, 3, 4, 5];
-// 代码建议数量上限可选档位（2~8）。
+// Selectable tiers for the max code suggestions (2~8).
 const MAX_CODE_SUGGESTIONS_OPTIONS = [2, 3, 4, 5, 6, 7, 8];
 
 /**
- * Agent 策略：扩展 Agent 行为控制的分区，子项以缩进的「功能列表」逐行展示（行首圆点 + 标题 + 说明，
- * 右侧控件）。右侧控件不限于开关——自动追问用 Switch，追问数量 / 代码建议数量用下拉（同一通用
- * .settings-sublist-*）。追问数量仅在自动追问开启时可调（关闭时下拉禁用）。后续策略项在此追加一行即可。
+ * Agent strategy: a section extending Agent behavior controls, with sub-items shown row by row as an indented
+ * "feature list" (leading dot + title + description, control on the right). Right-side controls aren't limited to
+ * switches—auto follow-up ask uses a Switch, follow-up ask count / code suggestion count use dropdowns (the same
+ * generic .settings-sublist-*). The follow-up ask count is only adjustable when auto follow-up ask is on (the dropdown
+ * is disabled when off). Append later strategy items as one more row here.
  */
 export function AgentStrategySection({
   autoFollowup,
@@ -52,7 +54,7 @@ export function AgentStrategySection({
               {t('settings.maxFollowupAsksHint')}
             </span>
           </div>
-          {/* 追问数量仅在自动追问开启时生效 → 关闭时禁用，避免「开关关、数量却可调」的歧义。 */}
+          {/* The follow-up ask count only takes effect when auto follow-up ask is on → disabled when off, avoiding the ambiguity of "switch off, yet count adjustable". */}
           <select
             className="settings-input settings-sublist-select"
             value={maxFollowupAsks}

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/ConcurrencySection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/ConcurrencySection.tsx
@@ -3,16 +3,16 @@ import { CONCURRENCY_TIERS } from '../utils';
 import { TierSlider } from './TierSlider';
 
 /**
- * 评审任务并发（pr_agent.max_concurrency，1~8）：同时执行的评审 run 数。
- * 复用轮询配置的数值拖拽组件（TierSlider）。
+ * Review task concurrency (pr_agent.max_concurrency, 1~8): the number of review runs executed simultaneously.
+ * Reuses the numeric drag component (TierSlider) from the polling config.
  */
 export function ConcurrencySection({
   value,
   onChange,
 }: {
-  /** 当前并发数 */
+  /** Current concurrency count */
   value: number;
-  /** 选定档位 → 回传该档并发数 */
+  /** Selected tier → pass back that tier's concurrency count */
   onChange: (max: number) => void;
 }) {
   const { t } = useTranslation();
@@ -22,7 +22,7 @@ export function ConcurrencySection({
       <p className="muted" style={{ margin: '0 0 8px' }}>
         {t('settings.concurrencyHint')}
       </p>
-      {/* 并发数为纯数字、无单位，且刻度已标 1~8 并高亮当前档 → 省去右侧重复读数。 */}
+      {/* The concurrency count is a plain number with no unit, and the scale already marks 1~8 and highlights the current tier → omit the redundant readout on the right. */}
       <TierSlider
         tiers={CONCURRENCY_TIERS}
         value={value}

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/EditorSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/EditorSection.tsx
@@ -2,13 +2,14 @@ import { useTranslation } from 'react-i18next';
 import { EDITOR_FONT_SIZE_PRESETS } from '@meebox/shared';
 
 /**
- * 编辑器字体分区：代码编辑器（Monaco）等宽字体 + 字号配置。两项均即时生效（字体输入失焦才写盘，
- * onChange 实时预览），由 useAppearanceDraft 编排。本分区在「常规」内以分隔线与语言 / 主题分组。
- * 编辑器配色主题已升格为全局「主题」分区（见 ThemeSection），不在此处。
+ * Editor font section: code editor (Monaco) monospace font + font size config. Both take effect immediately (the font
+ * input only writes to disk on blur, onChange live-previews), orchestrated by useAppearanceDraft. This section is grouped
+ * under "General" with a divider alongside language / theme.
+ * The editor color theme has been promoted to the global "theme" section (see ThemeSection), not here.
  *
- * 字体仿 VS Code `editor.fontFamily`：自由输入、可逗号分隔多个候选（按序优先），整体作为 font-family
- * 前缀拼到内置 mono 字体栈之前（拼接见 theme/resolveEditorFontFamily）。不做本机字体枚举（枚举会阻塞 UI
- * 1~2s）。
+ * The font mimics VS Code `editor.fontFamily`: free input, comma-separated multiple candidates (prioritized in order), the
+ * whole thing prepended as a font-family prefix before the built-in mono font stack (see theme/resolveEditorFontFamily for
+ * the concatenation). No local font enumeration (enumeration would block the UI for 1~2s).
  */
 export function EditorSection({
   fontFamily,
@@ -24,14 +25,14 @@ export function EditorSection({
   onFontSizeChange: (next: number) => void;
 }) {
   const { t } = useTranslation();
-  // 当前字号若不在预设档位（config 手改），并入下拉、按数值排序，保证选中态可见。
+  // If the current font size isn't among the preset tiers (hand-edited config), merge it into the dropdown and sort by value, ensuring the selected state is visible.
   const sizeOptions = [...new Set<number>([...EDITOR_FONT_SIZE_PRESETS, fontSize])].sort(
     (a, b) => a - b,
   );
 
   return (
     <section className="modal-section modal-section-divider">
-      {/* 字体为自由输入（可能较长的逗号分隔列表）→ 单独成行、输入框铺满，不与标题挤在一行。 */}
+      {/* The font is free input (possibly a long comma-separated list) → on its own row with the input filling the width, not crammed onto the title row. */}
       <div className="settings-field-stacked">
         <h4>{t('settings.editorFontTitle')}</h4>
         <input

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/LlmContextSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/LlmContextSection.tsx
@@ -3,16 +3,16 @@ import { LLM_CONTEXT_TIERS, formatTokens } from '../utils';
 import { TierSlider } from './TierSlider';
 
 /**
- * LLM 上下文长度：裁剪输入内容的上下文长度上限（token），32k~1M 间的习惯档位。
- * 复用轮询配置的数值拖拽组件（TierSlider）。本地 CLI 模式不生效（CLI 工具自管上下文）。
+ * LLM context length: the upper limit of the context length (tokens) for trimming input content, with common tiers between 32k~1M.
+ * Reuses the numeric drag component (TierSlider) from the polling config. Does not take effect in local CLI mode (the CLI tool manages context itself).
  */
 export function LlmContextSection({
   value,
   onChange,
 }: {
-  /** 当前上下文长度（token） */
+  /** Current context length (tokens) */
   value: number;
-  /** 选定档位 → 回传该档 token 数 */
+  /** Selected tier → pass back that tier's token count */
   onChange: (tokens: number) => void;
 }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/NotificationSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/NotificationSection.tsx
@@ -3,14 +3,17 @@ import type { Config } from '@meebox/shared';
 import { Switch } from '../../../common';
 import { invoke } from '../../../../api';
 
-// macOS 在系统层管控通知授权（应用无法代为开启）→ 仅 macOS 展示「打开系统通知设置」引导按钮。
+// macOS gates notification authorization at the system level (the app can't enable it on the user's behalf) → only macOS shows the "Open system notification settings" guidance button.
 const IS_MAC = navigator.platform.toLowerCase().includes('mac');
 
 /**
- * 通知分区：总开关 + 分类型系统通知——面向评审的（新 PR / 评论回复 / 评论 @）与面向「我创建的」PR 的
- * （新评论 / 被标记需修改 / 出现冲突）。总开关关闭时下属各项禁用（灰显但保留各自值）。系统通知受 OS 权限
- * 约束——用户在系统设置关闭后应用静默降级，此处仅控制应用侧意图。macOS dock「待回应」计数角标随总开关默认
- * 启用、无独立开关，故此处不列。
+ * Notification section: master switch + per-type system notifications — review-facing ones (new PR /
+ * comment reply / comment @) and "my authored" PR ones (new comment / marked needs-work / conflict
+ * appeared). When the master switch is off the sub-items are disabled (grayed out but keep their own
+ * values). System notifications are subject to OS permission — once the user disables them in system
+ * settings the app silently degrades; this only controls the app-side intent. The macOS dock
+ * "awaiting response" count badge is enabled by default with the master switch, has no independent
+ * switch, and so is not listed here.
  */
 export function NotificationSection({
   value,
@@ -122,7 +125,7 @@ export function NotificationSection({
         </li>
       </ul>
       {IS_MAC && (
-        // macOS 授权引导：系统层未授权时通知会被静默丢弃，应用无法代为开启 → 提供按钮跳转系统设置由用户开启。
+        // macOS authorization guidance: when unauthorized at the system level notifications are silently dropped and the app can't enable it on the user's behalf → provide a button to jump to system settings for the user to enable.
         <div className="settings-edit-row" style={{ marginTop: 8 }}>
           <span className="muted settings-sublist-desc" style={{ flex: 1 }}>
             {t('settings.notifyMacPermissionHint')}

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/PollerSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/PollerSection.tsx
@@ -6,9 +6,9 @@ export function PollerSection({
   value,
   onChange,
 }: {
-  /** 当前轮询秒数（字符串形态，与底层 pollerInput 一致） */
+  /** Current polling seconds (string form, consistent with the underlying pollerInput) */
   value: string;
-  /** 选定档位 → 回传该档秒数 */
+  /** Selected tier → return that tier's seconds */
   onChange: (seconds: number) => void;
 }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/ProxySection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/ProxySection.tsx
@@ -15,8 +15,8 @@ export function ProxySection({
       <div className="modal-section-head">
         <div className="modal-section-head-title">
           <h4>{t('settings.proxyTitle')}</h4>
-          {/* 启用状态用 chip 表达（绿=已启用/灰=未启用），与应用其它状态视觉一致；
-              地址不在此展示，详情见「配置」弹窗。 */}
+          {/* Enabled state shown as a chip (green=enabled / gray=disabled), visually consistent with
+              other app states; the address isn't shown here, see the "Configure" dialog for details. */}
           <span className={`settings-status-chip ${on ? 'is-on' : 'is-off'}`}>
             {on ? t('settings.proxyEnabledStatus') : t('settings.proxyDisabledStatus')}
           </span>

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/RuntimeSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/RuntimeSection.tsx
@@ -7,17 +7,17 @@ import { UpdateCheckButton } from '../elements/UpdateCheckButton';
 
 export function RuntimeSection({ info, updateEnabled }: { info: AppInfo; updateEnabled: boolean }) {
   const { t } = useTranslation();
-  // 复制后短暂切到「打勾 + 已复制」绿色态作反馈（无 toast 体系，按钮内联反馈）。
+  // After copying, briefly switch to a green "check + copied" state as feedback (no toast system, inline button feedback).
   const [copied, setCopied] = useState(false);
-  // pr-agent 运行时状态：从状态栏弱化下沉到此处按需展示，打开关于页时拉取。
+  // pr-agent runtime status: de-emphasized from the status bar down to here for on-demand display, fetched when the about page opens.
   const [prAgent, setPrAgent] = useState<PrAgentStatus | null>(null);
   useEffect(() => {
     void invoke('app:prAgentStatus', undefined)
       .then(setPrAgent)
       .catch(() => setPrAgent(null));
   }, []);
-  // 仅展示版本号（不显示 embedded/local-cli 运行策略——对用户无意义）：embedded 的 version 形如
-  // `pr-agent 0.36.0` → 取 `0.36.0`；local-cli 为 help 首行 → 截到首个空白前。
+  // Only show the version number (not the embedded/local-cli run strategy — meaningless to the user): embedded version looks like
+  // `pr-agent 0.36.0` → take `0.36.0`; local-cli is the first help line → truncate before the first whitespace.
   const prAgentVer = prAgent?.available
     ? prAgent.strategy === 'embedded'
       ? prAgent.version.replace(/^pr-agent\s+/, '')
@@ -25,10 +25,10 @@ export function RuntimeSection({ info, updateEnabled }: { info: AppInfo; updateE
     : null;
   const prAgentText = prAgent ? (prAgentVer ?? t('statusBar.prAgentUnavailable')) : '…';
 
-  // 操作系统：平台代号 + 系统版本合并展示（如「darwin 15.5」）。
+  // Operating system: platform code + system version shown combined (e.g. "darwin 15.5").
   const osText = `${info.platform} ${info.osVersion}`.trim();
 
-  // 整体运行环境信息的纯文本快照（每行「键: 值」），供一键复制粘贴到 issue / 反馈。
+  // Plain-text snapshot of the overall runtime environment info (each line "key: value"), for one-click copy-paste into issues / feedback.
   const infoText = [
     `${t('settings.appVersion')}: ${info.appVersion}`,
     `Electron: ${info.electronVersion}`,
@@ -87,7 +87,7 @@ export function RuntimeSection({ info, updateEnabled }: { info: AppInfo; updateE
           {t('settings.openDevTools')}
         </button>
       </div>
-      {/* 关于 & 反馈：低频社区链接。http(s) 外链由 App 顶层点击拦截走 openExternal 在系统浏览器打开。 */}
+      {/* About & feedback: low-frequency community links. http(s) external links are intercepted by the App top-level click and routed through openExternal to open in the system browser. */}
       <div className="settings-about-links">
         <span className="muted settings-about-label">{t('settings.aboutFeedback')}</span>
         <a

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/ServiceSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/ServiceSection.tsx
@@ -4,10 +4,13 @@ import type { Config } from '@meebox/shared';
 import { CopyIcon, EyeIcon, EyeOffIcon, Switch, SyncIcon } from '../../../common';
 
 /**
- * 本地 API 服务监听分区：总开关（分区头）+ 缩进「功能列表」逐行展示监听地址 / 访问令牌（行首圆点 +
- * 标签 + 说明，右侧控件），与「策略」「通知」等分区风格统一。地址为 http://<host>:<port> 组合，token
- * 可显示 / 复制 / 重新生成；任何开关状态下均可编辑。启用且无 token 时自动生成；非 loopback 绑定给安全
- * 警示。监听地址 / 端口 / token 均为**草稿制**——随底栏「保存」经 config:setService 生效，不保存则丢弃。
+ * Local API service listen section: master switch (section head) + an indented "feature list" showing
+ * the listen address / access token line by line (leading dot + label + description, controls on the
+ * right), stylistically consistent with the "Strategy" / "Notification" sections. The address is an
+ * http://<host>:<port> combination; the token can be revealed / copied / regenerated, and is editable
+ * under any switch state. When enabled with no token one is auto-generated; a non-loopback binding
+ * shows a security warning. Listen address / port / token are all **draft-based** — they take effect
+ * via config:setService with the bottom-bar "Save", and are discarded if not saved.
  */
 export function ServiceSection({
   value,
@@ -16,24 +19,24 @@ export function ServiceSection({
 }: {
   value: Config['service'];
   onChange: (next: Config['service']) => void;
-  /** 立即重新生成 token（写盘 + 即时生效）；启用且无 token 时也由此自动补一枚。 */
+  /** Regenerate the token immediately (write to disk + take effect instantly); also used to auto-add one when enabled with no token. */
   onRegenerateToken: () => void;
 }) {
   const { t } = useTranslation();
   const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
   const on = value.enabled;
-  // 暴露判定：非 loopback 绑定（0.0.0.0 / 局域网 IP 等）即视为可被同网段访问，给安全警示。
+  // Exposure check: a non-loopback binding (0.0.0.0 / LAN IP, etc.) is treated as accessible from the same subnet, so show a security warning.
   const host = value.host.trim();
   const exposed = host !== '' && !['127.0.0.1', 'localhost', '::1'].includes(host);
 
   const set = (patch: Partial<Config['service']>): void => onChange({ ...value, ...patch });
 
-  // 监听地址组与令牌组共用同一固定宽度，使两行右侧控件左右边缘对齐；组内输入框自适应填充剩余。
+  // The listen address group and the token group share the same fixed width so the right-side controls of both rows align at their left and right edges; the input inside each group flexibly fills the remainder.
   const CONTROL_W = 320;
 
   const handleEnabled = (v: boolean): void => {
-    if (v && !value.token) onRegenerateToken(); // 启用且无 token → 自动生成一枚
+    if (v && !value.token) onRegenerateToken(); // enabled with no token → auto-generate one
     set({ enabled: v });
   };
 
@@ -44,7 +47,7 @@ export function ServiceSection({
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      /* 复制失败静默 */
+      /* copy failure silenced */
     }
   };
 

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/ThemeSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/ThemeSection.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next';
 import { EDITOR_THEME_OPTIONS, type EditorTheme } from '@meebox/shared';
 
 /**
- * 全局主题分区：选择应用主题（Monaco 配色主题，亦驱动整个 GUI chrome 与浅 / 深语义色板）。
- * 'auto'（自动适应系统）走 i18n、其余主题用专名（GitHub Dark / Monokai…，各 UI 语言一致不翻译）。
+ * Global theme section: pick the app theme (Monaco color theme, also drives the whole GUI chrome and light / dark semantic palette).
+ * 'auto' (auto-adapt to system) goes through i18n; other themes use proper names (GitHub Dark / Monokai…, consistent across UI languages, not translated).
  */
 export function ThemeSection({
   theme,

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/TierSlider.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/TierSlider.tsx
@@ -2,9 +2,9 @@ import type { CSSProperties } from 'react';
 import { nearestTierIdx } from '../utils';
 
 /**
- * 离散档位滑块（数值拖拽组件）：拖的是档位索引而非数值，从而实现非线性步长 + 刻度吸附。
- * 轮询间隔 / 评审并发 / LLM 上下文长度等数值配置共用此组件（见 PollerSection 等）。
- * 仅负责滑块 + 刻度 + 右侧读数的呈现；具体档位 / 文案由调用方传入。
+ * Discrete tier slider (numeric drag component): drags the tier index rather than the value, achieving non-linear step size + tick snapping.
+ * Numeric configs such as poll interval / review concurrency / LLM context length share this component (see PollerSection etc.).
+ * Only responsible for rendering the slider + ticks + right-side readout; specific tiers / text are passed in by the caller.
  */
 export function TierSlider({
   tiers,
@@ -14,16 +14,16 @@ export function TierSlider({
   formatTick = String,
   formatValue,
 }: {
-  /** 档位数值集合（升序）；滑块在其索引上移动。 */
+  /** Tier value set (ascending); the slider moves over its indices. */
   tiers: readonly number[];
-  /** 当前数值（不在档位上时就近吸附到最接近档位）。 */
+  /** Current value (snaps to the nearest tier when not on a tier). */
   value: number;
-  /** 选定档位 → 回传该档数值。 */
+  /** Selected tier → passes back that tier's value. */
   onChange: (value: number) => void;
   ariaLabel: string;
-  /** 刻度文案（默认直接显示数值）。 */
+  /** Tick text (defaults to showing the value directly). */
   formatTick?: (tier: number) => string;
-  /** 右侧读数文案；省略则不渲染右侧读数（纯数字无单位、与刻度重复时可隐藏）。 */
+  /** Right-side readout text; omit to not render the right-side readout (can hide when it's a plain unitless number that duplicates the ticks). */
   formatValue?: (value: number) => string;
 }) {
   const idx = nearestTierIdx(tiers, value);
@@ -42,8 +42,8 @@ export function TierSlider({
           onChange={(e) => onChange(tiers[Number.parseInt(e.target.value, 10)]!)}
           aria-label={ariaLabel}
         />
-        {/* 档位刻度：按 thumb 实际停靠位置绝对定位（thumb 宽 12px，两端内缩 6px），
-            translateX(-50%) 居中对齐；当前档位高亮。 */}
+        {/* Tier ticks: absolutely positioned by the thumb's actual resting position (thumb is 12px wide, inset 6px at each end),
+            translateX(-50%) for center alignment; current tier highlighted. */}
         <div className="settings-range-ticks">
           {tiers.map((tier, i) => {
             const frac = i / (tiers.length - 1);

--- a/apps/desktop/src/renderer/src/components/features/settings/statusbar/LlmChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/statusbar/LlmChip.tsx
@@ -4,8 +4,8 @@ import type { Config } from '@meebox/shared';
 import { StarIcon, StatusChip } from '../../../common';
 
 /**
- * 当前 active LLM profile 概要。点击展开下拉，列出所有 profile 直接切换。
- * 未配置时显示 "LLM: 未配置"，点击直接打开设置。
+ * Summary of the currently active LLM profile. Click to expand a dropdown listing all profiles for direct switching.
+ * When unconfigured, shows "LLM: not configured"; clicking opens settings directly.
  */
 export function LlmChip({
   llm,
@@ -18,7 +18,7 @@ export function LlmChip({
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  // 点外面关菜单
+  // Click outside to close the menu
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent): void => {

--- a/apps/desktop/src/renderer/src/components/features/settings/statusbar/UserChip.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/statusbar/UserChip.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import type { ConnectionSummary } from '@meebox/ipc';
 import { PersonIcon } from '../../../common';
 
-/** 当前连接的登录用户概要（多连接时带连接名前缀）。无可识别用户时不渲染。 */
+/** Summary of the logged-in user for the current connection (prefixed with the connection name when there are multiple connections). Not rendered when there is no identifiable user. */
 export function UserChip({ connections }: { connections: ConnectionSummary[] }) {
   const { t } = useTranslation();
   const labels = connections

--- a/apps/desktop/src/renderer/src/components/features/settings/utils.ts
+++ b/apps/desktop/src/renderer/src/components/features/settings/utils.ts
@@ -1,14 +1,14 @@
-// 轮询间隔档位（秒）：低值细（30s 一档）、高值粗（分钟级），梯度放大。滑块拖的是
-// 档位索引而非秒数，从而实现非线性步长 + 离散刻度（见 TierSlider）。
+// Poll-interval tiers (seconds): fine at low values (30s per step), coarse at high values (minute-level), with a widening gradient. The slider drags
+// the tier index rather than the seconds, achieving a nonlinear step size + discrete ticks (see TierSlider).
 export const POLLER_TIERS = [60, 90, 120, 180, 300, 600, 900];
 
-// 评审任务并发档位（pr_agent.max_concurrency，1~8 整数）。
+// Review-task concurrency tiers (pr_agent.max_concurrency, integer 1~8).
 export const CONCURRENCY_TIERS = [1, 2, 3, 4, 5, 6, 7, 8];
 
-// LLM 上下文长度档位（token）：32k~1M 间的主要习惯配置。与 schema 默认 128000 对齐。
+// LLM context-length tiers (tokens): the main conventional configs between 32k~1M. Aligned with the schema default 128000.
 export const LLM_CONTEXT_TIERS = [32000, 64000, 128000, 256000, 512000, 1000000];
 
-/** 取最接近给定值的档位索引（配置值不在档位上时就近吸附）。 */
+/** Get the tier index closest to the given value (snap to the nearest when the config value isn't on a tier). */
 export function nearestTierIdx(tiers: readonly number[], value: number): number {
   let best = 0;
   for (let i = 1; i < tiers.length; i++) {
@@ -17,13 +17,13 @@ export function nearestTierIdx(tiers: readonly number[], value: number): number 
   return best;
 }
 
-/** token 数 → 习惯简写（32000 → 32k，1000000 → 1M）。 */
+/** Token count → conventional shorthand (32000 → 32k, 1000000 → 1M). */
 export function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${n / 1_000_000}M`;
   return `${Math.round(n / 1000)}k`;
 }
 
-/** 字节数 → 人类可读（B / KB / MB / GB）。 */
+/** Byte count → human-readable (B / KB / MB / GB). */
 export function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;

--- a/apps/desktop/src/renderer/src/components/layout/MainPane.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/MainPane.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react';
 
 /**
- * 主内容区（layout 薄壳）：仅提供语义化 `<main>` 槽位，内容由上层（App）按当前业务决定。
- * 不感知 PR 等具体领域，便于后续扩展非 PR 的主区业务——往这个槽里塞别的面板即可。
+ * Main content area (thin layout shell): provides only the semantic `<main>` slot; content is
+ * decided by the upper layer (App) per the current business.
+ * Domain-agnostic (unaware of PRs etc.), easing future non-PR main-area business—just drop another
+ * pane into this slot.
  */
 export function MainPane({ children }: { children: ReactNode }) {
   return <main className="main">{children}</main>;

--- a/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/Sidebar.tsx
@@ -14,48 +14,49 @@ import { useChatRunStore } from '../../stores/chat-run-store';
 import { HistoryIcon, PaneLoading } from '../common';
 import { PrItem } from '../features/pr';
 
-// 二级筛选键复用 @meebox/shared 的 PrSecondaryFilter（与本地 API 同源）：
-// 'conflict' / 'mergeable' 按远端 merge 状态跨 localStatus 横切；'all' 不限定。
+// Secondary filter key reuses @meebox/shared's PrSecondaryFilter (same source as the local API):
+// 'conflict' / 'mergeable' cut across localStatus by remote merge status; 'all' is unrestricted.
 export type FilterKey = PrSecondaryFilter;
 
-/** PR 列表范围：进行中（活跃，按发现分类 + 状态细分）/ 已关闭（归档冷存储，扁平只读浏览）。 */
+/** PR list scope: active (in-progress, subdivided by discovery category + status) / archived (cold-storage archive, flat read-only browsing). */
 export type SidebarScope = 'active' | 'archived';
 
 interface SidebarProps {
   prs: StoredPullRequest[];
   /**
-   * 活跃范围 PR（始终传入，与当前 scope 无关）：供一级发现分类标签的未读圆点计算——即便处在
-   * 「已关闭」视图，标签仍反映活跃分类的未读。缺省回退到 prs。
+   * Active-scope PRs (always passed, independent of the current scope): feeds the unread-dot
+   * computation for primary discovery-category tabs—even in the "archived" view, the tabs still
+   * reflect unread of active categories. Falls back to prs when omitted.
    */
   activePrs?: StoredPullRequest[];
   selectedId: string | null;
   onSelect: (pr: StoredPullRequest) => void;
   width: number;
   onResize: (next: number) => void;
-  /** 活动连接支持的发现分类（来自 capabilities）；为空 / undefined 时不渲染分类标签行。 */
+  /** Discovery categories supported by the active connection (from capabilities); when empty / undefined, the category tab row is not rendered. */
   availableFilters?: readonly PrDiscoveryFilter[];
-  /** 当前选中的发现分类。 */
+  /** Currently selected discovery category. */
   discoveryFilter?: PrDiscoveryFilter;
   onDiscoveryFilterChange?: (filter: PrDiscoveryFilter) => void;
-  /** 状态筛选（待处理 / 全部 / 冲突 / 可合并等），由 App 持有以便命令面板亦可驱动。 */
+  /** Status filter (pending / all / conflict / mergeable etc.), held by App so the command palette can drive it too. */
   statusFilter: FilterKey;
   onStatusFilterChange: (filter: FilterKey) => void;
-  /** 当前范围：进行中 / 已关闭。 */
+  /** Current scope: in-progress / archived. */
   scope: SidebarScope;
-  /** 切回「进行中」（无发现分类的平台用单一锚点；有发现分类则点 tab 经 onDiscoveryFilterChange 切回）。 */
+  /** Switch back to "in-progress" (platforms without discovery categories use a single anchor; with categories, clicking a tab goes back via onDiscoveryFilterChange). */
   onViewActive: () => void;
-  /** 切到「已关闭」（归档）范围。 */
+  /** Switch to the "archived" scope. */
   onViewArchived: () => void;
-  /** 列表数据加载中（如归档冷存储懒加载）：列表区显示 loading 占位，替代「无 PR」空态。 */
+  /** List data loading (e.g. archive cold-storage lazy load): the list area shows a loading placeholder in place of the "no PR" empty state. */
   loading?: boolean;
-  /** 活动连接是否支持 needs_work（「需修改」）评审态：决定非「待我评审」分类下是否保留「待处理」状态筛选。 */
+  /** Whether the active connection supports the needs_work ("needs work") review state: decides whether the "pending" status filter is kept under categories other than "review requested". */
   supportsNeedsWork?: boolean;
 }
 
 export const SIDEBAR_MIN_WIDTH = 240;
 export const SIDEBAR_MAX_WIDTH = 720;
 
-/** 发现分类标签 i18n key；实际展示哪几类由活动连接的 capabilities.discoveryFilters 决定。 */
+/** Discovery-category tab i18n keys; which categories actually show is decided by the active connection's capabilities.discoveryFilters. */
 const DISCOVERY_LABEL_KEYS: Record<PrDiscoveryFilter, string> = {
   'review-requested': 'sidebar.discoveryReviewRequested',
   created: 'sidebar.discoveryCreated',
@@ -72,8 +73,9 @@ export const FILTERS: ReadonlyArray<{ value: FilterKey; labelKey: string }> = [
   { value: 'mergeable', labelKey: 'sidebar.filterMergeable' },
 ];
 
-// reviewer 决断类（通过/需修改）：有发现分类标签时只对「待我评审」有意义，其余标签下恒空，
-// 故隐藏；无发现分类的场景仍展示全部六项状态筛选。
+// Reviewer-decision filters (approved/needs work): with discovery-category tabs they only make sense
+// under "review requested", being always empty under other tabs, so they are hidden; without
+// discovery categories, all six status filters are still shown.
 export const DECISION_STATUS_FILTERS: ReadonlySet<FilterKey> = new Set(['approved', 'needs_work']);
 
 interface PrGroup {
@@ -100,7 +102,7 @@ export function Sidebar({
   supportsNeedsWork = false,
 }: SidebarProps) {
   const { t } = useTranslation();
-  // 已关闭范围：扁平浏览（不分发现分类、不分状态、强制「全部」）；进行中范围维持原细分行为。
+  // Archived scope: flat browsing (no discovery categories, no status split, forced "all"); the in-progress scope keeps the original subdivided behavior.
   const isArchived = scope === 'archived';
   const startResize = (e: React.MouseEvent): void => {
     e.preventDefault();
@@ -124,34 +126,35 @@ export function Sidebar({
   };
 
   const [query, setQuery] = useState('');
-  // 切换 PR 类型（发现分类标签 / 进行中⇄已关闭范围）后清空搜索框，避免上一类型遗留的过滤条件连带到新类型。
+  // Clear the search box after switching PR type (discovery-category tab / in-progress⇄archived scope), to avoid the previous type's filter carrying over into the new type.
   useEffect(() => {
     setQuery('');
   }, [discoveryFilter, scope]);
-  // 状态筛选改由 App 持有（受控）：命令面板的「分类筛选」亦可驱动；折叠侧栏也不丢选择。
+  // Status filter is now held by App (controlled): the command palette's "category filter" can drive it too; collapsing the sidebar doesn't lose the selection.
   const filter = statusFilter;
   const setFilter = onStatusFilterChange;
-  // 哪些组当前折叠了。默认空集合 = 全部展开。
+  // Which groups are currently collapsed. Default empty set = all expanded.
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  // 评审建议台账 recommendation（per localId，手动 / AutoPilot 一视同仁），PR 列表 ★ 徽标用；
-  // prs 变化时批量重取。
+  // Review recommendation ledger (per localId, manual / AutoPilot treated alike), used for the ★ badge in the PR list;
+  // batch-refetched when prs changes.
   const [reviewVerdicts, setReviewVerdicts] = useState<
     Record<string, AgentRecommendationVerdict>
   >({});
 
-  // 「执行中」指示数据源：运行队列里有在跑 / 排队 run 的 PR（active + waiting），**并上**有编排 Agent
-  // 运行中的 PR（agentPrs，含纯思考阶段、无活跃工具 run 时）——补齐 agent 思考态下列表项缺执行中标记的空档。
+  // Data source for the "executing" indicator: PRs with a running / queued run in the run queue (active + waiting),
+  // **unioned with** PRs that have an orchestrating Agent running (agentPrs, including the pure-thinking phase with no active tool run)—filling the gap where list items lack an executing marker during the agent's thinking state.
   const { active, waiting, agentPrs } = useChatRunStore();
   const executingPrIds = useMemo(
     () => new Set([...active.map((r) => r.prLocalId), ...waiting.map((r) => r.prLocalId), ...agentPrs]),
     [active, waiting, agentPrs],
   );
 
-  // 状态筛选可见性随发现分类细化（localStatus = 本人的 reviewer 决断）：
-  // - 无发现分类（单一「待我评审」平台）：六项全展示。
-  // - 有发现分类：reviewer 决断类（通过 / 需修改）恒隐藏。「待处理」在「待我评审」恒有意义；其余分类
-  //   （我创建的 / 指派给我 / 提及我）下仅当平台支持 needs_work（GitHub / Bitbucket，可表达「需修改」语义）
-  //   时保留，GitLab（二元审批、无 needs_work）下「待处理」无意义、隐藏，只留 全部 / 冲突 / 可合并。
+  // Status-filter visibility refines with discovery category (localStatus = the user's own reviewer decision):
+  // - No discovery categories (single "review requested" platform): all six shown.
+  // - With discovery categories: reviewer-decision filters (approved / needs work) always hidden. "pending" is always
+  //   meaningful under "review requested"; under the other categories (created / assigned / mentioned) it is kept only
+  //   when the platform supports needs_work (GitHub / Bitbucket, which can express the "needs work" semantics),
+  //   while on GitLab (binary approval, no needs_work) "pending" is meaningless and hidden, leaving only all / conflict / mergeable.
   const hasDiscoveryTabs = Boolean(availableFilters && availableFilters.length > 0);
   const visibleFilters = useMemo(() => {
     if (!hasDiscoveryTabs) return FILTERS;
@@ -162,14 +165,14 @@ export function Sidebar({
       return true;
     });
   }, [hasDiscoveryTabs, discoveryFilter, supportsNeedsWork]);
-  // 当前选中的状态筛选在本分类下不可见时，回落到首个可见项（待我评审 → 待处理；其余 → 全部），避免按不可见筛选过滤。
+  // When the currently selected status filter is not visible under this category, fall back to the first visible item (review requested → pending; others → all), to avoid filtering by an invisible filter.
   useEffect(() => {
     if (!visibleFilters.some((f) => f.value === filter)) {
       setFilter(visibleFilters[0]?.value ?? 'all');
     }
   }, [visibleFilters, filter, setFilter]);
 
-  // AutoPilot 徽标：批量取当前 PR 的台账建议（prs 变化时刷新；ledger 在下次 poll 更新 prs 后体现）。
+  // AutoPilot badge: batch-fetch the ledger recommendations for the current PRs (refresh when prs changes; the ledger is reflected after the next poll updates prs).
   useEffect(() => {
     const localIds = prs.map((p) => p.localId);
     if (localIds.length === 0) {
@@ -185,7 +188,7 @@ export function Sidebar({
     };
   }, [prs]);
 
-  // 清空某 PR 执行历史会一并清掉其 AutoPilot 台账 → 即时清掉该 PR 的评审建议 ★（不必等下个 poll 重取）。
+  // Clearing a PR's execution history also clears its AutoPilot ledger → immediately clear that PR's review-recommendation ★ (no need to wait for the next poll to refetch).
   useEffect(() => {
     const unsub = subscribe('agent:reviewStatusCleared', (ev) => {
       setReviewVerdicts((prev) => {
@@ -198,8 +201,8 @@ export function Sidebar({
     return unsub;
   }, []);
 
-  // 评审完成（手动 / AutoPilot 都经 recordReviewSummaryMessage 写台账 + 广播 agent:conversationChanged）→
-  // 即时重取该 PR 的评审建议，让 ★ 立刻出现在 PR 列表，不必等下个 poll 刷新 prs 才体现。
+  // Review completion (both manual / AutoPilot write the ledger via recordReviewSummaryMessage + broadcast agent:conversationChanged) →
+  // immediately refetch that PR's review recommendation, so the ★ appears in the PR list at once, without waiting for the next poll to refresh prs.
   useEffect(() => {
     const unsub = subscribe('agent:conversationChanged', (ev) => {
       void invoke('agent:autopilotLedgers', { localIds: [ev.prLocalId] }).then((v) => {
@@ -213,16 +216,16 @@ export function Sidebar({
     return unsub;
   }, []);
 
-  // GitHub 发现分类：按 PR 上的 discoveryFilters 标记本地过滤（poller 已把四类都抓回来缓存），
-  // 切标签纯本地、瞬时、零远端请求。非 GitHub（discoveryFilter 未设）时用全量。
+  // GitHub discovery categories: filter locally by the discoveryFilters marked on each PR (the poller has already fetched and cached all four categories),
+  // so switching tabs is purely local, instantaneous, zero remote requests. For non-GitHub (discoveryFilter unset), use the full set.
   const scopedPrs = useMemo(
     () => prs.filter((p) => matchesDiscoveryFilter(p, !isArchived ? discoveryFilter : undefined)),
     [prs, discoveryFilter, isArchived],
   );
 
-  // 未读圆点始终基于**活跃** PR（缺省回退 prs）：即便当前在「已关闭」视图，一级标签仍反映活跃分类的未读。
+  // Unread dots are always based on **active** PRs (falls back to prs): even in the "archived" view, primary tabs still reflect unread of active categories.
   const unreadSourcePrs = activePrs ?? prs;
-  // 各一级发现分类下是否有未读 PR → 在标签文字后加未读圆点，提示该分类有新的待处理。
+  // Whether each primary discovery category has any unread PR → add an unread dot after the tab text, hinting the category has new items to handle.
   const unreadFilters = useMemo(() => {
     const s = new Set<PrDiscoveryFilter>();
     for (const p of unreadSourcePrs) {
@@ -231,7 +234,7 @@ export function Sidebar({
     }
     return s;
   }, [unreadSourcePrs]);
-  // 无发现分类平台的单一「进行中」锚点：任一活动 PR 未读即标圆点。
+  // Single "in-progress" anchor for platforms without discovery categories: mark the dot if any active PR is unread.
   const anyUnread = useMemo(() => unreadSourcePrs.some((p) => p.unread), [unreadSourcePrs]);
 
   const counts = useMemo(() => {
@@ -248,7 +251,7 @@ export function Sidebar({
       if (p.hasConflict) out.conflict += 1;
       if (p.mergeStatus?.canMerge) out.mergeable += 1;
     }
-    // 「我创建的」下「待处理」并入冲突 PR（作者需跟进），复用同源谓词重算、避免与冲突计数重复叠加。
+    // Under "created", "pending" folds in conflicting PRs (the author needs to follow up); recompute via the same-source predicate to avoid double-counting with the conflict count.
     if (!isArchived && discoveryFilter === 'created') {
       out.pending = scopedPrs.filter((p) => matchesSecondaryFilter(p, 'pending', 'created')).length;
     }
@@ -256,8 +259,8 @@ export function Sidebar({
   }, [scopedPrs, isArchived, discoveryFilter]);
 
   const filtered = useMemo(() => {
-    // 已关闭范围强制「全部」（不应用状态筛选）；进行中范围按当前状态筛选。过滤 / 检索语义复用
-    // @meebox/shared 纯谓词（与本地 API 同源），并传入一级发现分类以启用分类相关的语义细化。
+    // Archived scope forces "all" (no status filter applied); in-progress scope filters by the current status. Filter / search
+    // semantics reuse @meebox/shared's pure predicates (same source as the local API), passing in the primary discovery category to enable category-specific semantic refinement.
     const effFilter: FilterKey = isArchived ? 'all' : filter;
     const effPrimary = !isArchived ? discoveryFilter : undefined;
     return scopedPrs.filter(
@@ -273,7 +276,7 @@ export function Sidebar({
       if (list) list.push(pr);
       else m.set(key, [pr]);
     }
-    // 组按 repo 路径字母序；组内 PR 按远端 updatedAt 倒序（最新修改在上）
+    // Groups sorted alphabetically by repo path; PRs within a group sorted by remote updatedAt descending (most recently modified on top)
     return Array.from(m.entries())
       .map(([key, items]) => ({
         key,
@@ -282,7 +285,7 @@ export function Sidebar({
       .sort((a, b) => a.key.localeCompare(b.key));
   }, [filtered]);
 
-  // 搜索时强制展开（否则用户在折叠组里看不到匹配的 PR）
+  // Force expand while searching (otherwise the user won't see matching PRs inside collapsed groups)
   const searching = query.trim().length > 0;
 
   const toggleGroup = (key: string): void => {
@@ -302,8 +305,8 @@ export function Sidebar({
         title={t('sidebar.resizeTitle')}
         aria-label="resize sidebar"
       />
-      {/* 范围行（常驻）：左组 = 进行中（发现分类细分，或无分类平台的单一锚点）、右组 = 已关闭辅助切换。
-          左组始终有锚点，使「已关闭」恒为旁侧的次要项、不致被误读为唯一分类。 */}
+      {/* Scope row (always present): left group = in-progress (subdivided by discovery category, or a single anchor for platforms without categories), right group = archived auxiliary toggle.
+          The left group always has an anchor, keeping "archived" a secondary item to the side and not misread as the only category. */}
       <div className="sidebar-toolbar sidebar-scope" role="tablist" aria-label={t('sidebar.discoveryTablistAria')}>
         <div className="sidebar-scope-primary">
           {hasDiscoveryTabs && availableFilters && onDiscoveryFilterChange ? (
@@ -335,7 +338,7 @@ export function Sidebar({
             </button>
           )}
         </div>
-        {/* 非 tab：独立图标按钮（切换到已关闭范围），toggle 语义用 aria-pressed */}
+        {/* Not a tab: standalone icon button (switch to archived scope), toggle semantics via aria-pressed */}
         <button
           type="button"
           aria-pressed={isArchived}

--- a/apps/desktop/src/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/StatusBar.tsx
@@ -19,29 +19,30 @@ interface StatusBarProps {
   refreshing: boolean;
   sidebarCollapsed: boolean;
   chatCollapsed: boolean;
-  /** Poller 最近一次完成时间（ISO 字符串）；null 表示从未同步 */
+  /** Poller's most recent completion time (ISO string); null means never synced */
   lastSyncAt: string | null;
   onToggleSidebar: () => void;
   onToggleChat: () => void;
   onRefresh: () => void;
   onOpenSettings: () => void;
-  /** 切换 active LLM profile，由父组件做实际持久化 */
+  /** Switch the active LLM profile; the parent component does the actual persistence */
   onSwitchActiveLlm: (profileId: string) => void;
   /**
-   * 跳到指定 PR (供"pr-agent 运行中"chip 点击使用)。可空 —— 不传时 chip 仍展示但
-   * 不可点击。父组件传 `setSelectedId` 即可
+   * Jump to a given PR (used by the "pr-agent running" chip click). Nullable — when omitted the chip still
+   * shows but is not clickable. The parent component can just pass `setSelectedId`
    */
   onJumpToPr?: (localId: string) => void;
-  /** 启动检测到的新版本；非空且 hasUpdate 时展示「新版本」chip，点击跳转下载页。 */
+  /** New version detected at startup; when non-null and hasUpdate, show the "new version" chip, clicking jumps to the download page. */
   updateInfo?: UpdateCheckResult | null;
-  /** AutoPilot 是否启用（agent.autopilot.enabled）；点击切换，由父组件持久化。 */
+  /** Whether AutoPilot is enabled (agent.autopilot.enabled); click to toggle, persisted by the parent component. */
   autopilotEnabled: boolean;
   onToggleAutopilot: () => void;
 }
 
 /**
- * pr-agent 运行时 chip：仅在**不可用**（错误态）时显示红色「不可用」告警（可操作信息）。可用时的版本
- * 号已从状态栏弱化下沉到「关于」页展示（见 RuntimeSection），此处不再渲染，减少常态噪声。
+ * pr-agent runtime chip: shows a red "unavailable" warning (actionable info) only when **unavailable** (error state).
+ * The version number for the available case has been de-emphasized off the status bar and moved down to the "About"
+ * page (see RuntimeSection), and is no longer rendered here, reducing steady-state noise.
  */
 function PrAgentRuntimeChip({ status }: { status: PrAgentStatus }) {
   const { t } = useTranslation();
@@ -54,9 +55,9 @@ function PrAgentRuntimeChip({ status }: { status: PrAgentStatus }) {
 }
 
 /**
- * 应用状态栏（薄壳）：左侧折叠按钮 + 同步 / 仓库镜像 / pr-agent 运行时 / PR 计数 / 用户，
- * 右侧 pr-agent 活动 / AutoPilot / LLM / 更新，末尾 chat 折叠 + 设置。各业务 chip 由其所属
- * feature 提供（features/<x>/statusbar/），本组件只做组合与布局。
+ * App status bar (thin shell): left side collapse button + sync / repo mirror / pr-agent runtime / PR count / user,
+ * right side pr-agent activity / AutoPilot / LLM / update, and at the end chat collapse + settings. Each business chip
+ * is provided by its owning feature (features/<x>/statusbar/); this component only does composition and layout.
  */
 export function StatusBar({
   prsCount,
@@ -93,13 +94,13 @@ export function StatusBar({
         <PanelToggleIcon side="left" collapsed={sidebarCollapsed} />
       </button>
       <LastSyncChip at={lastSyncAt} refreshing={refreshing} onRefresh={onRefresh} />
-      {/* 当前正在 sync 的 repo (clone/fetch 中)。idle 不渲染 */}
+      {/* The repo currently being synced (cloning/fetching). Not rendered when idle */}
       <RepoSyncChip />
       {prAgent && <PrAgentRuntimeChip status={prAgent} />}
       <PrsCountChip count={prsCount} />
       <UserChip connections={connections} />
       <div className="statusbar-spacer" />
-      {/* pr-agent 活动 / 空闲指示。pr-agent 不可用时不显示（上方运行时 chip 已红色提示）。 */}
+      {/* pr-agent activity / idle indicator. Hidden when pr-agent is unavailable (the runtime chip above already shows a red warning). */}
       {prAgent?.available && <PrAgentActiveChip onJumpToPr={onJumpToPr} />}
       <AutopilotChip enabled={autopilotEnabled} onToggle={onToggleAutopilot} />
       <LlmChip llm={llm} onSwitch={onSwitchActiveLlm} onOpenSettings={onOpenSettings} />

--- a/apps/desktop/src/renderer/src/components/layout/TitleBar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/TitleBar.tsx
@@ -5,11 +5,11 @@ import type { SettingsCategory } from '../features/settings';
 import type { FilterKey } from './Sidebar';
 
 interface TitleBarProps {
-  /** 运行平台：macOS 需为红绿灯留出左侧占位；Windows/Linux 窗控由系统 overlay 画在右上。 */
+  /** Running platform: macOS needs left-side space reserved for the traffic-light buttons; Windows/Linux window controls are drawn top-right by the system overlay. */
   platform: Platform;
-  /** 标题区展示的上下文文案（如当前 PR 标题）；非必要、窄屏让位给命令面板，可省略隐藏。 */
+  /** Context text shown in the title area (e.g. the current PR title); non-essential, yields to the command palette on narrow screens, can be omitted/hidden. */
   title?: string;
-  /** 命令面板上下文：当前配置 + 选中 PR + 同步父级状态 + 打开设置面板。 */
+  /** Command palette context: current config + selected PR + synced parent state + open settings panel. */
   config: Config;
   selectedPrId: string | null;
   patchConfig: (updater: (c: Config) => Config) => void;
@@ -25,14 +25,14 @@ interface TitleBarProps {
 }
 
 /**
- * 无边框窗口的自绘标题栏（VS Code 风）。整条 `-webkit-app-region: drag` 可拖拽窗口，
- * 其中的交互元素需各自标 `no-drag`（见 styles/titlebar.scss）。
+ * Self-drawn title bar for the frameless window (VS Code style). The whole bar is `-webkit-app-region: drag`
+ * so the window can be dragged; interactive elements within it must each be marked `no-drag` (see styles/titlebar.scss).
  *
- * 平台差异：
- * - macOS：`titleBarStyle: hidden` 保留红绿灯，左侧留 72px 占位避免与品牌名重叠；
- *   左上空间被红绿灯占据，**不展示**应用图标，仅品牌名。
- * - Windows/Linux：`titleBarOverlay` 让系统在右上画最小化/最大化/关闭，故右侧留白，
- *   勿在右上角放可点元素（会被 overlay 覆盖）；左侧空闲，开头展示应用图标。
+ * Platform differences:
+ * - macOS: `titleBarStyle: hidden` keeps the traffic-light buttons, leaving 72px on the left to avoid overlapping the brand name;
+ *   the top-left space is occupied by the traffic lights, so the app icon is **not shown**, only the brand name.
+ * - Windows/Linux: `titleBarOverlay` lets the system draw minimize/maximize/close top-right, so the right side is left blank;
+ *   do not place clickable elements top-right (they would be covered by the overlay); the left side is free, showing the app icon at the start.
  */
 export function TitleBar({
   platform,
@@ -55,9 +55,9 @@ export function TitleBar({
     <header className={`app-titlebar${isMac ? ' app-titlebar--mac' : ''}`}>
       {!isMac && <img className="app-titlebar-icon" src={brandIcon} alt="" />}
       <div className="app-titlebar-brand">Code Meeseeks</div>
-      {/* PR 标题留在左侧原位（避开右上 Windows 窗控）；窄屏时右缘渐隐、被居中的命令面板浮层遮盖。 */}
+      {/* PR title stays in its original left position (avoiding the top-right Windows window controls); on narrow screens its right edge fades out and is covered by the centered command-palette overlay. */}
       {title && <div className="app-titlebar-title">{title}</div>}
-      {/* 命令面板：居中绝对浮层（DOM 置后→绘制在标题之上，输入框不透明底覆盖其下标题）。 */}
+      {/* Command palette: centered absolute overlay (placed later in DOM → drawn above the title, the input's opaque background covers the title beneath it). */}
       <div className="app-titlebar-center">
         <CommandPalette
           platform={platform}

--- a/apps/desktop/src/renderer/src/errors.ts
+++ b/apps/desktop/src/renderer/src/errors.ts
@@ -2,23 +2,23 @@ import { decodeAppError, errorDomain } from '@meebox/shared';
 import i18n from './i18n';
 
 /**
- * 把 main 进程 / 适配器 / fetch 抛出的原始异常翻成用户能读懂的文案。
+ * Translate raw exceptions thrown by the main process / adapters / fetch into text the user can understand.
  *
- * 设计原则：
- * - **不把原始 message 隐藏掉**，detail 字段保留原文便于诊断
- * - 只识别常见模式给个 title 标签，未匹配的直接落到"未知错误"标签
- * - 不在这里 console.error，调用方决定是否记日志
+ * Design principles:
+ * - **Do not hide the raw message**, the detail field keeps the original text for diagnosis
+ * - Only recognize common patterns to give a title label; unmatched ones fall to the "unknown error" label
+ * - Do not console.error here, the caller decides whether to log
  */
 export interface FormattedError {
-  /** 短标签，UI 顶部色字或图标旁文案，如"连接超时" */
+  /** Short label, colored text at the top of the UI or text next to an icon, e.g. "Connection timed out" */
   title: string;
-  /** 详情，给用户看的人话或原始 message */
+  /** Detail, human-readable text for the user or the raw message */
   detail: string;
-  /** 给可观测性 / 自动重试逻辑用的归类 */
+  /** Classification for observability / auto-retry logic */
   kind: 'timeout' | 'network' | 'auth' | 'not-found' | 'platform' | 'unknown';
 }
 
-// title/hint 存 i18n key，实际文案在 formatBackendError 用 i18n.t() 翻译（纯模块无法用 hook）
+// title/hint store i18n keys, the actual text is translated in formatBackendError via i18n.t() (a pure module cannot use hooks)
 const MATCHERS: Array<{
   re: RegExp;
   titleKey: string;
@@ -88,8 +88,8 @@ const MATCHERS: Array<{
 
 export function formatBackendError(err: unknown): FormattedError {
   const raw = err instanceof Error ? err.message : String(err);
-  // 先解码统一错误码（AppError 信封）→ 按码精确 i18n（errors.<CODE>，meta 作插值）。未注册码 / 缺 key →
-  // 通用兜底文案 + 显示原始码（便于报障）。非本信封 → 落到下方正则模式匹配（第三方 / 历史未编码错误兜底）。
+  // First decode the unified error code (AppError envelope) → precise i18n by code (errors.<CODE>, meta as interpolation). Unregistered code / missing key →
+  // generic fallback text + show the raw code (eases reporting). Not this envelope → fall to the regex pattern matching below (fallback for third-party / historical uncoded errors).
   const decoded = decodeAppError(raw);
   if (decoded) {
     const key = `errors.${decoded.code}`;

--- a/apps/desktop/src/renderer/src/hooks/useAppStores.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAppStores.ts
@@ -5,10 +5,10 @@ import { wireFindingClosuresStore } from '../stores/finding-closures-store';
 import { wireRepoSyncStore } from '../stores/repo-sync-store';
 
 /**
- * 把 IPC 事件流接到各全局 store（挂载到 React 树根，效果等价于「应用级 hook」）：
- * - chatRunStore：pr-agent 活动 run + 实时 stdout，ChatPane 跨 PR 切换可读回运行态
- * - repoSyncStore：repo 镜像 clone/fetch 进度，StatusBar 任意时刻可读当前同步任务
- * - draftsStore：草稿写盘后 drafts:changed 触发指定 PR 的草稿列表自动刷新
+ * Wire the IPC event streams to each global store (mounted at the React tree root, effectively an "app-level hook"):
+ * - chatRunStore: pr-agent active run + real-time stdout, ChatPane can read back the run state when switching across PRs
+ * - repoSyncStore: repo mirror clone/fetch progress, StatusBar can read the current sync task at any time
+ * - draftsStore: after a draft is written to disk, drafts:changed triggers an auto-refresh of the given PR's draft list
  */
 export function useAppStores(): void {
   useEffect(() => wireChatRunStore(), []);

--- a/apps/desktop/src/renderer/src/hooks/useBootstrap.ts
+++ b/apps/desktop/src/renderer/src/hooks/useBootstrap.ts
@@ -16,17 +16,18 @@ export interface BootstrapState {
 }
 
 interface UseBootstrapParams {
-  /** PR 列表 store 的写入口（usePullRequests）：启动 / 热刷新时注入最新列表。 */
+  /** Write entry point for the PR list store (usePullRequests): injects the latest list on bootstrap / hot refresh. */
   setPrs: Dispatch<SetStateAction<StoredPullRequest[]>>;
-  /** 读缓存重拉 PR 列表（usePullRequests）：poll tick / 窗口聚焦时调用。 */
+  /** Re-fetch the PR list from cache (usePullRequests): called on poll tick / window focus. */
   reloadPrs: () => Promise<void>;
 }
 
 /**
- * 应用启动与全局生命周期：首帧前加载 boot（info/paths/config/prAgent + 初始 PR 列表 + 连接摘要 +
- * 最近同步）并定档 UI 语言；运行时跟随 config.language 切换；订阅 poll tick（刷新最近同步 + 重拉
- * 列表 + 补连接摘要）与窗口聚焦刷新；并提供首启向导完成 / 连接热生效后的整体重载。派生 needsOnboarding
- * 供 App 决定是否进向导。
+ * App bootstrap and global lifecycle: before the first frame, loads boot (info/paths/config/prAgent + initial
+ * PR list + connection summary + last sync) and locks in the UI language; switches at runtime following
+ * config.language; subscribes to poll tick (refresh last sync + reload list + top up connection summary) and
+ * window focus refresh; and provides a full reload after onboarding completes / connections take effect hot.
+ * Derives needsOnboarding for App to decide whether to enter the wizard.
  */
 export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
   boot: BootstrapState | null;
@@ -35,19 +36,20 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
   needsOnboarding: boolean;
   completeOnboarding: (result: OnboardingResult) => Promise<void>;
   refreshBootAndPrs: () => Promise<void>;
-  /** 乐观更新 boot.config（IPC 写盘后本地同步，如切 LLM / 切 AutoPilot / 设置页改动）。 */
+  /** Optimistically update boot.config (local sync after IPC persists, e.g. switching LLM / AutoPilot / settings page edits). */
   patchConfig: (fn: (config: Config) => Config) => void;
 } {
   const [boot, setBoot] = useState<BootstrapState | null>(null);
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [lastSyncAt, setLastSyncAt] = useState<string | null>(null);
-  // 仅调试用：localStorage 里 meebox.forceOnboarding='1' 时强制进首启向导，不必动 config.yaml。
+  // Debug only: when localStorage meebox.forceOnboarding='1', force entry into the onboarding wizard without touching config.yaml.
   const [forceOnboarding, setForceOnboarding] = useState(
     () => localStorage.getItem('meebox.forceOnboarding') === '1',
   );
 
-  // 连接改动（尤其切换活动连接）后整体刷新 boot：活动连接变化后 main 端 app:connections /
-  // prs:list 都随之变，必须重拉，否则 boot.connections、PR 列表会过期。
+  // Full boot refresh after connection changes (especially switching the active connection): after the active
+  // connection changes, main's app:connections / prs:list both change, so a re-fetch is mandatory or boot.connections
+  // and the PR list go stale.
   const refreshBootAndPrs = useCallback(async (): Promise<void> => {
     const [config, connections, freshPrs, lastSync] = await Promise.all([
       invoke('config:read', undefined),
@@ -60,7 +62,7 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
     setLastSyncAt(lastSync.at);
   }, [setPrs]);
 
-  // 启动加载：拉齐 boot 数据 + 初始列表，并先把 UI 语言切到目标并等资源加载完，再 setBoot 渲染主界面。
+  // Bootstrap load: fetch all boot data + initial list, first switch the UI language to the target and wait for resources to load, then setBoot to render the main UI.
   useEffect(() => {
     void (async () => {
       try {
@@ -88,11 +90,12 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
     })();
   }, [setPrs]);
 
-  // 运行时语言切换（如设置页改 config.language）：仅依赖 config.language。
-  // **不能依赖整个 boot**——poll:tick 会 setBoot 刷新 connections 等字段，boot 频繁换新引用；
-  // 若依赖 boot，每次 poll 都会 i18n.changeLanguage(同一语言) → react-i18next 发 languageChanged
-  // → 所有 useTranslation 的 t 换新引用 → 凡是 effect 依赖 t 的组件（如 InlineCodeContext 抓取代码
-  // 片段的 effect）都被无谓重跑，内嵌 Monaco 随之 setSnippet(null)→重建 → 刷新抖动。
+  // Runtime language switch (e.g. settings page changes config.language): depends only on config.language.
+  // **Must not depend on the whole boot** — poll:tick calls setBoot to refresh fields like connections, so boot
+  // frequently gets a new reference; if it depended on boot, every poll would call i18n.changeLanguage(same language)
+  // → react-i18next emits languageChanged → t for every useTranslation gets a new reference → any component whose
+  // effect depends on t (e.g. InlineCodeContext's effect that grabs code snippets) reruns needlessly, and the embedded
+  // Monaco then setSnippet(null)→rebuilds → refresh jitter.
   const configLanguage = boot?.config.language;
   useEffect(() => {
     if (configLanguage === undefined) return;
@@ -101,8 +104,9 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
     void i18n.changeLanguage(lang);
   }, [configLanguage]);
 
-  // poll tick：刷新「最近同步」+ 重拉列表（后台轮询新增/删除即时反映）+ 补连接摘要
-  // （启动 ping 在建窗后才完成，借首轮 tick 把状态栏用户/能力位补上）。
+  // poll tick: refresh "last sync" + reload list (background polling reflects additions/deletions immediately) + top up
+  // connection summary (the startup ping only completes after the window is built, so use the first tick to fill in the
+  // status bar user/capability bits).
   useEffect(() => {
     if (!window.api) return;
     return subscribe('poll:tick', (info) => {
@@ -111,14 +115,14 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
       void invoke('app:connections', undefined).then(
         (connections) => setBoot((b) => (b ? { ...b, connections } : b)),
         () => {
-          /* 摘要刷新失败不影响主流程 */
+          /* summary refresh failure does not affect the main flow */
         },
       );
     });
   }, [reloadPrs]);
 
-  // 窗口重新获得焦点时主动 refresh 远端：拉 PR meta，Bitbucket 上加 comment / 改状态后
-  // PR.updatedAt 跳变 → PrPanel 的 prUpdatedAt dep 触发 → force listComments 拉新评论。
+  // Proactively refresh the remote when the window regains focus: fetch PR meta; on Bitbucket, after adding a comment /
+  // changing status, PR.updatedAt jumps → PrPanel's prUpdatedAt dep fires → force listComments to fetch new comments.
   useEffect(() => {
     if (!boot) return;
     const onFocus = (): void => {
@@ -127,7 +131,7 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
           await invoke('prs:refresh', undefined);
           await reloadPrs();
         } catch {
-          // 静默：focus 触发的刷新失败不该弹错给用户
+          // Silent: a focus-triggered refresh failure should not surface an error to the user
         }
       })();
     };
@@ -135,8 +139,8 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
     return () => window.removeEventListener('focus', onFocus);
   }, [boot, reloadPrs]);
 
-  // 首启向导完成：落盘连接（必）+ LLM / 缓存目录（按需），再整体重载 boot；boot.config 拿到有效
-  // active 连接后 needsOnboarding 派生为 false，向导自然卸载、切入主界面。
+  // Onboarding complete: persist connection (required) + LLM / cache dir (as needed), then fully reload boot; once
+  // boot.config has a valid active connection, needsOnboarding derives to false, the wizard unmounts, and we cut into the main UI.
   const completeOnboarding = useCallback(
     async (result: OnboardingResult): Promise<void> => {
       await invoke('config:setConnections', {
@@ -153,7 +157,7 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
         });
       }
       const trimmedRepos = result.reposDir.trim();
-      // 注意：与初值不同才写盘 —— 这里用最新一次 read 比对（boot 闭包可能旧），交给 main 幂等即可。
+      // Note: only persist when different from the initial value — compare against the latest read here (the boot closure may be stale), leaving idempotency to main.
       if (trimmedRepos) {
         const cur = await invoke('config:read', undefined);
         if (trimmedRepos !== (cur.workspace.repos_dir ?? '')) {
@@ -161,7 +165,7 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
         }
       }
       await refreshBootAndPrs();
-      // 走完向导清掉调试 flag，避免强制模式下完成后仍被困在向导
+      // Clear the debug flag after finishing the wizard, to avoid staying stuck in the wizard after completing in forced mode
       if (forceOnboarding) {
         localStorage.removeItem('meebox.forceOnboarding');
         setForceOnboarding(false);
@@ -170,8 +174,8 @@ export function useBootstrap({ setPrs, reloadPrs }: UseBootstrapParams): {
     [forceOnboarding, refreshBootAndPrs],
   );
 
-  // gate 条件 = 有无「有效的 active 连接」：连接为空 / active 悬空都触发首启向导。
-  // 不依赖一次性 firstRun 标记 —— 用户清空连接后下次进入仍会回到向导。
+  // Gate condition = whether there is a "valid active connection": empty connections / dangling active both trigger the onboarding wizard.
+  // Does not rely on a one-time firstRun flag — after the user clears connections, the next entry still returns to the wizard.
   const needsOnboarding =
     !!boot &&
     (forceOnboarding ||

--- a/apps/desktop/src/renderer/src/hooks/useDockBadge.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDockBadge.ts
@@ -3,9 +3,11 @@ import type { Config, StoredPullRequest } from '@meebox/shared';
 import { invoke } from '../api';
 
 /**
- * macOS dock 角标同步：把活跃 PR「@我 / 回复我」待回应总数推给主进程落到 dock 图标。角标无独立开关——随通知
- * 总开关默认启用，关闭则置 0 清除；非 macOS 直接跳过（主进程也仅在 macOS 落地）。随 PR 列表 / 通知配置变化
- * 重算并推送。各 PR 计数已在 poll 端封顶 10，故总数自带上界。
+ * macOS dock badge sync: pushes the total pending-response count of active PRs ("@me / replies to me") to the main
+ * process to land on the dock icon. The badge has no independent switch — it follows the notification master switch,
+ * enabled by default, and is set to 0 to clear when disabled; skipped outright on non-macOS (the main process also
+ * only lands it on macOS). Recomputes and pushes as the PR list / notification config changes. Each PR's count is
+ * already capped at 10 on the poll side, so the total has a built-in upper bound.
  */
 export function useDockBadge({
   prs,
@@ -22,7 +24,7 @@ export function useDockBadge({
       ? prs.reduce((sum, p) => sum + (p.unreadMentionCount ?? 0), 0)
       : 0;
     void invoke('app:setBadgeCount', { count }).catch(() => {
-      /* 角标失败不影响主流程 */
+      /* badge failure does not affect the main flow */
     });
   }, [prs, platform, notifications]);
 }

--- a/apps/desktop/src/renderer/src/hooks/useExternalLinkGuard.ts
+++ b/apps/desktop/src/renderer/src/hooks/useExternalLinkGuard.ts
@@ -2,9 +2,9 @@ import { useEffect } from 'react';
 import { invoke } from '../api';
 
 /**
- * 全局外链跳转防护：所有 UGC 场景（评论 / PR 描述 / finding / chat 等）内的
- * `<a href="http(s)://">` 点击都走系统默认浏览器，不允许 Electron 在 app window 内直接跳转
- * 覆盖整个界面。capture 阶段 listener 先于 React onClick 跑。
+ * Global external link navigation guard: clicks on `<a href="http(s)://">` in any UGC scenario (comments / PR
+ * description / finding / chat, etc.) all go through the system default browser; Electron is not allowed to navigate
+ * directly within the app window and cover the entire UI. The capture-phase listener runs before React onClick.
  */
 export function useExternalLinkGuard(): void {
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/useGlobalShortcuts.ts
+++ b/apps/desktop/src/renderer/src/hooks/useGlobalShortcuts.ts
@@ -3,14 +3,15 @@ import { invoke } from '../api';
 import { chatRunStore } from '../stores/chat-run-store';
 
 /**
- * 窗口级全局快捷键（VS Code 风），统一在此挂一个 `keydown` 监听：
- * - **F5**：对当前选中 PR 运行自动评审（与命令面板同逻辑：有选中 PR、可参与、且未在跑才触发——重入保护）。
- * - **DevTools**：mac ⌥⌘I / 其余 Ctrl+Shift+I（带 Shift/Alt，与下面单修饰键的 B/J 区分）。
- * - **查看已关闭**：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）。
- * - **布局开关**：Ctrl/Cmd+B 切 PR 列表（左侧栏）、Ctrl/Cmd+J 切对话面板（右侧）；单修饰键，排除 Shift/Alt
- *   （避开 Cmd+Shift+P 命令面板）。
+ * Window-level global shortcuts (VS Code style), all attached to a single `keydown` listener here:
+ * - **F5**: run auto review on the currently selected PR (same logic as the command palette: only triggers when there
+ *   is a selected PR, it's engageable, and it's not already running — reentrancy guard).
+ * - **DevTools**: mac ⌥⌘I / otherwise Ctrl+Shift+I (with Shift/Alt, distinguished from the single-modifier B/J below).
+ * - **View closed**: mac ⌘⇧H (avoiding the system "Hide App" ⌘H) / otherwise Ctrl+H (browser history convention).
+ * - **Layout toggles**: Ctrl/Cmd+B toggles the PR list (left sidebar), Ctrl/Cmd+J toggles the chat panel (right);
+ *   single modifier, excluding Shift/Alt (avoiding the Cmd+Shift+P command palette).
  *
- * `selectedId` / `canEngage` 经 ref 读实时值，使监听只随 platform 与几个稳定回调重建、不随选中 PR 频繁重订阅。
+ * `selectedId` / `canEngage` are read live via ref, so the listener rebuilds only with platform and a few stable callbacks, not resubscribing frequently as the selected PR changes.
  */
 export function useGlobalShortcuts({
   platform,
@@ -27,7 +28,7 @@ export function useGlobalShortcuts({
   setSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
   setChatCollapsed: Dispatch<SetStateAction<boolean>>;
 }): void {
-  // 选中 PR / 可参与态的 ref：供稳定监听读实时值，免得每次切 PR 重订阅。
+  // Refs for the selected PR / engageable state: let the stable listener read live values, avoiding a resubscribe on every PR switch.
   const selectedIdRef = useRef(selectedId);
   selectedIdRef.current = selectedId;
   const canEngageRef = useRef(canEngage);
@@ -37,7 +38,7 @@ export function useGlobalShortcuts({
     const isMac = platform === 'darwin';
     const onKey = (e: KeyboardEvent): void => {
       const k = e.key.toLowerCase();
-      // F5：对当前选中 PR 运行自动评审（有选中 PR、可参与、且未在跑才触发——重入保护）
+      // F5: run auto review on the currently selected PR (only triggers when there is a selected PR, it's engageable, and it's not already running — reentrancy guard)
       if (k === 'f5') {
         const id = selectedIdRef.current;
         if (id && canEngageRef.current && !chatRunStore.getSnapshot().agentPrs.includes(id)) {
@@ -46,7 +47,7 @@ export function useGlobalShortcuts({
         }
         return;
       }
-      // DevTools：mac ⌥⌘I / 其余 Ctrl+Shift+I（带 Shift/Alt，与下面单修饰键的 B/J 区分）
+      // DevTools: mac ⌥⌘I / otherwise Ctrl+Shift+I (with Shift/Alt, distinguished from the single-modifier B/J below)
       if (k === 'i') {
         const devtools = isMac
           ? e.metaKey && e.altKey && !e.shiftKey && !e.ctrlKey
@@ -57,7 +58,7 @@ export function useGlobalShortcuts({
         }
         return;
       }
-      // 查看已关闭（history）：mac ⌘⇧H（避开系统「隐藏应用」⌘H）/ 其余 Ctrl+H（浏览器历史惯例）
+      // View closed (history): mac ⌘⇧H (avoiding the system "Hide App" ⌘H) / otherwise Ctrl+H (browser history convention)
       if (k === 'h') {
         const wantArchived = isMac
           ? e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey
@@ -68,7 +69,7 @@ export function useGlobalShortcuts({
         }
         return;
       }
-      // 单修饰键布局开关：Ctrl/Cmd+B（PR 列表）、Ctrl/Cmd+J（对话面板）
+      // Single-modifier layout toggles: Ctrl/Cmd+B (PR list), Ctrl/Cmd+J (chat panel)
       const mod = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
       if (!mod || e.shiftKey || e.altKey) return;
       if (k === 'b') {

--- a/apps/desktop/src/renderer/src/hooks/usePanelLayout.ts
+++ b/apps/desktop/src/renderer/src/hooks/usePanelLayout.ts
@@ -8,8 +8,8 @@ function clampWidth(raw: string | null, min: number, max: number): number {
 }
 
 /**
- * 左右两栏（PR 列表 / chat）的宽度与折叠态：初值从 localStorage 读（夹到各自 min/max），
- * 变化即回写。纯 UI 布局态，不涉及业务。
+ * Width and collapsed state of the two side panels (PR list / chat): initial values read from localStorage (clamped
+ * to each one's min/max), written back on change. Pure UI layout state, no business logic involved.
  */
 export function usePanelLayout(): {
   sidebarWidth: number;
@@ -31,7 +31,7 @@ export function usePanelLayout(): {
     clampWidth(localStorage.getItem('meebox.chatWidth'), CHAT_MIN_WIDTH, CHAT_MAX_WIDTH),
   );
   const [chatCollapsed, setChatCollapsed] = useState<boolean>(
-    // 默认收起：chat 早期是空壳，避免空占地方
+    // Collapsed by default: chat was an empty shell early on, avoid taking up space for nothing
     () => (localStorage.getItem('meebox.chatCollapsed') ?? '1') === '1',
   );
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/hooks/usePrNavigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/usePrNavigation.ts
@@ -4,8 +4,8 @@ import { invoke, subscribe } from '../api';
 import { formatBackendError } from '../errors';
 
 /**
- * 跨组件跳转意图（M4）：ChatPane finding card 点「编辑」/ PublishReviewModal anchor 点击 / 通知点击 inline
- * 评论 → 这里 set → PrPanel 切到 Diff tab + 透传给 DiffView 做 scroll/highlight/(可选)open edit zone，消费完清空。
+ * Cross-component jump intent (M4): ChatPane finding card "edit" click / PublishReviewModal anchor click / notification click on inline
+ * comment → set here → PrPanel switches to Diff tab + passes through to DiffView for scroll/highlight/(optional) open edit zone, cleared once consumed.
  */
 export interface PendingDiffNav {
   runId?: string;
@@ -14,25 +14,25 @@ export interface PendingDiffNav {
 }
 
 export interface PrNavigation {
-  /** 列表范围：进行中（活跃）/ 已关闭（归档冷存储，懒加载、只读）。 */
+  /** List scope: in-progress (active) / closed (archived cold storage, lazy-loaded, read-only). */
   scope: 'active' | 'archived';
-  /** GitHub 发现分类（运行时筛选，不持久化）；仅活动连接支持时在 PR 列表展示。 */
+  /** GitHub discovery category (runtime filter, not persisted); shown in PR list only when the active connection supports it. */
   discoveryFilter: PrDiscoveryFilter;
-  /** 当前展示列表（归档范围用归档列表，其余用活跃列表）。 */
+  /** Currently displayed list (archived scope uses the archived list, otherwise the active list). */
   displayedPrs: StoredPullRequest[];
-  /** 当前展示列表里解析出的选中 PR（解析不到回 null）。 */
+  /** Selected PR resolved from the currently displayed list (null when not resolvable). */
   selectedPr: StoredPullRequest | null;
-  /** 归档冷存储拉取中（列表区据此显示 loading）。 */
+  /** Archived cold storage fetch in progress (the list area shows loading based on this). */
   archivedLoading: boolean;
-  /** 选发现分类（侧栏 tab / 命令面板）→ 回到「进行中」范围并切分类。 */
+  /** Select a discovery category (sidebar tab / command panel) → return to "in-progress" scope and switch category. */
   selectDiscovery: (f: PrDiscoveryFilter) => void;
-  /** 切到「进行中」范围。 */
+  /** Switch to "in-progress" scope. */
   viewActive: () => void;
-  /** 切到「已关闭」范围（触发懒加载）。 */
+  /** Switch to "closed" scope (triggers lazy load). */
   viewArchived: () => void;
-  /** 按 URL 打开当前平台 PR（命令面板「打开 URL」）：定位本地或拉取存档后切到对应范围并选中；失败弹 toast。 */
+  /** Open a PR of the current platform by URL (command panel "open URL"): locate locally or fetch the archive, then switch to the matching scope and select it; shows a toast on failure. */
   openPrByUrl: (url: string) => Promise<void>;
-  /** 定位并选中某 PR（活跃命中切活跃 + 必要时切分类 + 标已读；否则视为已归档 → 切归档范围、加载归档列表后选中）。 */
+  /** Locate and select a PR (active hit switches to active + switches category if needed + marks read; otherwise treated as archived → switch to archived scope, load the archived list, then select). */
   jumpToPr: (localId: string) => Promise<void>;
   pendingDiffNav: PendingDiffNav | null;
   setPendingDiffNav: Dispatch<SetStateAction<PendingDiffNav | null>>;
@@ -41,11 +41,11 @@ export interface PrNavigation {
 }
 
 /**
- * PR 导航 / 范围领域：在 {@link usePullRequests} 的列表 + 选中之上，统管发现分类、活跃 / 归档范围切换、
- * 归档冷存储懒加载、按 URL 打开、定位跳转（活跃 / 归档统一逻辑），并消费系统通知点击的导航意图
- * （`notification:activate` → jumpToPr + inline 评论跳 Diff 行 / summary 评论开「活动」标签）。
+ * PR navigation / scope domain: on top of {@link usePullRequests}'s list + selection, governs discovery categories, active / archived scope switching,
+ * archived cold storage lazy loading, opening by URL, locate-and-jump (unified active / archived logic), and consumes navigation intent from system notification clicks
+ * (`notification:activate` → jumpToPr + inline comment jumps to Diff line / summary comment opens the "activity" tab).
  *
- * 选中态 / 已读由 usePullRequests 拥有（经入参传入）；本 hook 只负责「去哪儿、看哪个范围」。
+ * Selection state / read status is owned by usePullRequests (passed in via props); this hook only handles "where to go, which scope to view".
  */
 export function usePrNavigation({
   prs,
@@ -63,13 +63,13 @@ export function usePrNavigation({
   const [discoveryFilter, setDiscoveryFilter] = useState<PrDiscoveryFilter>('review-requested');
   const [scope, setScope] = useState<'active' | 'archived'>('active');
   const [archivedPrs, setArchivedPrs] = useState<StoredPullRequest[]>([]);
-  // 归档冷存储拉取中：列表区据此显示 loading（归档规模大、可能慢；PaneLoading 自带 150ms 延迟，快路径不闪）。
+  // Archived cold storage fetch in progress: the list area shows loading based on this (archives are large and may be slow; PaneLoading has a built-in 150ms delay, so the fast path doesn't flash).
   const [archivedLoading, setArchivedLoading] = useState(false);
   const [pendingDiffNav, setPendingDiffNav] = useState<PendingDiffNav | null>(null);
-  // 通知点击 summary 评论 → 请求 PrPanel 切到「活动」对话标签（inline 评论走 pendingDiffNav）。
+  // Notification click on a summary comment → request PrPanel to switch to the "activity" conversation tab (inline comments go through pendingDiffNav).
   const [pendingTab, setPendingTab] = useState<'activity' | null>(null);
 
-  // 进入「已关闭」范围时懒加载归档冷存储（每次进入重取，纳入此后新归档的 PR）；离开不清，便于来回切。
+  // Lazy-load archived cold storage on entering "closed" scope (re-fetch on each entry to include newly archived PRs); don't clear on leaving, to make back-and-forth switching easy.
   useEffect(() => {
     if (scope !== 'archived') return;
     let cancelled = false;
@@ -86,7 +86,7 @@ export function usePrNavigation({
     };
   }, [scope]);
 
-  // 选发现分类（侧栏 tab / 命令面板）即回到「进行中」范围；「查看已关闭」切到归档范围。
+  // Selecting a discovery category (sidebar tab / command panel) returns to "in-progress" scope; "view closed" switches to archived scope.
   const selectDiscovery = useCallback((f: PrDiscoveryFilter) => {
     setScope('active');
     setDiscoveryFilter(f);
@@ -94,7 +94,7 @@ export function usePrNavigation({
   const viewActive = useCallback(() => setScope('active'), []);
   const viewArchived = useCallback(() => setScope('archived'), []);
 
-  // 当前发现分类的 ref：供 openPrByUrl / jumpToPr 在稳定回调里读最新值，免得把 discoveryFilter 进依赖、频繁重建。
+  // Ref to the current discovery category: lets openPrByUrl / jumpToPr read the latest value in stable callbacks, avoiding putting discoveryFilter in the deps and rebuilding frequently.
   const discoveryFilterRef = useRef(discoveryFilter);
   discoveryFilterRef.current = discoveryFilter;
 
@@ -104,10 +104,10 @@ export function usePrNavigation({
         const res = await invoke('prs:openByUrl', { url });
         setScope(res.location);
         if (res.location === 'archived') {
-          // 归档范围（已存在归档 / 新拉取存档）需重载列表纳入目标 PR。
+          // Archived scope (already archived / newly fetched archive) needs a list reload to include the target PR.
           setArchivedPrs(await invoke('prs:listArchived', undefined));
         } else if (
-          // 活跃 PR：若当前发现分类不含它，落到包含它的分类，确保侧栏能展示并高亮（否则只剩详情显示、列表无选中）。
+          // Active PR: if the current discovery category doesn't include it, fall to a category that does, ensuring the sidebar can show and highlight it (otherwise only the detail view shows, with no list selection).
           res.discoveryFilters.length > 0 &&
           !res.discoveryFilters.includes(discoveryFilterRef.current)
         ) {
@@ -122,12 +122,12 @@ export function usePrNavigation({
     [setSelectedId, markRead, notifyError],
   );
 
-  // 活跃 PR 列表 ref：供通知点击 / 状态栏跳转在稳定回调里读最新值，免得把 prs 进依赖、频繁重建。
+  // Ref to the active PR list: lets notification clicks / status bar jumps read the latest value in stable callbacks, avoiding putting prs in the deps and rebuilding frequently.
   const prsRef = useRef(prs);
   prsRef.current = prs;
-  // 状态栏运行指示 / 通知点击 → 定位 PR。任务运行期间该 PR 可能已被 poll 归档（任务不取消、仍在跑），故活跃列表
-  // 里找不到时视为已归档：切归档范围 + 重载归档列表（覆盖「本 tick 刚归档、缓存未含」与「已在归档范围、setScope
-  // 同值不触发懒加载」两种情况）再选中。活跃命中则切活跃范围 + 必要时切到含它的发现分类（确保侧栏展示并高亮）+ 标已读。
+  // Status bar run indicator / notification click → locate the PR. During a task run the PR may already have been archived by a poll (the task isn't cancelled, still running), so when
+  // it's not found in the active list it's treated as archived: switch to archived scope + reload the archived list (covers both "just archived this tick, cache doesn't have it" and "already in
+  // archived scope, setScope with the same value doesn't trigger lazy load") then select. On an active hit, switch to active scope + switch to a discovery category that includes it if needed (ensuring the sidebar shows and highlights it) + mark read.
   const jumpToPr = useCallback(
     async (localId: string) => {
       const active = prsRef.current.find((p) => p.localId === localId);
@@ -150,8 +150,8 @@ export function usePrNavigation({
     [markRead, setSelectedId],
   );
 
-  // 系统通知点击 → 导航：复用 jumpToPr 选中目标，再按类型定位——inline 评论跳 Diff 行，summary 评论
-  // （mention / reply）开「活动」标签，new_pr 仅选中。与状态栏跳转走同一套活跃 / 归档定位逻辑。
+  // System notification click → navigation: reuse jumpToPr to select the target, then locate by type — inline comment jumps to the Diff line, summary comment
+  // (mention / reply) opens the "activity" tab, new_pr only selects. Shares the same active / archived locate logic as the status bar jump.
   useEffect(() => {
     return subscribe('notification:activate', ({ localId, kind, anchor }) => {
       void jumpToPr(localId);
@@ -163,8 +163,8 @@ export function usePrNavigation({
     });
   }, [jumpToPr]);
 
-  // 列表 / 详情数据源随范围切换：已关闭范围用归档列表，其余用活跃列表。选中 PR 从当前展示列表解析——
-  // 切到归档范围时若原选中是活跃 PR 则解析不到、详情区回落空态，选归档项后再展示其详情。
+  // The list / detail data source switches with scope: closed scope uses the archived list, otherwise the active list. The selected PR is resolved from the currently displayed list —
+  // when switching to archived scope, if the previous selection was an active PR it won't resolve and the detail area falls back to an empty state, showing details again after an archived item is selected.
   const displayedPrs = scope === 'archived' ? archivedPrs : prs;
   const selectedPr = displayedPrs.find((p) => p.localId === selectedId) ?? null;
 

--- a/apps/desktop/src/renderer/src/hooks/useTheme.ts
+++ b/apps/desktop/src/renderer/src/hooks/useTheme.ts
@@ -11,20 +11,20 @@ import { applyChromeFromEditorTheme } from '../theme/editor-chrome-sync';
 import { setEditorAppearance, useEditorAppearance } from '../stores/editor-appearance-store';
 import { invoke } from '../api';
 
-/** 主题应用后把派生的窗控配色（Windows titleBarOverlay）推给主进程；null 回退通用深/浅。失败静默。 */
+/** After a theme is applied, push the derived window-control colors (Windows titleBarOverlay) to the main process; null falls back to generic dark/light. Fails silently. */
 function syncWindowControls(colors: { color: string; symbolColor: string } | null): void {
   void invoke('window:setControlColors', colors).catch(() => {
-    /* 平台不支持 / 主进程未就绪 → 忽略 */
+    /* platform unsupported / main process not ready → ignore */
   });
 }
 
 /**
- * 全局主题生效：主题变化时把它反推浅 / 深写到 documentElement.data-theme（驱动语义色板）+ 派生结构性
- * chrome 色覆盖 + 持久化到 localStorage（供下次启动同步命中）；'auto' 主题下还监听 OS 深 / 浅色切换、
- * 实时重解析跟随。
+ * Apply the global theme: when the theme changes, resolve it to light / dark and write it to documentElement.data-theme (driving the semantic palette) + derive structural
+ * chrome color overrides + persist to localStorage (for a synchronous hit on next startup); under the 'auto' theme also watch OS dark / light changes and
+ * re-resolve in real time to follow.
  *
- * 主题源为共享 store（由 useEditorAppearanceSync 从 config.appearance.editor_theme 注入，设置页即时
- * 改动经 setEditorAppearance 同步），故主题切换与语言切换走同一条「config 驱动 + 即时生效」路径。
+ * The theme source is a shared store (injected by useEditorAppearanceSync from config.appearance.editor_theme, with instant settings-page
+ * changes synced via setEditorAppearance), so theme switching and language switching go through the same "config-driven + instant effect" path.
  */
 export function useGlobalTheme(): void {
   const { editorTheme } = useEditorAppearance();
@@ -32,14 +32,14 @@ export function useGlobalTheme(): void {
     applyGlobalTheme(editorTheme);
     persistEditorTheme(editorTheme);
     syncWindowControls(applyChromeFromEditorTheme(editorTheme, resolveGlobalTheme(editorTheme)));
-    // 'auto' 主题：OS 深浅切换时重写 data-theme（watch 内部已做）并重派生 chrome + 同步窗控配色
+    // 'auto' theme: on OS dark/light switch, rewrite data-theme (watch already does this) and re-derive chrome + sync window-control colors
     return watchSystemThemeForAuto(editorTheme, () => {
       syncWindowControls(applyChromeFromEditorTheme(editorTheme, resolveGlobalTheme(editorTheme)));
     });
   }, [editorTheme]);
 }
 
-/** 订阅 documentElement.data-theme 变化（含 system 偏好下 OS 切换）。 */
+/** Subscribe to documentElement.data-theme changes (including OS switches under the system preference). */
 function subscribeResolvedTheme(onChange: () => void): () => void {
   const obs = new MutationObserver(onChange);
   obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
@@ -51,16 +51,16 @@ function getResolvedThemeSnapshot(): ResolvedTheme {
 }
 
 /**
- * 当前实际生效的视觉主题（解析后的 light / dark），随 data-theme 变化实时更新。供需按主题切换内部
- * 配色的非 CSS 组件用（如 Monaco 编辑器、Mermaid —— 它们的主题不走 CSS 自定义属性，须显式传入）。
+ * The visual theme currently in effect (resolved light / dark), updated in real time as data-theme changes. For non-CSS components that need to switch internal
+ * colors by theme (e.g. the Monaco editor, Mermaid — their themes don't go through CSS custom properties and must be passed in explicitly).
  */
 export function useResolvedTheme(): ResolvedTheme {
   return useSyncExternalStore(subscribeResolvedTheme, getResolvedThemeSnapshot);
 }
 
 /**
- * 把 config.appearance 的编辑器外观同步到运行时：写入共享 store（供 Monaco 组件读）+ 应用等宽字体
- * CSS 变量（供全应用 $font-mono）。源为 config（启动注入、设置页即时改动经 patchConfig 同步）。
+ * Sync config.appearance's editor appearance to the runtime: write the shared store (read by Monaco components) + apply the monospace-font
+ * CSS variable (used app-wide by $font-mono). The source is config (injected at startup, with instant settings-page changes synced via patchConfig).
  */
 export function useEditorAppearanceSync(appearance: Config['appearance']): void {
   const { editor_theme, editor_font_family, editor_font_size } = appearance;
@@ -75,8 +75,8 @@ export function useEditorAppearanceSync(appearance: Config['appearance']): void 
 }
 
 /**
- * 当前生效的 Monaco 编辑器主题名：编辑器主题偏好为 'auto' 时跟随 GUI 解析主题（浅 'light-2026' / 深
- * 'dark-2026'，即默认的 2026 配色），否则用所选主题 id。
+ * The Monaco editor theme name currently in effect: when the editor theme preference is 'auto', it follows the GUI resolved theme (light 'light-2026' / dark
+ * 'dark-2026', i.e. the default 2026 colors), otherwise it uses the selected theme id.
  */
 export function useMonacoEditorTheme(): string {
   const { editorTheme } = useEditorAppearance();

--- a/apps/desktop/src/renderer/src/hooks/useToast.ts
+++ b/apps/desktop/src/renderer/src/hooks/useToast.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
 /**
- * 操作级 toast（审批 / 合并等远端动作失败时提示，区别于 fatalError 整屏报错）。
- * key 用随机数：同样文案连续触发也能重置自动消失计时器；6s 后自动消失。
+ * Action-level toast (shown when a remote action such as approve / merge fails, as opposed to fatalError's full-screen error).
+ * The key uses a random number: the same text triggered consecutively can still reset the auto-dismiss timer; auto-dismisses after 6s.
  */
 export function useToast(): {
   toast: { text: string; key: number } | null;
@@ -18,7 +18,7 @@ export function useToast(): {
     if (!toast) return;
     const id = setTimeout(() => setToast(null), 6000);
     return () => clearTimeout(id);
-    // 仅依赖 key：同一 toast 重渲不重置计时，新 toast (key 变) 才重置
+    // Depend only on key: re-rendering the same toast doesn't reset the timer, only a new toast (key changes) resets it
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toast?.key]);
   return { toast, notifyError, dismiss };

--- a/apps/desktop/src/renderer/src/hooks/useUpdateNotice.ts
+++ b/apps/desktop/src/renderer/src/hooks/useUpdateNotice.ts
@@ -3,9 +3,9 @@ import type { UpdateCheckResult } from '@meebox/shared';
 import { invoke, subscribe } from '../api';
 
 /**
- * 版本更新提示（main 为单一真相源）：挂载时水合已缓存结果（设置页手动检查 / 定时检查到的新版
- * 不因窗口重挂载而丢失），再订阅后续广播。另含 dev 调试钩子——控制台 dispatch
- * `meebox:debug-update`（detail 可带 latestVersion / 为 null 清除）模拟「发现新版」验证状态栏 chip。
+ * Version update notice (main is the single source of truth): on mount, hydrate the cached result (a new version found via the settings-page manual check / scheduled check
+ * isn't lost when the window remounts), then subscribe to subsequent broadcasts. Also includes a dev debug hook — the console can dispatch
+ * `meebox:debug-update` (detail may carry latestVersion / null to clear) to simulate "new version found" and verify the status bar chip.
  */
 export function useUpdateNotice(): UpdateCheckResult | null {
   const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);

--- a/apps/desktop/src/renderer/src/i18n/index.ts
+++ b/apps/desktop/src/renderer/src/i18n/index.ts
@@ -10,30 +10,30 @@ import {
 import enUS from './locales/en-US.json';
 
 /**
- * 渲染层国际化（react-i18next）。
+ * Renderer internationalization (react-i18next).
  *
- * - key 是**中立标识符**（`chatPane.emptySelectPrTitle` 这种）；zh-CN / en-US / ja-JP /
- *   de-DE 是**对等的译文集**（各 locale 满覆盖、无源/译层级），按「组件命名空间」组织
- *   （顶层 object 对应一个组件，common 放跨组件复用文案）。
- * - 实际语言由 config.language 经 `resolveLanguage` 决定（空则按 OS 偏好回落英语）；
- *   App 启动拿到 boot.config 后调 `i18n.changeLanguage` 切换。
+ * - Keys are **neutral identifiers** (like `chatPane.emptySelectPrTitle`); zh-CN / en-US / ja-JP /
+ *   de-DE are **equivalent translation sets** (each locale fully covered, no source/translation hierarchy), organized by "component namespace"
+ *   (a top-level object corresponds to a component, common holds cross-component reusable text).
+ * - The actual language is decided by config.language via `resolveLanguage` (empty falls back to English per OS preference);
+ *   after App startup gets boot.config it calls `i18n.changeLanguage` to switch.
  *
- * 默认 / 兜底语言取 **en-US**（国际化项目标准：英文最通用）：
- * - en-US **静态打包**进入口，同时作 `fallbackLng`——任何 locale 缺 key 都回退英文而非中文。
- * - zh-CN / ja-JP / de-DE 经 resourcesToBackend + 动态 import **按需懒加载**：Vite 把每份
- *   locale 拆成独立 chunk，仅当切到该语言时才拉取，不进入口包（语言越多收益越大）。
- * - `partialBundledLanguages` 让静态 resources 与 backend 懒加载共存；`useSuspense: false`
- *   使切换懒加载语言时不走 Suspense——加载完成自动重渲，期间回退当前语言，无需 Suspense 边界。
+ * The default / fallback language is **en-US** (i18n project standard: English is most universal):
+ * - en-US is **statically bundled** into the entry, and also serves as `fallbackLng` — any locale missing a key falls back to English rather than Chinese.
+ * - zh-CN / ja-JP / de-DE are **lazy-loaded on demand** via resourcesToBackend + dynamic import: Vite splits each
+ *   locale into a separate chunk, pulled only when switching to that language, not entering the entry bundle (the more languages, the greater the benefit).
+ * - `partialBundledLanguages` lets static resources coexist with backend lazy loading; `useSuspense: false`
+ *   makes switching a lazy-loaded language avoid Suspense — it auto re-renders once loaded, falling back to the current language meanwhile, no Suspense boundary needed.
  */
 
 export { SUPPORTED_LANGUAGES, matchSupportedLanguage, type SupportedLanguage };
 
-// 渲染层同步缓存的「上次语言」：config.language 经 IPC 异步到达，启动时拿不到；
-// localStorage 可同步读，故用它做初始语言，避免英语/日语/德语用户启动先闪一帧中文。
-// App 拿到 config.language 后会 persistLanguage 回写，供下次启动直接命中。
+// Renderer synchronously cached "last language": config.language arrives asynchronously via IPC and is unavailable at startup;
+// localStorage can be read synchronously, so use it as the initial language, avoiding English/Japanese/German users flashing a frame of Chinese on startup.
+// Once App gets config.language it persistLanguage-writes it back, for the next startup to hit directly.
 const LANG_STORAGE_KEY = 'meebox.language';
 
-/** 浏览器/OS 偏好语言列表（作 config 为空时的 OS 探测来源）。 */
+/** Browser/OS preferred language list (the OS-detection source when config is empty). */
 function osLocales(): string[] {
   try {
     return [...(navigator.languages ?? [navigator.language])].filter(Boolean);
@@ -42,40 +42,40 @@ function osLocales(): string[] {
   }
 }
 
-/** 解析有效 UI 语言：config.language 优先，空则按 OS 偏好回落英语。 */
+/** Resolve the effective UI language: config.language takes priority, empty falls back to English per OS preference. */
 export function resolveUiLanguage(configLang: string | null | undefined): SupportedLanguage {
   return resolveLanguage(configLang, osLocales());
 }
 
 function readInitialLanguage(): SupportedLanguage {
   try {
-    // 上次持久化的语言已是解析后的受支持值，直接命中；首启无记录时按 OS 偏好探测。
+    // The last persisted language is already a resolved supported value, hit it directly; on first launch with no record, detect per OS preference.
     return matchSupportedLanguage(localStorage.getItem(LANG_STORAGE_KEY)) ?? resolveUiLanguage('');
   } catch {
     return resolveUiLanguage('');
   }
 }
 
-/** 持久化当前语言到 localStorage，供下次启动同步读取作初始语言。 */
+/** Persist the current language to localStorage, for the next startup to read synchronously as the initial language. */
 export function persistLanguage(lang: string): void {
   try {
     const matched = matchSupportedLanguage(lang);
     if (matched) localStorage.setItem(LANG_STORAGE_KEY, matched);
   } catch {
-    // localStorage 不可用时忽略：仅影响下次启动的初始语言命中，不影响功能。
+    // Ignore when localStorage is unavailable: only affects the next startup's initial language hit, not functionality.
   }
 }
 
 /**
- * 让 `<html lang>` 跟随当前 UI 语言（初始 + 每次切换）。index.html 静态写死 `zh-CN`、切语言时不更新，
- * 会误导 CSS `hyphens:auto` 断词（用错语言的断词词典）、屏幕阅读器与字体选择。i18n 的 languageChanged
- * 覆盖所有切换来源（启动 / 设置页 / 首启向导 / 命令面板），在此一处同步即可。
+ * Make `<html lang>` follow the current UI language (initial + every switch). index.html statically hardcodes `zh-CN` and does not update on language switch,
+ * which would mislead CSS `hyphens:auto` hyphenation (wrong-language hyphenation dictionary), screen readers, and font selection. i18n's languageChanged
+ * covers all switch sources (startup / settings page / onboarding wizard / command palette), so syncing in this one place suffices.
  */
 function syncDocumentLang(lng: string): void {
   try {
     document.documentElement.lang = lng;
   } catch {
-    // document 不可用（非常规宿主）时忽略：仅影响断词 / 可达性提示，不影响功能。
+    // Ignore when document is unavailable (non-standard host): only affects hyphenation / accessibility hints, not functionality.
   }
 }
 
@@ -85,7 +85,7 @@ i18n.on('languageChanged', syncDocumentLang);
 
 void i18n
   .use(
-    // zh-CN 已静态打包，backend 只为其余语言按需拉取对应 chunk。
+    // zh-CN is already statically bundled, the backend only pulls the corresponding chunk on demand for the remaining languages.
     resourcesToBackend(
       (lng: string) =>
         import(`./locales/${lng}.json`) as Promise<{ default: Record<string, unknown> }>,
@@ -94,28 +94,28 @@ void i18n
   .use(initReactI18next)
   .init({
     resources: {
-      // 仅默认语言 en-US 静态进入口；其余由 backend 懒加载。
+      // Only the default language en-US statically enters the entry; the rest are lazy-loaded by the backend.
       'en-US': { translation: enUS },
     },
     partialBundledLanguages: true,
-    // 初始语言取持久化值 / OS 偏好（默认按 OS 回落英语）：直接以用户语言启动。
+    // Initial language takes the persisted value / OS preference (default falls back to English per OS): start directly in the user's language.
     lng: initialLanguage,
-    // 兜底取 en-US（国际化标准：英文最通用）：任何 locale 缺 key 回退英文而非中文。
-    // 各 locale 满覆盖，单层兜底足够；en-US 已静态打包，作 fallback 也不必再拉 chunk。
+    // Fallback takes en-US (i18n standard: English is most universal): any locale missing a key falls back to English rather than Chinese.
+    // Each locale is fully covered, single-layer fallback suffices; en-US is already statically bundled, so serving as fallback needs no extra chunk pull.
     fallbackLng: 'en-US',
     supportedLngs: [...SUPPORTED_LANGUAGES],
-    // 注意：**不要**开 nonExplicitSupportedLngs。它会把带地区码的 'zh-CN' 按基码 'zh'
-    // 规整查找，而资源 bundle 是按 'zh-CN' 注册的 → 命名空间落空、t() 退化成裸 key（整页
-    // 不翻译）。语言进 i18n 前已由 resolveLanguage/matchSupportedLanguage 规整成精确受支持码
-    // （zh-CN/en-US/ja-JP/de-DE），无需 i18next 再做非精确匹配。
+    // Note: **do not** enable nonExplicitSupportedLngs. It would normalize the region-coded 'zh-CN' to the base code 'zh'
+    // for lookup, whereas the resource bundle is registered under 'zh-CN' → the namespace comes up empty, t() degrades to bare keys (whole page
+    // untranslated). Before entering i18n the language is already normalized to an exact supported code by resolveLanguage/matchSupportedLanguage
+    // (zh-CN/en-US/ja-JP/de-DE), so i18next need not do non-exact matching.
     load: 'currentOnly',
     interpolation: {
-      // React 已对插值做转义，关闭 i18next 二次转义避免 &amp; 之类。
+      // React already escapes interpolation, disable i18next's double-escaping to avoid things like &amp;.
       escapeValue: false,
     },
     returnNull: false,
     react: {
-      // 切到懒加载语言时不抛 Suspense；加载完成后自动重渲，期间回退当前语言。
+      // Do not throw Suspense when switching to a lazy-loaded language; auto re-render once loaded, falling back to the current language meanwhile.
       useSuspense: false,
     },
   });

--- a/apps/desktop/src/renderer/src/lib/editor-font.ts
+++ b/apps/desktop/src/renderer/src/lib/editor-font.ts
@@ -1,8 +1,8 @@
-// macOS 下 Monaco 的字号视觉上比 Windows 偏大（系统字体渲染差异），同样的 px 值在 mac
-// 看着更大。统一在 mac 上把编辑器字号缩小一号，让两端体验接近。
+// On macOS Monaco's font size looks visually larger than on Windows (system font rendering differences); the same
+// px value looks bigger on mac. Uniformly shrink the editor font size by one on mac to bring both platforms closer.
 export const IS_MAC = navigator.platform.toLowerCase().includes('mac');
 
-/** 按平台校正 Monaco 字号：mac 减 1px，其他平台原值。 */
+/** Correct Monaco font size per platform: mac minus 1px, original value on other platforms. */
 export function editorFontSize(base: number): number {
   return IS_MAC ? base - 1 : base;
 }

--- a/apps/desktop/src/renderer/src/lib/markdown.ts
+++ b/apps/desktop/src/renderer/src/lib/markdown.ts
@@ -1,9 +1,10 @@
-// 远端 markdown（PR 描述 / 评论）里常含原始 HTML —— 典型如 Qodo / pr-agent 机器人用
-// <details> 折叠、<table>、<picture>/<img>、<sub>/<sup> 等 GitHub 风格 HTML。react-markdown
-// 默认会丢弃原始 HTML，导致这类评论显示残缺。这里用 rehype-raw 解析 HTML，再用 rehype-sanitize
-// 按白名单过滤（剔除 <script>、on* 事件、javascript: 链接等），既能渲染又不引入 XSS。
+// Remote markdown (PR descriptions / comments) often contains raw HTML — typically GitHub-style HTML like Qodo /
+// pr-agent bots' <details> folds, <table>, <picture>/<img>, <sub>/<sup>, etc. react-markdown drops raw HTML by
+// default, leaving such comments rendered incompletely. Here rehype-raw parses the HTML, then rehype-sanitize
+// filters it by an allowlist (stripping <script>, on* events, javascript: links, etc.), rendering it without
+// introducing XSS.
 //
-// 仅对**远端来源**的 markdown 启用（评论、PR 描述）；本地 / AI 生成的内容无需放开 HTML。
+// Enabled only for **remote-sourced** markdown (comments, PR descriptions); local / AI-generated content needs no HTML.
 import type { Options } from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
@@ -12,13 +13,13 @@ function extend<T>(list: readonly T[] | null | undefined, extra: readonly T[]): 
   return Array.from(new Set<T>([...(list ?? []), ...extra]));
 }
 
-// 在 rehype-sanitize 的 GitHub 默认白名单基础上，补齐 Qodo 等机器人常用但默认未必放开的标签/属性。
+// On top of rehype-sanitize's GitHub default allowlist, add tags/attributes commonly used by bots like Qodo but not necessarily allowed by default.
 const schema = {
   ...defaultSchema,
-  // 放行 Bitbucket 评论的 `attachment:<repoId>/<id>` 内部协议（内嵌图片/附件引用）。
-  // 默认 protocols 白名单 src/href 只许 http/https，会在 react-markdown 的 urlTransform
-  // 之前就把 attachment: 的 src/href 整个剥掉 → img 收不到 src（BitbucketImage 不触发）、
-  // a 收不到 href（渲染成裸文字）。两条附件渲染路径都被卡死，故在此显式放行 attachment 协议。
+  // Allow Bitbucket comments' `attachment:<repoId>/<id>` internal protocol (inline image/attachment references).
+  // The default protocols allowlist only permits http/https for src/href, and would strip attachment:'s src/href
+  // entirely before react-markdown's urlTransform → img gets no src (BitbucketImage doesn't fire), a gets no href
+  // (rendered as bare text). Both attachment render paths are dead-ended, so explicitly allow the attachment protocol here.
   protocols: {
     ...defaultSchema.protocols,
     src: extend(defaultSchema.protocols?.src, ['attachment']),
@@ -47,7 +48,7 @@ const schema = {
   },
 };
 
-/** 远端 markdown 的 rehype 插件链：解析原始 HTML → 按白名单消毒。 */
+/** rehype plugin chain for remote markdown: parse raw HTML → sanitize by allowlist. */
 export const REMOTE_REHYPE_PLUGINS: NonNullable<Options['rehypePlugins']> = [
   rehypeRaw,
   [rehypeSanitize, schema],

--- a/apps/desktop/src/renderer/src/lib/monaco-setup.ts
+++ b/apps/desktop/src/renderer/src/lib/monaco-setup.ts
@@ -1,23 +1,24 @@
-// 让 @monaco-editor/react 使用本地 monaco-editor 包，而不是从 CDN 拉 loader.js。
-// 配合 CSP 严格化（无 cdn.jsdelivr.net 例外）。
+// Make @monaco-editor/react use the local monaco-editor package instead of pulling loader.js from a CDN.
+// Pairs with the strict CSP (no cdn.jsdelivr.net exception).
 //
-// 仅注册 base editor worker，markdown / 通用 diff 用不到 JSON/CSS/HTML/TS language worker。
-// M1+ 真正要做语法高亮时再按需 import 对应 language worker。
+// Only register the base editor worker; markdown / generic diff don't need the JSON/CSS/HTML/TS language workers.
+// When M1+ actually needs syntax highlighting, import the corresponding language worker on demand.
 
 import * as monaco from 'monaco-editor';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import { loader } from '@monaco-editor/react';
-// 4 个「带 worker 后端语言服务」的 contribution 子模块（editor.main 已加载，这里再引一次只为
-// 取其具名导出的 *Defaults；ES module 单例不会重复执行）。它们的运行期 JS 具名导出
-// typescriptDefaults / jsonDefaults / cssDefaults … 但 .d.ts 误为 `export {}`（monaco 0.55 ESM
-// 打包缺陷），故按 namespace 引入、下方经 unknown 转成已知形状取用，不引入 any。
+// The 4 contribution submodules for "worker-backed language services" (editor.main already loaded them; importing
+// again here is only to grab their named-exported *Defaults; ES module singletons won't re-execute). Their runtime
+// JS named-exports typescriptDefaults / jsonDefaults / cssDefaults … but the .d.ts is wrongly `export {}` (monaco
+// 0.55 ESM bundling defect), so import as namespace and cast via unknown below into the known shapes, without any.
 import * as tsLang from 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
 import * as jsonLang from 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 import * as cssLang from 'monaco-editor/esm/vs/language/css/monaco.contribution.js';
 import * as htmlLang from 'monaco-editor/esm/vs/language/html/monaco.contribution.js';
-// 第三方编辑器主题（IStandaloneThemeData 形状，vendored 自 monaco-themes，见 editor-themes/NOTICE.md），
-// 下方经 defineTheme 注册供选择。id 与 @meebox/shared EDITOR_THEME_OPTIONS 对齐；vs / vs-dark / hc-*
-// 为 Monaco 内置、无需注册。就地内置而非 npm 依赖：monaco-themes 的 exports 未暴露 ./themes/* 子路径。
+// Third-party editor themes (IStandaloneThemeData shape, vendored from monaco-themes, see editor-themes/NOTICE.md),
+// registered via defineTheme below for selection. ids align with @meebox/shared EDITOR_THEME_OPTIONS; vs / vs-dark /
+// hc-* are Monaco built-ins, no registration needed. Vendored in place rather than an npm dependency: monaco-themes'
+// exports don't expose the ./themes/* subpath.
 import githubLight from './editor-themes/github-light.json';
 import githubDark from './editor-themes/github-dark.json';
 import monokai from './editor-themes/monokai.json';
@@ -30,11 +31,11 @@ import solarizedLight from './editor-themes/solarized-light.json';
 import solarizedDark from './editor-themes/solarized-dark.json';
 import cobalt2 from './editor-themes/cobalt2.json';
 import oceanicNext from './editor-themes/oceanic-next.json';
-// VS Code 内置 2026 默认主题（转换自 microsoft/vscode theme-defaults，已解析 include 链并转为 Monaco 形状）。
+// VS Code built-in 2026 default themes (converted from microsoft/vscode theme-defaults, include chain resolved and converted to Monaco shape).
 import dark2026 from './editor-themes/dark-2026.json';
 import light2026 from './editor-themes/light-2026.json';
 
-// Vite 的 ?worker import 返回一个可 new 的 Worker 构造类。
+// Vite's ?worker import returns a newable Worker constructor class.
 self.MonacoEnvironment = {
   getWorker() {
     return new editorWorker();
@@ -43,8 +44,8 @@ self.MonacoEnvironment = {
 
 loader.config({ monaco });
 
-// 注册第三方编辑器主题（id → 主题数据）。Monaco 内置 vs / vs-dark / hc-* 不在此列。JSON 的 base
-// 字段类型为 string，与 IStandaloneThemeData 的字面量联合不完全兼容，经 unknown 转换取用。
+// Register third-party editor themes (id → theme data). Monaco built-in vs / vs-dark / hc-* aren't in this list.
+// The JSON's base field is typed string, not fully compatible with IStandaloneThemeData's literal union, so cast via unknown.
 const CUSTOM_EDITOR_THEMES: ReadonlyArray<readonly [string, unknown]> = [
   ['github-light', githubLight],
   ['github-dark', githubDark],
@@ -66,9 +67,10 @@ for (const [id, data] of CUSTOM_EDITOR_THEMES) {
 }
 
 /**
- * 【SPIKE】按主题 id 取其 base + colors，供「GUI chrome 跟随编辑器主题」验证从中提取 background /
- * foreground / selection 等 base 色。第三方 monaco-themes 仅带极少数 colors（editor.* 几个键），
- * 内置 vs / vs-dark / hc-* 无 JSON、在此补最小已知色。验证完毕若不采纳可整体移除。
+ * [SPIKE] Get a theme's base + colors by id, for the "GUI chrome follows editor theme" experiment to extract base
+ * colors like background / foreground / selection. Third-party monaco-themes carry only a handful of colors (a few
+ * editor.* keys); built-in vs / vs-dark / hc-* have no JSON, so supply minimal known colors here. Removable
+ * wholesale if not adopted after the experiment.
  */
 export interface EditorThemeColorData {
   base: string;
@@ -119,24 +121,26 @@ export function getEditorThemeColors(id: string): EditorThemeColorData | null {
 }
 
 /**
- * 关掉 4 个「带 worker 后端语言服务」的语言族的全部特性：typescript/javascript（ts.worker）、
- * json（json.worker）、css/scss/less（css.worker）、html/handlebars/razor（html.worker）。
+ * Turn off all features of the 4 "worker-backed language service" language families: typescript/javascript
+ * (ts.worker), json (json.worker), css/scss/less (css.worker), html/handlebars/razor (html.worker).
  *
- * 本应用只用 Monaco 做只读 diff + 语法着色（着色走 monarch tokenizer，与语言服务无关），不需要
- * 补全 / 悬浮 / 符号 / 诊断 / 格式化等；而这些特性会向对应 *.worker 发 RPC（getNavigationTree /
- * getSyntacticDiagnostics / doValidation …）。但我们只注册了 base editor.worker（见上 getWorker）
- * → 这些方法找不到 handler，抛 `Missing requestHandler or method: …`。
+ * This app only uses Monaco for read-only diff + syntax coloring (coloring goes through the monarch tokenizer,
+ * unrelated to language services), and needs no completion / hover / symbols / diagnostics / formatting, etc.;
+ * those features send RPCs to the corresponding *.worker (getNavigationTree / getSyntacticDiagnostics /
+ * doValidation …). But we only registered the base editor.worker (see getWorker above) → these methods find no
+ * handler and throw `Missing requestHandler or method: …`.
  *
- * 传空 ModeConfiguration（各字段均 optional，缺省即不注册对应 provider）→ 这些 provider 不再注册、
- * 不再发 RPC，从源头消除整族报错（下方 window 兜底退化为纯保险）。其余 80+ 语言是 monarch
- * tokenizer 纯着色、无 worker 后端，不受影响也无需处理。
+ * Passing an empty ModeConfiguration (each field is optional, absent = don't register that provider) → these
+ * providers are no longer registered, no longer send RPCs, eliminating the whole family of errors at the source
+ * (the window fallback below degrades to pure insurance). The other 80+ languages are pure monarch tokenizer
+ * coloring with no worker backend, unaffected and needing no handling.
  */
 interface LangServiceDefaults {
-  // 传空 ModeConfiguration（各字段均 optional，缺省即不注册对应 provider）= 关掉全部特性
+  // Passing an empty ModeConfiguration (each field is optional, absent = don't register that provider) = turn off all features
   setModeConfiguration(modeConfiguration: object): void;
 }
-// 运行期具名导出存在（见各 contribution.js 的 export），但其 .d.ts 误为 `export {}`，故经
-// unknown 转成已知 *Defaults 形状取用（不引入 any）；名字缺失时 filter 兜底，未来 monaco 改名不崩。
+// The runtime named exports exist (see each contribution.js's export), but their .d.ts is wrongly `export {}`, so
+// cast via unknown into the known *Defaults shape (without any); filter as fallback when a name is missing, so a future monaco rename won't crash.
 const defaultsOf = (mod: unknown, names: readonly string[]): LangServiceDefaults[] =>
   names
     .map((n) => (mod as Record<string, LangServiceDefaults | undefined>)[n])
@@ -152,18 +156,19 @@ for (const d of [
 }
 
 /**
- * Monaco 在 DiffEditor 快速切换文件时，会出现 model 已 dispose 但 widget 还在
- * 收尾的竞态；以及"内置 ts/js language contribution 主动询问 inlayHints /
- * quickInfo / navigationTree / ...，editor.worker 没实现对应方法"的一系列运行时
- * 报错。两类都不影响渲染，但污染 console 让用户以为应用挂了。
+ * When Monaco quickly switches files in DiffEditor, a race occurs where the model is already disposed but the
+ * widget is still finishing up; plus a series of runtime errors from "the built-in ts/js language contribution
+ * proactively asking for inlayHints / quickInfo / navigationTree / ..., which editor.worker doesn't implement".
+ * Neither affects rendering, but they pollute the console and make users think the app crashed.
  *
- * 仅按消息前缀黑名单吞掉，不动其他真实业务错误。
+ * Only swallow by a message-prefix blacklist, leaving other real business errors untouched.
  *
- * `Missing requestHandler or method:` 整族源于 worker RPC 找不到 handler（已在上方从源头
- * 关闭对应语言服务，这里留作双保险）；`TextModel got disposed …` 是 DiffEditor 切换 model
- * 的 dispose 竞态。两类都是 Monaco 上游已知问题、不影响渲染、应用侧无法根除 → **默认静默忽略**
- * （作为已知问题）。需诊断时在 devtools 执行 `localStorage.setItem('meebox.monacoDebug','1')`
- * 再刷新，即可看到被吞的报错明细。
+ * The whole `Missing requestHandler or method:` family stems from worker RPCs finding no handler (already turned
+ * off at the source above by disabling the corresponding language services; kept here as double insurance);
+ * `TextModel got disposed …` is the DiffEditor model-switch dispose race. Both are Monaco upstream known issues,
+ * don't affect rendering, and can't be eradicated on the app side → **silently ignored by default** (as known
+ * issues). To diagnose, run `localStorage.setItem('meebox.monacoDebug','1')` in devtools and refresh to see the
+ * details of the swallowed errors.
  */
 const MONACO_DEBUG = (() => {
   try {
@@ -187,7 +192,7 @@ function isBenignMonacoError(msg: unknown): boolean {
 window.addEventListener('error', (e) => {
   if (isBenignMonacoError(e.message) || isBenignMonacoError(e.error?.message)) {
     e.preventDefault();
-    // 默认静默（已知问题）；开 meebox.monacoDebug 才打一行便于诊断
+    // Silent by default (known issue); only log a line when meebox.monacoDebug is on, for diagnostics
     if (MONACO_DEBUG) console.warn('[monaco] suppressed benign error:', e.message);
   }
 });

--- a/apps/desktop/src/renderer/src/lib/remark-emoji.ts
+++ b/apps/desktop/src/renderer/src/lib/remark-emoji.ts
@@ -1,22 +1,23 @@
 import { reactionCodeToEmoji } from '@meebox/shared';
 
-/** mdast 节点的最小结构（仅取本插件用到的字段，避免引入 mdast 类型依赖）。 */
+/** Minimal shape of an mdast node (only the fields this plugin uses, avoiding an mdast type dependency). */
 interface MdNode {
   type: string;
   value?: string;
   children?: MdNode[];
 }
 
-// `:shortcode:`：字母 / 数字 / _ / + / -（覆盖 gemoji 风格名，如 tada / +1 / heart_eyes）。
+// `:shortcode:`: letters / digits / _ / + / - (covers gemoji-style names, like tada / +1 / heart_eyes).
 const SHORTCODE = /:([a-z0-9_+-]{1,40}):/gi;
 
 /**
- * remark 插件：把评论正文里的 `:shortcode:`（如 `:tada:` → 🎉）替换为对应 emoji 字符，复用内置精选集
- * （{@link reactionCodeToEmoji}，含 `+1`/`-1` 别名）。
+ * remark plugin: replace `:shortcode:` in comment bodies (like `:tada:` → 🎉) with the corresponding emoji
+ * character, reusing the built-in curated set ({@link reactionCodeToEmoji}, including `+1`/`-1` aliases).
  *
- * 只改写 mdast `text` 节点——代码（inlineCode / code 块）的内容不在 text 节点里，故天然跳过，
- * `def f(x):` / `http://h:8080` 等不会被误伤；内置集外的未知 shortcode 原样保留（部分渲染、与精选集
- * 路线一致）。emoji 是纯文本，直接就地替换字符串、无需拆分节点。
+ * Only rewrites mdast `text` nodes — the contents of code (inlineCode / code blocks) aren't in text nodes, so they're
+ * naturally skipped, and `def f(x):` / `http://h:8080`, etc. won't be hit by mistake; unknown shortcodes outside the
+ * built-in set are kept as-is (partial rendering, consistent with the curated-set approach). emoji are plain text,
+ * so replace the string in place directly, no need to split nodes.
  */
 export function remarkEmojiShortcodes() {
   return (tree: MdNode): void => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -2,18 +2,18 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { addCollection } from '@iconify/react';
 import materialIconTheme from '@iconify-json/material-icon-theme/icons.json';
-// 注意：Monaco（~10MB）不在入口加载。monaco-setup 已移进 DiffView / InlineCodeContext
-// 两个懒模块，仅在首次看 diff / 行内代码上下文时才拉取，避免阻塞窗口首帧。
-// i18n 必须在 App 之前 import：副作用里同步 init i18next，保证首帧渲染前 t() 可用。
+// Note: Monaco (~10MB) is not loaded at the entry. monaco-setup has been moved into the two
+// lazy modules DiffView / InlineCodeContext, pulled only on first viewing a diff / inline code context, avoiding blocking the window's first frame.
+// i18n must be imported before App: its side effect synchronously inits i18next, ensuring t() is available before the first-frame render.
 import './i18n';
-// theme 同样在 App 之前 import：副作用里按 localStorage 缓存同步定下首帧主题（写 data-theme），
-// 避免浅色用户启动先闪一帧深色。
+// theme is likewise imported before App: its side effect synchronously pins the first-frame theme from the localStorage cache (writing data-theme),
+// avoiding a light-mode user flashing a frame of dark on startup.
 import './theme';
 import App from './App';
 import './App.scss';
 
-// 预加载 PKief Material Icon Theme，让 <Icon icon="material-icon-theme:..." />
-// 走 bundle 而非默认的 api.iconify.design CDN（CSP 不允许）
+// Preload the PKief Material Icon Theme so that <Icon icon="material-icon-theme:..." />
+// goes through the bundle instead of the default api.iconify.design CDN (disallowed by CSP)
 addCollection(materialIconTheme);
 
 const container = document.getElementById('root');

--- a/apps/desktop/src/renderer/src/stores/chat-run-store.ts
+++ b/apps/desktop/src/renderer/src/stores/chat-run-store.ts
@@ -3,23 +3,27 @@ import type { PragentRunInfo } from '@meebox/ipc';
 import { invoke, subscribe } from '../api';
 
 /**
- * 跨 ChatPane 实例的 pr-agent run 队列 + 实时 stdout 缓存。放模块级 store 而不是
- * React 状态，原因：用户切 PR 时 ChatPane 会被卸载重建，但 pr-agent 在主进程仍
- * 在跑、还在持续发 `pragent:runProgress` 事件 —— 把 (active, waiting, 已收到的
- * lines) 提到 React 树之上，新挂载的 ChatPane 能立刻读到正确状态。
+ * Cross-ChatPane-instance pr-agent run queue + live stdout cache. Kept in a
+ * module-level store rather than React state because: switching PRs unmounts and
+ * rebuilds ChatPane, but pr-agent keeps running in the main process and keeps
+ * emitting `pragent:runProgress` events — lifting (active, waiting, received
+ * lines) above the React tree lets a freshly mounted ChatPane read the correct
+ * state immediately.
  *
- * 数据 immutable 替换 (linesByRunId 用全新 Map / 数组，waiting 用新数组)，配合
- * useSyncExternalStore 的 identity 检查触发 re-render。
+ * Data is replaced immutably (linesByRunId uses a brand-new Map / array, waiting
+ * a new array), pairing with useSyncExternalStore's identity check to trigger a
+ * re-render.
  */
 export interface ChatRunStoreState {
-  /** 当前并发运行中的 run 列表（长度 ≤ max_concurrency）。空数组表示当前无 run 在跑 */
+  /** List of runs currently running concurrently (length ≤ max_concurrency). Empty array means no run is currently running */
   active: ReadonlyArray<PragentRunInfo>;
-  /** 等待执行的 run 队列 (FIFO，前面的先跑)。空数组表示无人排队 */
+  /** Queue of runs waiting to execute (FIFO, earlier ones run first). Empty array means nobody is queued */
   waiting: ReadonlyArray<PragentRunInfo>;
-  /** 各 run 的实时 stdout 行缓存。键 = runId；run 完成后保留直到 clearLines 调用 */
+  /** Live stdout line cache per run. Key = runId; retained after a run completes until clearLines is called */
   linesByRunId: ReadonlyMap<string, ReadonlyArray<string>>;
-  /** 有编排 Agent 运行中（思考或派发工具）的 PR localId 集合——含纯思考阶段（无活跃工具 run），
-   *  来自主进程 `agent:runningChanged`。PR 列表项「执行中」指示在工具队列之外再并入此集合。 */
+  /** Set of PR localIds with an orchestrating Agent running (thinking or dispatching tools) — includes the pure-thinking
+   *  phase (no active tool run), from the main process's `agent:runningChanged`. The PR list item's "running" indicator
+   *  merges in this set on top of the tool queue. */
   agentPrs: ReadonlyArray<string>;
 }
 
@@ -50,11 +54,11 @@ function setQueue(
   waiting: ReadonlyArray<PragentRunInfo>,
 ): void {
   const sameActive = sameRunList(state.active, active);
-  // 浅相等优化：active / waiting 的 runId(+startedAt) 序列都没变 → 不通知，避免无谓 re-render
+  // Shallow-equality optimization: if the runId(+startedAt) sequences of active / waiting are unchanged → don't notify, avoiding pointless re-renders
   if (sameActive && sameRunList(state.waiting, waiting)) return;
-  // 全局回收 stdout 缓存：离开 active 的 run（成功/失败/取消完成）清掉其 lines。
-  // 放在 store 层而非 ChatPane —— 不依赖用户当前打开哪个 PR，避免非当前 PR 上完成的
-  // run 的 lines 长期驻留。删除合并进同一次 state 更新，只 notify 一次。
+  // Globally reclaim stdout cache: clear the lines of any run that left active (completed as success/failure/cancel).
+  // Placed at the store layer rather than ChatPane — independent of which PR the user currently has open, avoiding
+  // long-lived lines for runs completed on a non-current PR. The deletions merge into the same state update, notifying only once.
   let linesByRunId = state.linesByRunId;
   if (!sameActive) {
     const nextActiveIds = new Set(active.map((r) => r.runId));
@@ -70,7 +74,7 @@ function setQueue(
   notify();
 }
 
-/** 集合相等（顺序无关）：长度相同且每个 id 都在旧集合里。避免广播顺序差异引发无谓 re-render。 */
+/** Set equality (order-independent): same length and every id is in the old set. Avoids pointless re-renders from broadcast ordering differences. */
 function sameIdSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>): boolean {
   if (a.length !== b.length) return false;
   const sa = new Set(a);
@@ -118,12 +122,12 @@ export function useChatRunStore(): ChatRunStoreState {
 }
 
 /**
- * 把 IPC → store 的数据流接起来。在 App 顶层 useEffect 调用一次。
- * - 启动时拉一次队列快照兜底 (window reload / preload 重连后仍能恢复 UI)
- * - 订阅 queueChanged 事件，更新 store.active + store.waiting
- * - 订阅 runProgress 事件，把 line 追加到对应 runId 的 lines 缓存
+ * Wire up the IPC → store data flow. Call once in a top-level App useEffect.
+ * - Pull a queue snapshot once at startup as a fallback (UI can still recover after window reload / preload reconnect)
+ * - Subscribe to queueChanged events, updating store.active + store.waiting
+ * - Subscribe to runProgress events, appending each line to the lines cache of the corresponding runId
  *
- * 返回 cleanup 函数，App unmount 时一并取消订阅。
+ * Returns a cleanup function that unsubscribes everything on App unmount.
  */
 export function wireChatRunStore(): () => void {
   let cancelled = false;
@@ -132,7 +136,7 @@ export function wireChatRunStore(): () => void {
       const snap = await invoke('pragent:queue', undefined);
       if (!cancelled) chatRunStore.setQueue(snap.active, snap.waiting);
     } catch {
-      // 启动阶段拿不到队列也不致命，等事件兜
+      // Failing to get the queue at startup is not fatal; events will fill in as a fallback
     }
   })();
   const unsubQueue = subscribe('pragent:queueChanged', (ev) => {
@@ -141,7 +145,7 @@ export function wireChatRunStore(): () => void {
   const unsubProgress = subscribe('pragent:runProgress', (ev) => {
     chatRunStore.appendLine(ev.runId, ev.line);
   });
-  // 编排 Agent 运行中（含纯思考阶段）的 PR 集合：手动 run/ask 与 AutoPilot 后台评审一并计入。
+  // Set of PRs with an orchestrating Agent running (including the pure-thinking phase): manual run/ask and AutoPilot background review are both counted in.
   const unsubAgentRunning = subscribe('agent:runningChanged', (ev) => {
     chatRunStore.setAgentPrs(ev.prLocalIds);
   });

--- a/apps/desktop/src/renderer/src/stores/drafts-store.ts
+++ b/apps/desktop/src/renderer/src/stores/drafts-store.ts
@@ -3,20 +3,20 @@ import type { ReviewDraft } from '@meebox/shared';
 import { invoke, subscribe } from '../api';
 
 /**
- * 跨组件共享的草稿池。每个 PR 的草稿独立存一份 (按 localId 维护)，避免 PR 切换时
- * 把别 PR 的草稿洗掉。
+ * Cross-component shared draft pool. Each PR's drafts are stored separately (keyed
+ * by localId), avoiding wiping another PR's drafts when switching PRs.
  *
- * 数据流：
- *   main IPC `drafts:create/update/delete` → 写盘 + 广播 `drafts:changed` →
- *   本 store 收到事件 → 调 `drafts:list` 重拉 → notify subscribers
+ * Data flow:
+ *   main IPC `drafts:create/update/delete` → write to disk + broadcast `drafts:changed` →
+ *   this store receives the event → calls `drafts:list` to re-pull → notify subscribers
  *
- * ChatPane / DiffView 都通过 `useDraftsForPr(localId)` 读，跟 chatRunStore /
- * repoSyncStore 同模。
+ * ChatPane / DiffView both read via `useDraftsForPr(localId)`, following the same
+ * pattern as chatRunStore / repoSyncStore.
  */
 export interface DraftsStoreState {
-  /** localId → 该 PR 的全部草稿。未拉过的 PR 缺 key (UI 第一次访问会触发 hydrate) */
+  /** localId → all drafts of that PR. A PR not yet pulled is missing its key (the UI's first access triggers hydrate) */
   byPr: ReadonlyMap<string, ReadonlyArray<ReviewDraft>>;
-  /** 正在 fetch 的 localId 集合，避免重复触发 */
+  /** Set of localIds currently being fetched, to avoid duplicate triggers */
   loading: ReadonlySet<string>;
 }
 
@@ -50,7 +50,7 @@ async function hydrate(localId: string): Promise<void> {
     const list = await invoke('drafts:list', { localId });
     setForPr(localId, list);
   } catch {
-    // 失败静默；UI 看到空草稿，重试由下次 hydrate 触发
+    // Fail silently; the UI sees empty drafts, and a retry is triggered by the next hydrate
     setForPr(localId, []);
   }
 }
@@ -63,9 +63,9 @@ export const draftsStore = {
       subscribers.delete(cb);
     };
   },
-  /** 强制重拉 (drafts:changed 事件触发) */
+  /** Force a re-pull (triggered by the drafts:changed event) */
   refresh: (localId: string): Promise<void> => hydrate(localId),
-  /** 首次访问时按需 hydrate；已 fetch 过 / 正在 fetch 不重复 */
+  /** Hydrate on demand on first access; skip if already fetched / currently fetching */
   ensureLoaded: (localId: string): void => {
     if (state.byPr.has(localId) || state.loading.has(localId)) return;
     void hydrate(localId);
@@ -73,15 +73,16 @@ export const draftsStore = {
 };
 
 /**
- * 读取指定 PR 的草稿数组。首次访问触发后台 hydrate；hydrate 完成后通过 store
- * subscription 自动 re-render。返回 null 表示还在 loading (UI 可显示加载占位)。
+ * Read the draft array of a given PR. First access triggers a background hydrate;
+ * after hydrate completes it auto re-renders via the store subscription. Returns
+ * null to indicate still loading (the UI can show a loading placeholder).
  */
 export function useDraftsForPr(localId: string | null | undefined): ReadonlyArray<ReviewDraft> | null {
   const snap = useSyncExternalStore(draftsStore.subscribe, draftsStore.getSnapshot);
-  // 首次访问按需 hydrate。**必须放 effect、绝不在 render 阶段触发**：ensureLoaded →
-  // markLoading → notify() 会同步通知所有订阅者，render 期调用即「渲染 A 组件时更新了
-  // 同样订阅本 store 的 B 组件」，React 报 "Cannot update a component while rendering a
-  // different component"。effect 在 commit 后跑，notify 落在渲染之外，告警消除。
+  // Hydrate on demand on first access. **Must go in an effect, never trigger during the render phase**: ensureLoaded →
+  // markLoading → notify() synchronously notifies all subscribers, and calling it during render means "updating component B
+  // that also subscribes to this store while rendering component A", for which React reports "Cannot update a component while
+  // rendering a different component". An effect runs after commit, so notify lands outside rendering and the warning is gone.
   useEffect(() => {
     if (localId) draftsStore.ensureLoaded(localId);
   }, [localId]);
@@ -91,12 +92,12 @@ export function useDraftsForPr(localId: string | null | undefined): ReadonlyArra
 }
 
 /**
- * 在 App 顶层 useEffect 调用一次。订阅 `drafts:changed` 事件，main 写盘后
- * renderer 自动同步。返回 cleanup 函数。
+ * Call once in a top-level App useEffect. Subscribes to the `drafts:changed` event;
+ * after main writes to disk, the renderer auto-syncs. Returns a cleanup function.
  */
 export function wireDraftsStore(): () => void {
   return subscribe('drafts:changed', (ev) => {
-    // 只重拉本地已有 (其他 PR 的草稿先不动，省 IPC 往返)
+    // Only re-pull what's already local (leave other PRs' drafts untouched, saving IPC round-trips)
     if (state.byPr.has(ev.localId) || state.loading.has(ev.localId)) {
       void draftsStore.refresh(ev.localId);
     }

--- a/apps/desktop/src/renderer/src/stores/editor-appearance-store.ts
+++ b/apps/desktop/src/renderer/src/stores/editor-appearance-store.ts
@@ -2,18 +2,19 @@ import { useSyncExternalStore } from 'react';
 import type { EditorTheme } from '@meebox/shared';
 
 /**
- * 编辑器外观（Monaco 配色主题 + 等宽字体）的渲染层共享态。App 从 config.appearance 写入，深层的 Monaco
- * 组件（DiffPane / InlineCodeContext）经 useEditorAppearance 读出 —— 避免逐层透传 props。
+ * Renderer-layer shared state for editor appearance (Monaco color theme + monospace font). App writes it from
+ * config.appearance, and deep Monaco components (DiffPane / InlineCodeContext) read it via useEditorAppearance —
+ * avoiding threading props through every layer.
  *
- * 与 selection-store 同模（模块级状态 + Set<subscriber> + useSyncExternalStore）：纯本地、无 IPC、无
- * hydrate。持久化与写盘走 config（IPC config:setEditorAppearance），本 store 只承载「当前生效值」。
+ * Same pattern as selection-store (module-level state + Set<subscriber> + useSyncExternalStore): purely local, no IPC, no
+ * hydrate. Persistence and disk writes go through config (IPC config:setEditorAppearance); this store only carries the "currently effective value".
  */
 export interface EditorAppearanceState {
-  /** 编辑器配色主题偏好：'auto' 跟随 GUI 深 / 浅色，其余为具体 Monaco 主题名。 */
+  /** Editor color theme preference: 'auto' follows the GUI's dark / light mode, otherwise a specific Monaco theme name. */
   editorTheme: EditorTheme;
-  /** 等宽字体族（空 = 用内置 mono 字体栈）。 */
+  /** Monospace font family (empty = use the built-in mono font stack). */
   fontFamily: string;
-  /** 字号（px，未做平台微调的基准值）。 */
+  /** Font size (px, the baseline value before any platform fine-tuning). */
   fontSize: number;
 }
 
@@ -34,7 +35,7 @@ const store = {
   },
 };
 
-/** 写入当前编辑器外观（App 在 config 变化时调用）。各字段相等则跳过，避免无谓重渲。 */
+/** Write the current editor appearance (App calls this when config changes). Skips if all fields are equal, avoiding pointless re-renders. */
 export function setEditorAppearance(next: EditorAppearanceState): void {
   if (
     next.editorTheme === state.editorTheme &&
@@ -47,7 +48,7 @@ export function setEditorAppearance(next: EditorAppearanceState): void {
   notify();
 }
 
-/** 读当前编辑器外观（Monaco 组件用）。 */
+/** Read the current editor appearance (for Monaco components). */
 export function useEditorAppearance(): EditorAppearanceState {
   return useSyncExternalStore(store.subscribe, store.getSnapshot);
 }

--- a/apps/desktop/src/renderer/src/stores/finding-closures-store.ts
+++ b/apps/desktop/src/renderer/src/stores/finding-closures-store.ts
@@ -3,10 +3,10 @@ import type { FindingClosure } from '@meebox/shared';
 import { invoke, subscribe } from '../api';
 
 /**
- * 跨组件共享的 finding 关闭关系池（复评 /ask 取代/撤销原 finding 时建立）。每个 PR 独立一份，与
- * draftsStore 同模。数据流：main `findingClosures:create/delete` → 写盘 + 广播 `findingClosures:changed`
- * → 本 store 重拉 → notify。`useFindingClosuresForPr(localId)` 供 FindingCard / RunResultView 读，
- * 据 (runId, findingId) 反查某条 finding 是否已被复评关闭。
+ * Cross-component shared finding-closure relation pool (established when a re-review /ask supersedes/revokes the original
+ * finding). One separate copy per PR, same pattern as draftsStore. Data flow: main `findingClosures:create/delete` → write
+ * to disk + broadcast `findingClosures:changed` → this store re-pulls → notify. `useFindingClosuresForPr(localId)` is read
+ * by FindingCard / RunResultView to look up, by (runId, findingId), whether a given finding has been closed by re-review.
  */
 export interface FindingClosuresStoreState {
   byPr: ReadonlyMap<string, ReadonlyArray<FindingClosure>>;
@@ -62,7 +62,7 @@ export const findingClosuresStore = {
   },
 };
 
-/** 读取指定 PR 的关闭关系数组（null = loading）。首次访问触发后台 hydrate。 */
+/** Read the closure-relation array of a given PR (null = loading). First access triggers a background hydrate. */
 export function useFindingClosuresForPr(
   localId: string | null | undefined,
 ): ReadonlyArray<FindingClosure> | null {
@@ -70,7 +70,7 @@ export function useFindingClosuresForPr(
     findingClosuresStore.subscribe,
     findingClosuresStore.getSnapshot,
   );
-  // 同 draftsStore：hydrate 放 effect，避免 render 期 notify 触发跨组件更新告警。
+  // Same as draftsStore: put hydrate in an effect, avoiding a render-phase notify triggering the cross-component update warning.
   useEffect(() => {
     if (localId) findingClosuresStore.ensureLoaded(localId);
   }, [localId]);
@@ -79,7 +79,7 @@ export function useFindingClosuresForPr(
   return snap.byPr.get(localId)!;
 }
 
-/** App 顶层调用一次，订阅 `findingClosures:changed` 自动同步。 */
+/** Call once at the top level of App; subscribes to `findingClosures:changed` to auto-sync. */
 export function wireFindingClosuresStore(): () => void {
   return subscribe('findingClosures:changed', (ev) => {
     if (state.byPr.has(ev.localId) || state.loading.has(ev.localId)) {

--- a/apps/desktop/src/renderer/src/stores/repo-sync-store.ts
+++ b/apps/desktop/src/renderer/src/stores/repo-sync-store.ts
@@ -3,30 +3,30 @@ import type { SyncProgressEvent } from '@meebox/shared';
 import { subscribe } from '../api';
 
 /**
- * 跨组件共享的当前活动 repo sync 状态。
+ * Cross-component shared state of the currently active repo sync.
  *
- * 数据来源：main 的 `sync:progress` 事件流（每个 repo 的 start/progress/done/error）。
- * 一个 repo 一条记录：start → 进 active，progress 更新阶段+百分比，done/error 移出。
+ * Data source: main's `sync:progress` event stream (each repo's start/progress/done/error).
+ * One record per repo: start → enters active, progress updates stage + percent, done/error removes it.
  *
- * UI 用法：StatusBar 取 `getActive()` 第一条展示；没有任何 active 时 chip 隐藏不占位。
- * 同一时刻可能有多个 repo 排队 (RepoMirrorManager 已是全局单队列串行)，store 都收着
- * 便于"还有 N 个在排队"扩展，第一版只展示首条。
+ * UI usage: StatusBar displays the first entry from `getActive()`; when there is no active entry the chip is hidden and takes no space.
+ * Multiple repos may be queued at the same time (RepoMirrorManager is already a global single-queue serial), and the store keeps them all
+ * to allow a "N more queued" extension; the first version only displays the first entry.
  */
 export interface RepoSyncState {
-  /** repoKey ("host/group/repo") → 当前阶段快照 */
+  /** repoKey ("host/group/repo") → current stage snapshot */
   active: ReadonlyMap<string, RepoSyncSnapshot>;
 }
 
 export interface RepoSyncSnapshot {
-  /** 来自 sync:progress.repo，"host/projectKey/repoSlug" */
+  /** From sync:progress.repo, "host/projectKey/repoSlug" */
   repo: string;
-  /** simple-git 阶段名（compressing / receiving / resolving / ...）；start 时可能空 */
+  /** simple-git stage name (compressing / receiving / resolving / ...); may be empty at start */
   stage?: string;
-  /** 0-100；progress 阶段填，done 时一般已到 100 */
+  /** 0-100; filled during the progress stage, usually already at 100 on done */
   percent?: number;
-  /** 给 hover tooltip / 排障用 */
+  /** For the hover tooltip / troubleshooting */
   message?: string;
-  /** 进入 active 的时间戳，用于 UI 排序 / "停留 X 秒" 显示 */
+  /** Timestamp of entering active, used for UI ordering / "held for X seconds" display */
   startedAt: number;
 }
 
@@ -67,7 +67,7 @@ export const repoSyncStore = {
       subscribers.delete(cb);
     };
   },
-  /** 测试 / 调试用：直接灌一条事件 */
+  /** For testing / debugging: feed in an event directly */
   handleEvent,
 };
 
@@ -76,8 +76,8 @@ export function useRepoSyncStore(): RepoSyncState {
 }
 
 /**
- * 把 IPC sync:progress 事件接到 store。App 顶层 useEffect 调一次。
- * Date.now() 仅在事件发生时本地取，store 自身保持纯。
+ * Wire the IPC sync:progress event to the store. Call once in a top-level App useEffect.
+ * Date.now() is read locally only when an event occurs, keeping the store itself pure.
  */
 export function wireRepoSyncStore(): () => void {
   return subscribe('sync:progress', (ev) => {

--- a/apps/desktop/src/renderer/src/stores/selection-store.ts
+++ b/apps/desktop/src/renderer/src/stores/selection-store.ts
@@ -1,41 +1,43 @@
 import { useSyncExternalStore } from 'react';
 
 /**
- * 跨组件共享的「Diff 选区」池（渲染层内部态，不走 IPC）。DiffView 在用户于 Diff 里选中代码时写入，
- * ChatPane / ChatInputBar 读出，用于把选中代码作为**隐式上下文**带进 agent/ask 提问。
+ * Cross-component shared "Diff selection" pool (renderer-internal state, not via IPC). DiffView writes on
+ * user code selection in the Diff, ChatPane / ChatInputBar read it, to carry the selected code as **implicit
+ * context** into agent/ask questions.
  *
- * 数据流：
- *   DiffView 监听 Monaco onDidChangeCursorSelection → set(选区) / clear() →
- *   notify → useDiffSelection 重渲染 → 输入栏角标更新 →
- *   发送时（未忽略）formatReferencedContext(选区) → 作为 referencedContext 发给 main
+ * Data flow:
+ *   DiffView listens to Monaco onDidChangeCursorSelection → set(selection) / clear() →
+ *   notify → useDiffSelection re-renders → input bar badge updates →
+ *   on send (not ignored) formatReferencedContext(selection) → sent to main as referencedContext
  *
- * 与 drafts-store 同模（模块级状态 + Set<subscriber> + useSyncExternalStore），但纯本地、无 hydrate。
+ * Same pattern as drafts-store (module-level state + Set<subscriber> + useSyncExternalStore), but purely local, no hydrate.
  */
 export interface DiffSelection {
-  /** 选区归属 PR（防跨 PR 串台：useDiffSelection 不匹配当前 PR 时对外呈 null）。 */
+  /** PR the selection belongs to (prevents cross-PR mixups: useDiffSelection presents null when it doesn't match the current PR). */
   prLocalId: string;
-  /** 文件路径（head 侧用新路径，old 侧用基线路径）。 */
+  /** File path (head side uses new path, old side uses baseline path). */
   path: string;
-  /** 选区所在 Diff 子编辑器：old=基线(original) / new=变更(modified)。 */
+  /** Diff sub-editor the selection is in: old=baseline(original) / new=changed(modified). */
   side: 'old' | 'new';
-  /** 起止行（含两端，1 基，即该侧显示文件行号）。 */
+  /** Start/end lines (both ends inclusive, 1-based, i.e. the displayed file line numbers on that side). */
   startLine: number;
   endLine: number;
-  /** 行数（endLine - startLine + 1）。指 head/old 主选区的行数，不含下方 removed 附带行。 */
+  /** Line count (endLine - startLine + 1). Refers to the head/old primary selection line count, excluding the removed lines carried below. */
   lineCount: number;
-  /** 选中文本快照（选区产生时即取，发送时直接用，无需回查 model）。 */
+  /** Selected text snapshot (captured when the selection is produced, used directly on send, no need to re-query the model). */
   text: string;
   /**
-   * 内联（统一）视图专属：head 选区跨到的删除/改动 hunk 的**基线侧**原始行（含真实代码）。统一视图下
-   * 删除行是 Monaco view-zone、无法被光标选中，故据 getLineChanges() 映射、从 original model 取出，与
-   * 所选 head 行一并引用——让删除内容也能「像添加行一样」被引用。side==='new' 且非并排视图时可能有。
+   * Inline (unified) view only: the **baseline-side** original lines (with real code) of the deleted/changed hunk
+   * spanned by the head selection. In unified view the deleted lines are Monaco view-zones and can't be cursor-selected,
+   * so they are mapped via getLineChanges() and taken from the original model, referenced together with the selected
+   * head lines — letting deleted content also be referenced "like added lines". May be present when side==='new' and not side-by-side view.
    */
   removed?: { startLine: number; endLine: number; text: string };
 }
 
 interface SelectionStoreState {
   selection: DiffSelection | null;
-  /** 忽略态：用户点角标切到「不附带」，本条消息不带选区引用（角标仍显示，置灰 + eye-slash）。 */
+  /** Ignored state: user clicked the badge to toggle "don't carry", this message carries no selection reference (badge still shows, greyed out + eye-slash). */
   ignored: boolean;
 }
 
@@ -54,18 +56,18 @@ export const selectionStore = {
       subscribers.delete(cb);
     };
   },
-  /** 写入新选区。每次新选区默认「附带」（ignored 复位为 false）。 */
+  /** Write a new selection. Each new selection defaults to "carry" (ignored reset to false). */
   set: (selection: DiffSelection): void => {
     state = { selection, ignored: false };
     notify();
   },
-  /** 清空选区（选区塌缩 / 切 PR / 文件切换）。 */
+  /** Clear the selection (selection collapse / PR switch / file switch). */
   clear: (): void => {
     if (state.selection === null && !state.ignored) return;
     state = { selection: null, ignored: false };
     notify();
   },
-  /** 切换忽略态（角标点击）。 */
+  /** Toggle ignored state (badge click). */
   toggleIgnored: (): void => {
     if (!state.selection) return;
     state = { ...state, ignored: !state.ignored };
@@ -74,8 +76,8 @@ export const selectionStore = {
 };
 
 /**
- * 读取「归属当前 PR」的选区快照。选区 prLocalId 与传入不符（切到别的 PR / 无 PR）→ 返回 null 选区，
- * 避免把别 PR 的选区误带进本会话。
+ * Read the selection snapshot "belonging to the current PR". If the selection's prLocalId doesn't match the passed
+ * value (switched to another PR / no PR) → returns a null selection, to avoid carrying another PR's selection into this session.
  */
 export function useDiffSelection(prLocalId: string | null | undefined): {
   selection: DiffSelection | null;
@@ -88,7 +90,7 @@ export function useDiffSelection(prLocalId: string | null | undefined): {
   return snap;
 }
 
-/** 行范围标签：单行 `Lx`，多行 `Lx-Ly`。 */
+/** Line range label: single line `Lx`, multiple lines `Lx-Ly`. */
 function rangeLabel(startLine: number, endLine: number): string {
   return startLine === endLine
     ? `L${String(startLine)}`
@@ -96,10 +98,12 @@ function rangeLabel(startLine: number, endLine: number): string {
 }
 
 /**
- * 把选区拼成自描述的引用块（路径 + 行范围 + 侧 + 代码围栏），渲染层拼一次作为 referencedContext 发出。
- * 两条注入路径（pragent /ask 与 planner）共用此串。用四个反引号围栏，避免选中代码内含三反引号时破栏。
+ * Assemble the selection into a self-describing reference block (path + line range + side + code fence); the renderer
+ * assembles it once and sends it as referencedContext. Both injection paths (pragent /ask and planner) share this string.
+ * Uses four-backtick fences to avoid breaking the fence when the selected code contains triple backticks.
  *
- * 内联视图带 removed 时分两块列出：所选 head 行 + 跨到的基线删除行，让删除内容也能被引用。
+ * When the inline view carries removed, it lists two blocks: the selected head lines + the spanned baseline deleted lines,
+ * so the deleted content can also be referenced.
  */
 export function formatReferencedContext(sel: DiffSelection): string {
   const sideLabel = sel.side === 'old' ? 'base' : 'head';

--- a/apps/desktop/src/renderer/src/theme/editor-chrome-sync.ts
+++ b/apps/desktop/src/renderer/src/theme/editor-chrome-sync.ts
@@ -1,19 +1,23 @@
-// GUI chrome 跟随全局主题：从当前 Monaco 主题派生「结构性中性 token」（背景 / 前景 / 边框 / 选区）覆盖
-// 到 documentElement，使整个 chrome 与编辑器同主题。
+// GUI chrome follows the global theme: derive "structural neutral tokens" (background / foreground / border /
+// selection) from the current Monaco theme and override them on documentElement, so the whole chrome shares the
+// editor's theme.
 //
-// 混合方案（非「完全消除浅深色板」）：只派生结构性中性色；语义色（accent / approved / warning / danger /
-// chip / 文件状态点等）仍由 _theme.scss 的语义层按 data-theme 浅 / 深自管 —— 编辑器主题里没有这些产品
-// 语义色、且需对比度保证。
+// Hybrid approach (not "fully eliminate the light/dark palette"): only derive structural neutral colors; semantic
+// colors (accent / approved / warning / danger / chip / file status dots, etc.) are still self-managed by
+// _theme.scss's semantic layer per data-theme light / dark — the editor theme has no such product semantic colors
+// and they need contrast guarantees.
 //
-// 数据现实：第三方 monaco-themes 仅带 editor.background / foreground / selectionBackground 等极少数键
-// （见 monaco-setup getEditorThemeColors）。故 muted 文字 / 各级背景 / 边框全部从 fg↔bg 混合派生，
-// 并对次级文字加对比度地板（fadeWithFloor），防低对比主题（如 Solarized）击穿可读性。
+// Data reality: third-party monaco-themes carry only a handful of keys such as editor.background / foreground /
+// selectionBackground (see monaco-setup getEditorThemeColors). So muted text / each background level / borders are
+// all derived from fg↔bg mixing, with a contrast floor added to secondary text (fadeWithFloor) to keep low-contrast
+// themes (like Solarized) from breaking readability.
 //
-// 取不到色 / 缺 bg·fg 时清空覆盖，回退到纯语义色板（仍随 data-theme 浅 / 深正常显示）。
+// When no color is available / bg·fg is missing, clear the overrides and fall back to the pure semantic palette
+// (still displays normally per data-theme light / dark).
 
 import { getEditorThemeColors } from '../lib/monaco-setup';
 
-/** 本模块覆盖的全部 CSS 自定义属性（清理时逐个 remove，回退到 _theme.scss 的语义色板）。 */
+/** All CSS custom properties this module overrides (removed one by one on cleanup, falling back to _theme.scss's semantic palette). */
 const OVERRIDDEN_VARS = [
   '--bg-app',
   '--bg-panel',
@@ -40,7 +44,7 @@ interface Rgb {
   a: number;
 }
 
-/** 解析 #rgb / #rgba / #rrggbb / #rrggbbaa；失败返回 null。 */
+/** Parse #rgb / #rgba / #rrggbb / #rrggbbaa; return null on failure. */
 function parseHex(hex: string): Rgb | null {
   const h = hex.trim().replace(/^#/, '');
   const expand = (s: string): string =>
@@ -60,7 +64,7 @@ function parseHex(hex: string): Rgb | null {
   return { r, g, b, a };
 }
 
-/** 在 c1 → c2 间按 t（0..1）线性插值（忽略 alpha，结果不透明）。 */
+/** Linearly interpolate between c1 → c2 by t (0..1) (alpha ignored, result opaque). */
 function mix(c1: Rgb, c2: Rgb, t: number): Rgb {
   return {
     r: Math.round(c1.r + (c2.r - c1.r) * t),
@@ -74,13 +78,13 @@ function toRgbString({ r, g, b, a }: Rgb): string {
   return a >= 1 ? `rgb(${r}, ${g}, ${b})` : `rgb(${r} ${g} ${b} / ${a.toFixed(3)})`;
 }
 
-/** 转 #rrggbb（忽略 alpha）；供 Windows titleBarOverlay 用（其 color 取 hex）。 */
+/** Convert to #rrggbb (alpha ignored); for Windows titleBarOverlay (its color takes hex). */
 function toHex({ r, g, b }: Rgb): string {
   const h = (v: number): string => v.toString(16).padStart(2, '0');
   return `#${h(r)}${h(g)}${h(b)}`;
 }
 
-/** 相对亮度（WCAG）。 */
+/** Relative luminance (WCAG). */
 function luminance({ r, g, b }: Rgb): number {
   const ch = (v: number): number => {
     const s = v / 255;
@@ -89,7 +93,7 @@ function luminance({ r, g, b }: Rgb): number {
   return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b);
 }
 
-/** 对比度比值（WCAG，1..21）。 */
+/** Contrast ratio (WCAG, 1..21). */
 function contrastRatio(c1: Rgb, c2: Rgb): number {
   const l1 = luminance(c1);
   const l2 = luminance(c2);
@@ -98,9 +102,10 @@ function contrastRatio(c1: Rgb, c2: Rgb): number {
 }
 
 /**
- * 带对比度地板的「文字衰减」：本想把 fg 向 bg 混 desiredT（越大越淡），但从 desiredT 往 0 回收，
- * 直到结果对 bg 的对比度 ≥ floor 才停 —— 保证次级文字在低对比主题（如 Solarized）下不被衰减到不可读。
- * 代价是低对比主题里 muted 会塌回 ≈fg（与主文字同权重），是可读性优先的诚实取舍。
+ * "Text fade" with a contrast floor: intends to mix fg toward bg by desiredT (larger = fainter), but walks
+ * desiredT back toward 0 until the result's contrast against bg is ≥ floor — ensuring secondary text isn't faded
+ * to unreadable under low-contrast themes (like Solarized). The cost is that in low-contrast themes muted collapses
+ * back to ≈fg (same weight as primary text), an honest readability-first tradeoff.
  */
 function fadeWithFloor(fg: Rgb, bg: Rgb, desiredT: number, floor: number): Rgb {
   const steps = 24;
@@ -121,14 +126,15 @@ function clearChromeOverrides(): void {
 }
 
 /**
- * 把当前全局主题的 base 色派生为 GUI chrome 的结构性 token，写到 documentElement（覆盖 _theme.scss）。
- * 取不到色 / 缺 bg·fg 时清空覆盖、回退语义色板（仍随 data-theme 浅 / 深正常显示）。
+ * Derive the current global theme's base colors into structural tokens for the GUI chrome and write them to
+ * documentElement (overriding _theme.scss). When no color is available / bg·fg is missing, clear the overrides and
+ * fall back to the semantic palette (still displays normally per data-theme light / dark).
  */
 export function applyChromeFromEditorTheme(
   editorThemeId: string,
   resolvedGuiTheme: 'light' | 'dark',
 ): { color: string; symbolColor: string } | null {
-  // 'auto' 跟随解析主题 → 取默认 2026 主题（dark-2026 / light-2026）的 base 色
+  // 'auto' follows the resolved theme → take the default 2026 theme's (dark-2026 / light-2026) base color
   const effectiveId =
     editorThemeId === 'auto' ? (resolvedGuiTheme === 'dark' ? 'dark-2026' : 'light-2026') : editorThemeId;
   const data = getEditorThemeColors(effectiveId);
@@ -140,24 +146,24 @@ export function applyChromeFromEditorTheme(
     return null;
   }
   const isDark = luminance(bg) < 0.5;
-  const edge = isDark ? WHITE : BLACK; // 提升层（背景越「浮」越靠该边）/ 边框混合方向
+  const edge = isDark ? WHITE : BLACK; // elevation layer (the more a background "floats" the closer to this edge) / border mix direction
   const sel = parseHex(data?.colors['editor.selectionBackground'] ?? '') ?? mix(bg, edge, 0.16);
 
-  // 各级背景：editor.background 为基准，按 elevation 轻微向 edge 提
+  // Each background level: editor.background as baseline, lifted slightly toward edge by elevation
   const bgPanel = mix(bg, edge, 0.03);
   const bgPanelAlt = mix(bg, edge, 0.06);
   const bgElev = mix(bg, edge, 0.05);
   const bgSurface = mix(bg, edge, 0.08);
   const bgHover = mix(bg, edge, 0.1);
-  // 各级文字：editor.foreground 向 bg 衰减出 muted / subtle / dim，各带对比度地板防低对比主题击穿
+  // Each text level: fade editor.foreground toward bg into muted / subtle / dim, each with a contrast floor to keep low-contrast themes from breaking through
   const textMuted = fadeWithFloor(fg, bg, 0.45, 4.5);
   const textSubtle = fadeWithFloor(fg, bg, 0.52, 4.0);
   const textDim = fadeWithFloor(fg, bg, 0.6, 3.0);
-  // 边框：fg 大幅向 bg 衰减，留极淡轮廓
+  // Border: fade fg heavily toward bg, leaving a very faint outline
   const borderDefault = mix(fg, bg, 0.8);
   const borderMuted = mix(fg, bg, 0.88);
   const borderFade = { ...borderDefault, a: 0.5 };
-  // 分组头：向黑轻微下沉（比 bg-app 略暗的「凹陷」标题带，hover 走 --bg-panel 上浮），随主题派生。
+  // Group header: sink slightly toward black (a "recessed" title band slightly darker than bg-app, hover lifts up via --bg-panel), derived per theme.
   const bgGroupHeader = mix(bg, BLACK, 0.12);
 
   const set = (name: string, c: Rgb): void => document.documentElement.style.setProperty(name, toRgbString(c));
@@ -178,12 +184,12 @@ export function applyChromeFromEditorTheme(
   set('--bg-selected', sel);
   set('--bg-group-header', bgGroupHeader);
 
-  // 可读性体检：muted 文字 / 弱边框对背景的对比度（AA 正文≥4.5、次要文本/非文本≥3）
+  // Readability check: contrast of muted text / weak border against background (AA body text ≥4.5, secondary/non-text ≥3)
   const mutedCr = contrastRatio(textMuted, bg);
   const borderCr = contrastRatio(borderDefault, bg);
   console.info(
     `[chrome-sync] "${effectiveId}" (${isDark ? 'dark' : 'light'}) → muted/bg contrast ${mutedCr.toFixed(2)} (AA≥4.5), border/bg ${borderCr.toFixed(2)} (≥3)`,
   );
-  // 窗控按钮同色：把主题 base 背景 / 前景（hex）交回主进程更新 Windows titleBarOverlay（见 useGlobalTheme）。
+  // Match window control buttons: hand the theme base background / foreground (hex) back to the main process to update Windows titleBarOverlay (see useGlobalTheme).
   return { color: toHex(bg), symbolColor: toHex(fg) };
 }

--- a/apps/desktop/src/renderer/src/theme/index.ts
+++ b/apps/desktop/src/renderer/src/theme/index.ts
@@ -1,23 +1,23 @@
 import { resolveEditorThemeMode, editorThemeMode, type ResolvedTheme } from '@meebox/shared';
 
 /**
- * 渲染层主题运行时。
+ * Renderer theme runtime.
  *
- * 全局主题（Monaco 编辑器 + 整个 GUI chrome 共用同一主题，见 @meebox/shared EDITOR_THEME_OPTIONS）反推
- * 浅 / 深，写到 `documentElement` 的 `data-theme`；语义配色经 CSS 自定义属性整体切换（默认 :root = 暗色，
- * `[data-theme='light']` 覆盖为浅色，见 styles/_theme.scss）。结构性 chrome 色另由主题派生覆盖（见
- * editor-chrome-sync）。本模块只管 data-theme + 字体，不引 Monaco（保持首帧轻量）。
+ * The global theme (the Monaco editor + the entire GUI chrome share one theme, see @meebox/shared EDITOR_THEME_OPTIONS) is resolved to
+ * light / dark and written to `documentElement`'s `data-theme`; semantic colors switch wholesale via CSS custom properties (default :root = dark,
+ * `[data-theme='light']` overrides to light, see styles/_theme.scss). Structural chrome colors are separately overridden as derived from the theme (see
+ * editor-chrome-sync). This module only handles data-theme + fonts, and doesn't import Monaco (to keep the first frame lightweight).
  *
- * - 主题经 IPC 异步到达（config.appearance.editor_theme），启动时拿不到；localStorage 可同步读，故用它做
- *   首帧初始主题，避免启动闪错主题。App 拿到 config 后会 persist 回写，下次启动直接命中。
- * - 主题 mode 为 'auto' 时跟随 `prefers-color-scheme`，并由 watchSystemThemeForAuto 在 OS 切换时实时重解析。
- * - 默认主题取 **auto**（自动适应系统）：localStorage 无记录 / 不可用时回落 'auto'。
+ * - The theme arrives asynchronously via IPC (config.appearance.editor_theme), unavailable at startup; localStorage can be read synchronously, so it's used as
+ *   the first-frame initial theme to avoid a wrong-theme flash on startup. After App gets config it persists it back, for a direct hit on next startup.
+ * - When the theme mode is 'auto' it follows `prefers-color-scheme`, and watchSystemThemeForAuto re-resolves in real time on OS switches.
+ * - The default theme is **auto** (auto-adapt to the system): falls back to 'auto' when localStorage has no record / is unavailable.
  */
 
 const EDITOR_THEME_STORAGE_KEY = 'meebox.editorTheme';
 const DEFAULT_EDITOR_THEME = 'auto';
 
-/** OS 是否偏好深色（'auto' 主题据此解析）。matchMedia 不可用时保守按深色。 */
+/** Whether the OS prefers dark ('auto' theme resolves based on this). Conservatively assumes dark when matchMedia is unavailable. */
 function systemPrefersDark(): boolean {
   try {
     return window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -26,12 +26,12 @@ function systemPrefersDark(): boolean {
   }
 }
 
-/** 把全局主题 id 解析为实际视觉主题（'auto' 按 OS 深 / 浅落地）。 */
+/** Resolve a global theme id to the actual visual theme ('auto' lands on OS dark / light). */
 export function resolveGlobalTheme(editorTheme: string): ResolvedTheme {
   return resolveEditorThemeMode(editorTheme, systemPrefersDark());
 }
 
-/** 读 localStorage 缓存的主题作首帧初始值；无记录 / 不可用时回落默认（auto）。 */
+/** Read the localStorage-cached theme as the first-frame initial value; falls back to the default (auto) when there's no record / it's unavailable. */
 export function readInitialEditorTheme(): string {
   try {
     return localStorage.getItem(EDITOR_THEME_STORAGE_KEY) ?? DEFAULT_EDITOR_THEME;
@@ -40,23 +40,23 @@ export function readInitialEditorTheme(): string {
   }
 }
 
-/** 持久化主题到 localStorage，供下次启动同步读取作初始主题。 */
+/** Persist the theme to localStorage, for synchronous reading as the initial theme on next startup. */
 export function persistEditorTheme(editorTheme: string): void {
   try {
     localStorage.setItem(EDITOR_THEME_STORAGE_KEY, editorTheme);
   } catch {
-    // localStorage 不可用时忽略：仅影响下次启动的初始主题命中，不影响功能。
+    // Ignore when localStorage is unavailable: only affects the initial theme hit on next startup, not functionality.
   }
 }
 
-/** 把全局主题反推浅 / 深后写到 documentElement.data-theme，触发语义色板整体切换。 */
+/** Resolve the global theme to light / dark, then write it to documentElement.data-theme, triggering a wholesale semantic palette switch. */
 export function applyGlobalTheme(editorTheme: string): void {
   document.documentElement.dataset.theme = resolveGlobalTheme(editorTheme);
 }
 
 /**
- * 监听 OS 深 / 浅色变化。仅 'auto' 主题需要：OS 切换时实时重解析并重写 data-theme。
- * 返回取消订阅函数；非 'auto' 主题直接返回空 cleanup（无监听）。
+ * Watch OS dark / light changes. Needed only for the 'auto' theme: re-resolve in real time on OS switch and rewrite data-theme.
+ * Returns an unsubscribe function; non-'auto' themes just return an empty cleanup (no watching).
  */
 export function watchSystemThemeForAuto(editorTheme: string, onChange: () => void): () => void {
   if (editorThemeMode(editorTheme) !== 'auto') return () => {};
@@ -74,19 +74,19 @@ export function watchSystemThemeForAuto(editorTheme: string, onChange: () => voi
   return () => mq.removeEventListener('change', handler);
 }
 
-// 内置等宽字体兜底栈：用户自定义字体后置于其后，保证缺字时仍回落到合理 mono 字体。
+// Built-in monospace fallback stack: placed after the user's custom font, ensuring a fall-back to a reasonable mono font when glyphs are missing.
 const MONO_FALLBACK = "'Cascadia Code', 'Consolas', ui-monospace, monospace";
 
-/** 把用户配置的字体族解析为完整 font-family 串（追加兜底栈）；空配置返回 undefined（用默认）。 */
+/** Resolve the user-configured font family to a full font-family string (appending the fallback stack); empty config returns undefined (uses the default). */
 export function resolveEditorFontFamily(font: string): string | undefined {
   const f = font.trim();
   return f ? `${f}, ${MONO_FALLBACK}` : undefined;
 }
 
 /**
- * 应用编辑器等宽字体到全应用：写 documentElement 的 `--editor-font-family` 自定义属性（$font-mono 经
- * 它取值，覆盖 diff / 评论 / 代码块等所有等宽文本）。空配置时移除该属性，回落内置 mono 字体栈。
- * Monaco 编辑器内容字体另经其 fontFamily option 设置（见 DiffPane / InlineCodeContext）。
+ * Apply the editor monospace font app-wide: write documentElement's `--editor-font-family` custom property ($font-mono takes
+ * its value from it, covering all monospace text such as diff / comments / code blocks). When config is empty, remove the property and fall back to the built-in mono font stack.
+ * The Monaco editor content font is set separately via its fontFamily option (see DiffPane / InlineCodeContext).
  */
 export function applyEditorFontFamily(font: string): void {
   const resolved = resolveEditorFontFamily(font);
@@ -94,5 +94,5 @@ export function applyEditorFontFamily(font: string): void {
   else document.documentElement.style.removeProperty('--editor-font-family');
 }
 
-// 副作用：模块导入即按 localStorage 缓存定下首帧主题（在 React 渲染前），避免启动闪错主题。
+// Side effect: on module import, set the first-frame theme from the localStorage cache (before React renders), avoiding a wrong-theme flash on startup.
 applyGlobalTheme(readInitialEditorTheme());

--- a/apps/desktop/src/renderer/src/utils/ansi.ts
+++ b/apps/desktop/src/renderer/src/utils/ansi.ts
@@ -1,13 +1,13 @@
 /**
- * 把含 ANSI SGR 转义的字符串切成可渲染的 segment 列表。
+ * Slice a string containing ANSI SGR escapes into a renderable segment list.
  *
- * 底层用 [anser](https://github.com/IonicaBizau/anser)（事实标准 ANSI → JSON 解析器，
- * 7KB 体积，Sentry / Storybook / Jest 都在用）。它正确处理 SGR / OSC / CSI 全谱、
- * 16/256/truecolor、bold/italic/underline/dim 装饰，不踩自卷边角案的坑（之前自实现
- * 时撞过 `\x1b.` 贪心吃掉 CSI 起头的 bug）。
+ * Backed by [anser](https://github.com/IonicaBizau/anser) (de-facto standard ANSI → JSON parser,
+ * 7KB, used by Sentry / Storybook / Jest). It correctly handles the full SGR / OSC / CSI spectrum,
+ * 16/256/truecolor, bold/italic/underline/dim decorations, and avoids the pitfalls of a hand-rolled
+ * edge case (a prior self-implementation hit a `\x1b.` greedy bug that ate the CSI head).
  *
- * Anser 返回的 fg / bg 是 `"rgb(r, g, b)"` 字符串 (默认配色为标准 ANSI 16 色 + 256
- * 色 cube 算法)，直接塞进 React style 即可。
+ * Anser returns fg / bg as `"rgb(r, g, b)"` strings (default palette is standard ANSI 16 colors + 256
+ * color cube algorithm), which can be dropped straight into a React style.
  */
 
 import Anser from 'anser';
@@ -40,7 +40,7 @@ export function parseAnsi(input: string): AnsiSegment[] {
     });
 }
 
-/** AnsiSegment → React inline style；给 <span style={...}> 用 */
+/** AnsiSegment → React inline style; for use with <span style={...}> */
 export function segmentStyle(seg: AnsiSegment): React.CSSProperties {
   const style: React.CSSProperties = {};
   if (seg.fg) style.color = seg.fg;

--- a/apps/desktop/src/renderer/src/utils/language.ts
+++ b/apps/desktop/src/renderer/src/utils/language.ts
@@ -1,8 +1,8 @@
 /**
- * 按文件扩展名映射到 Monaco language id。Monaco 自带的 language 列表参见
+ * Map a file extension to a Monaco language id. For Monaco's built-in language list see
  * https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages
  *
- * 未识别 → 返回 'plaintext'。无扩展名文件按 basename 识别（Dockerfile / Makefile）。
+ * Unrecognized → returns 'plaintext'. Extensionless files are identified by basename (Dockerfile / Makefile).
  */
 export function languageFor(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase() ?? '';

--- a/apps/desktop/src/renderer/src/utils/time.ts
+++ b/apps/desktop/src/renderer/src/utils/time.ts
@@ -1,10 +1,10 @@
 import type { TFunction } from 'i18next';
 
 /**
- * 把毫秒时长格式化为 "Ns" / "Mm SSs"：
+ * Format a millisecond duration as "Ns" / "Mm SSs":
  *   < 60s  → "42s"
- *   >= 60s → "1m 30s"（秒两位补零定宽）；`compact` 时去掉空格 → "1m30s"（状态栏紧凑场景）
- * 用 `m` / `s` 单位字面而非冒号，避免跟时间戳 (HH:MM) 视觉混淆。
+ *   >= 60s → "1m 30s" (seconds zero-padded to a fixed two-digit width); with `compact` the space is dropped → "1m30s" (status bar compact scenario)
+ * Uses the `m` / `s` unit literals rather than a colon, to avoid visual confusion with a timestamp (HH:MM).
  */
 export function formatElapsed(ms: number, opts?: { compact?: boolean }): string {
   const totalSec = Math.max(0, Math.floor(ms / 1000));
@@ -15,8 +15,8 @@ export function formatElapsed(ms: number, opts?: { compact?: boolean }): string 
 }
 
 /**
- * 把时间点格式化为相对时间："刚刚 / N 秒前 / N 分钟前 / N 小时前"；超过 1 天给绝对时间，
- * 避免 "3 天前" 这种模糊。
+ * Format a point in time as relative time: "just now / N seconds ago / N minutes ago / N hours ago"; beyond 1 day
+ * give an absolute time, to avoid vagueness like "3 days ago".
  */
 export function formatRelative(date: Date, t: TFunction): string {
   const diffSec = Math.max(0, Math.round((Date.now() - date.getTime()) / 1000));

--- a/apps/desktop/src/renderer/src/utils/translate-pr-agent.ts
+++ b/apps/desktop/src/renderer/src/utils/translate-pr-agent.ts
@@ -1,23 +1,24 @@
 /**
- * pr-agent 输出模板的翻译（独立于 react-i18next 的 UI 文案）。
+ * Translation of pr-agent output templates (independent of react-i18next's UI text).
  *
- * 背景：`CONFIG__RESPONSE_LANGUAGE=zh-CN` 只影响 LLM 生成的**内容值**，但 pr-agent
- * 在其 Python 源码里**硬编码**了一批结构化模板字符串（section 标题 / fixed labels /
- * checkbox 文字），这些 LLM 不动它们，所以中文环境下仍以英文出现。我们在渲染层做一次
- * 替换，把已知模板词翻成目标语言。
+ * Background: `CONFIG__RESPONSE_LANGUAGE=zh-CN` only affects the **content values** the LLM generates, but pr-agent
+ * **hardcodes** a batch of structured template strings in its Python source (section headings / fixed labels /
+ * checkbox text) that the LLM leaves untouched, so under a Chinese environment they still appear in English. We do one
+ * pass of replacement in the renderer, translating known template words into the target language.
  *
- * 这不是「按 key 取串」而是「按英文原文匹配、整段 blob 子串替换」，与 react-i18next 的
- * 访问模型不同，故**不进 locale 资源**，各语言的 <英文模板 → 译文> 表独立维护在同目录
- * 的 `pr-agent-labels/<lang>.json`，由本文件的替换引擎加载。
+ * This is not "look up a string by key" but "match by English source, substring-replace across the whole blob", which
+ * differs from react-i18next's access model, so it **does not go into locale resources**; each language's
+ * <English template → translation> table is maintained separately in `pr-agent-labels/<lang>.json` in the same
+ * directory, loaded by this file's replacement engine.
  *
- * 字典随 pr-agent 版本维护（按输出模板分组、便于跟上游升级 spot-check；JSON 顺序不影响
- * 正确性——引擎按 key 长度倒序处理，避免"短键先吃掉长键的子串"）。pr-agent v0.36 把
- * issue_header "Possible bug" rewrite 成大写 I 的 "Possible Issue" 绕过 LLM 翻译，故字典
- * 里另列了大写版本。
+ * The dictionary is maintained per pr-agent version (grouped by output template, to ease spot-checking against upstream
+ * upgrades; JSON order does not affect correctness — the engine processes keys in descending length order, avoiding
+ * "a short key eating the substring of a long key"). pr-agent v0.36 rewrote the issue_header "Possible bug" into
+ * "Possible Issue" with an uppercase I to bypass LLM translation, so the dictionary also lists the uppercase version.
  *
- * 语言感知：仅当 UI 语言 (config.language) 有对应字典（当前 zh-CN）时替换；en-US 等无字典
- * 语言下 pr-agent 输出本就是英文，原样返回 (passthrough)。新增目标语言 = 加一份
- * `pr-agent-labels/<lang>.json` 并在 TRANSLATION_MAPS 注册。
+ * Language-aware: replaces only when the UI language (config.language) has a matching dictionary (currently zh-CN);
+ * under dictionary-less languages like en-US the pr-agent output is already English, returned as-is (passthrough).
+ * Adding a target language = add a `pr-agent-labels/<lang>.json` and register it in TRANSLATION_MAPS.
  */
 
 import i18n, { matchSupportedLanguage, type SupportedLanguage } from '../i18n';
@@ -25,14 +26,14 @@ import zhCN from './pr-agent-labels/zh-CN.json';
 import jaJP from './pr-agent-labels/ja-JP.json';
 import deDE from './pr-agent-labels/de-DE.json';
 
-// 各语言的 <英文模板 → 译文> 表注册表。未注册的语言（如 en-US）→ passthrough。
+// Registry of each language's <English template → translation> table. Unregistered languages (e.g. en-US) → passthrough.
 const TRANSLATION_MAPS: Partial<Record<SupportedLanguage, Record<string, string>>> = {
   'zh-CN': zhCN,
   'ja-JP': jaJP,
   'de-DE': deDE,
 };
 
-// 按语言缓存「预排序条目」(长 key 在前，避免短 key 先吃掉长 key 的子串)
+// Cache "pre-sorted entries" per language (long keys first, to avoid a short key eating a long key's substring)
 const SORTED_BY_LANG = new Map<SupportedLanguage, Array<[string, string]>>();
 function sortedEntriesFor(lang: SupportedLanguage): Array<[string, string]> | null {
   const map = TRANSLATION_MAPS[lang];
@@ -46,10 +47,10 @@ function sortedEntriesFor(lang: SupportedLanguage): Array<[string, string]> | nu
 }
 
 /**
- * 把含 pr-agent 模板英文标签的字符串按当前 UI 语言翻译。
- * - 替换是字面量 (split/join)，不走正则，避免特殊字符意外匹配。
- * - 大小写敏感：模板里都是首字母大写，保持原样。
- * - 当前语言无对应字典 (如 en-US) 时原样返回 (pr-agent 输出本就是英文)。
+ * Translate a string containing pr-agent template English labels according to the current UI language.
+ * - Replacement is literal (split/join), not regex, to avoid accidental matches on special characters.
+ * - Case-sensitive: templates are all title-cased, kept as-is.
+ * - When the current language has no matching dictionary (e.g. en-US) returns as-is (pr-agent output is already English).
  */
 export function translatePrAgentLabels(text: string): string {
   if (!text) return text;


### PR DESCRIPTION
## What & why

Backfill Chinese → English for **code comments in the desktop renderer (frontend)**, continuing the code-comment convention adopted in #184 (developer-facing code-surface artifacts are English). Scoped to `apps/desktop/src/renderer/` only — the `main/` backend is a separate follow-up PR.

## Scope of change

Comment text only (incl. multi-line JSX `{/* */}` blocks), by domain — one commit each, each verified `typecheck` + `lint` green:

| Batch | Area | Files |
| --- | --- | --- |
| foundation | App/main/errors · i18n · hooks · stores · utils · lib · theme | 30 |
| common | components/common | 14 |
| small | command-palette · onboarding · layout | 18 |
| chat | features/chat | 27 |
| settings | features/settings | 27 |
| pr | features/pr (list · tabs · diff+blame/search/zones/hooks · comments · drafts · shared) | 61 |

Plus `chore(gitignore)`: ignore Python bytecode (`__pycache__/`, `*.pyc`).

## Left verbatim (out of scope)
Never touched: identifiers, JSX text, string/template literals, **i18n keys**, CSS classes, Monaco/markdown APIs, IPC channels. User-facing text stays in i18n resources. Also left as intentional data: the `translate-pr-agent` mapping strings, and a few Chinese *example tokens* referenced inside English comments (UI labels like `"类型"`, an example date, `「张三」`).

## Verification
- Each batch: only comment / JSX-comment lines changed (no code statements), and `desktop` typecheck + lint green.
- A final sweep confirms no untranslated Chinese remains in comment positions (only English comments that intentionally cite Chinese example tokens).
- Comments-only change; no runtime behavior affected.