### PR TITLE
docs(main): translate backend code comments to English

### DIFF
--- a/apps/desktop/src/main/adapters.ts
+++ b/apps/desktop/src/main/adapters.ts
@@ -17,9 +17,10 @@ export interface BuiltAdapter {
 }
 
 /**
- * 可变的连接运行时持有：adapters（全量，IPC 按 id 查任意连接）+ adapterByHost
- * （repo-mirror 按 host 找 adapter 取 clone url）。设置页改连接时 reconfigure 原地替换
- * 内容，IPC handler / repoMirror 经引用读到新值，无需重启。
+ * Mutable connections runtime holding: adapters (full set, IPC looks up any connection by id) +
+ * adapterByHost (repo-mirror finds an adapter by host to get its clone url). When the settings page
+ * changes connections, reconfigure replaces the contents in place; IPC handler / repoMirror read the
+ * new values through the reference, no restart needed.
  */
 export interface ConnectionRuntime {
   adapters: BuiltAdapter[];
@@ -27,9 +28,11 @@ export interface ConnectionRuntime {
 }
 
 /**
- * 用草稿 base_url + token 临时起一个 adapter，仅供设置页 ping 测试用。kind 默认
- * bitbucket-server（向后兼容旧调用）。proxy 统一进连接层：把代理配置与工厂透传给 adapter，由连接层
- * 据 baseUrl host 一次解析（开关开且目标非 loopback 时 REST 经代理）。
+ * Spin up a temporary adapter from a draft base_url + token, only for the settings page ping test.
+ * kind defaults to bitbucket-server (backward compatible with old calls). proxy is unified into the
+ * connection layer: pass the proxy config and factory through to the adapter, and the connection layer
+ * resolves once by the baseUrl host (REST goes through the proxy when the switch is on and the target
+ * is non-loopback).
  */
 export function buildDraftAdapter(
   baseUrl: string,
@@ -38,7 +41,7 @@ export function buildDraftAdapter(
   kind: PlatformKind = 'bitbucket-server',
 ): PlatformAdapter {
   if (kind === 'github') {
-    // GitHub 草稿 base_url 可留空 → 默认官方 api.github.com
+    // GitHub draft base_url can be left empty → defaults to the official api.github.com
     const ghBase = baseUrl.trim() || GITHUB_DOTCOM_API_BASE;
     return new GitHubAdapter({
       baseUrl: ghBase,
@@ -49,7 +52,7 @@ export function buildDraftAdapter(
     });
   }
   if (kind === 'gitlab') {
-    // GitLab 草稿 base_url 可留空 → 默认官方 gitlab.com/api/v4
+    // GitLab draft base_url can be left empty → defaults to the official gitlab.com/api/v4
     const glBase = baseUrl.trim() || GITLAB_DOTCOM_API_BASE;
     return new GitLabAdapter({
       baseUrl: glBase,
@@ -69,9 +72,9 @@ export function buildDraftAdapter(
 }
 
 /**
- * 把 config.connections 映射成可用的 Adapter 列表。M1 只支持 bitbucket-server kind；
- * 未来扩 GitHub / GitLab 时在 switch 里加 case 即可。
- * proxy 透传到每个 adapter 的 REST fetch。
+ * Map config.connections into a list of usable Adapters. M1 only supports the bitbucket-server kind;
+ * to extend to GitHub / GitLab later, just add a case in the switch.
+ * proxy is passed through to each adapter's REST fetch.
  */
 export function buildAdapters(
   connections: readonly Connection[],
@@ -84,8 +87,9 @@ export function buildAdapters(
 }
 
 function buildOne(conn: Connection, proxy: ProxyConfig): PlatformAdapter {
-  // 代理统一进连接层：透传 proxy 配置与工厂，由连接层据 baseUrl host 解析（开关开 + 目标非
-  // loopback → 带 ProxyAgent 的 fetch；否则直连）。
+  // proxy is unified into the connection layer: pass the proxy config and factory through, and the
+  // connection layer resolves by the baseUrl host (switch on + target non-loopback → fetch with a
+  // ProxyAgent; otherwise direct).
   const common = {
     baseUrl: conn.base_url,
     token: conn.auth.token,

--- a/apps/desktop/src/main/bootstrap/connections-runtime.ts
+++ b/apps/desktop/src/main/bootstrap/connections-runtime.ts
@@ -8,11 +8,13 @@ import { buildAdapters, type ConnectionRuntime } from '../adapters.js';
 import { writeConnectionStates, type ConnectionState } from '../utils/connection-state.js';
 
 /**
- * 连接运行时控制器：把启动序列里的「连接接线 / ping / 热重配」从 index.ts 收口。「接线」与「ping」解耦，
- * 实现「启动不依赖网络」——见各方法注释。运行态（runtime + 连接级本地状态）是实例可变状态，故以 class 封装。
+ * Connections runtime controller: consolidates the startup sequence's "connection wiring / ping /
+ * hot-reconfigure" out of index.ts. "Wiring" and "ping" are decoupled to achieve "startup does not
+ * depend on the network" — see each method's comment. Runtime state (runtime + connection-level local
+ * state) is mutable instance state, hence wrapped in a class.
  */
 export class ConnectionRuntimeController {
-  /** 可变持有的连接运行时（adapters 全量 + adapterByHost）；IPC / repoMirror 经引用读到最新值。 */
+  /** Mutably held connections runtime (full adapters + adapterByHost); IPC / repoMirror read the latest values through the reference. */
   readonly runtime: ConnectionRuntime = { adapters: [], adapterByHost: new Map() };
 
   constructor(
@@ -20,23 +22,23 @@ export class ConnectionRuntimeController {
     private readonly stateStore: JsonFileStateStore,
     private readonly poller: Poller,
     private readonly logger: Logger,
-    /** 启动时载入的连接级本地状态（含上次 ping 的 currentUser）；随 ping 增量回写。 */
+    /** Connection-level local state loaded at startup (includes the last ping's currentUser); written back incrementally on each ping. */
     private connectionStates: Record<string, ConnectionState>,
   ) {}
 
-  /** 当前启用连接的 id 列表（poller.archiveConnectionsExcept 用）。 */
+  /** Id list of the currently enabled connections (used by poller.archiveConnectionsExcept). */
   activeConnectionIds(): string[] {
     return this.runtime.adapters
       .filter((a) => a.connectionId === this.bootstrap.config.active_connection_id)
       .map((a) => a.connectionId);
   }
 
-  /** 重建 adapters/byHost、用本地持久化身份预热 currentUser、把活动连接喂给 poller（同步、无网络，可在建窗前调）。 */
+  /** Rebuild adapters/byHost, prewarm currentUser from locally persisted identity, feed the active connection to the poller (synchronous, no network, callable before the window is created). */
   wire(): void {
     const adapters = buildAdapters(this.bootstrap.config.connections, this.bootstrap.config.proxy);
     const byHost = new Map<string, PlatformAdapter>();
     for (const { connectionId, adapter } of adapters) {
-      // 预热 currentUser：有本地记录就先填上（无记录则保持 null，由 ping 兜底）。
+      // Prewarm currentUser: if there's a local record, fill it in first (if no record, keep null, ping is the fallback).
       const cachedUser = this.connectionStates[connectionId]?.user;
       if (cachedUser) adapter.connection.setCurrentUser?.(cachedUser);
       const conn = this.bootstrap.config.connections.find((c) => c.id === connectionId);
@@ -49,20 +51,20 @@ export class ConnectionRuntimeController {
     }
     this.runtime.adapters = adapters;
     this.runtime.adapterByHost = byHost;
-    // 只轮询当前启用的连接（同时仅一条）；其余仅保留配置不轮询。
+    // Only poll the currently enabled connection (at most one at a time); the rest keep their config but are not polled.
     this.poller.setConnections(
       adapters.filter((a) => a.connectionId === this.bootstrap.config.active_connection_id),
     );
   }
 
-  /** 全异步 ping：刷新远端身份并增量持久化；活动连接身份变化（含首次取得）则补一轮 poll（有网络，不在启动关键路径）。 */
+  /** Fully async ping: refresh remote identity and persist incrementally; if the active connection's identity changes (including first acquisition), run one extra poll (has network, not on the startup critical path). */
   ping(): void {
     const activeId = this.bootstrap.config.active_connection_id;
     for (const { connectionId, adapter } of this.runtime.adapters) {
       const isActive = connectionId === activeId;
       const beforeName = adapter.connection.getCurrentUser()?.name ?? null;
-      // 活动连接启动时无缓存身份 → poller.start(immediate=false) 没跑首轮；此处 ping settle 后必须触发
-      // **首次同步**（无论 ping 成功与否）：「先确认身份，再立即同步一次」。
+      // If the active connection has no cached identity at startup → poller.start(immediate=false) skipped the first round; here, after ping settles, it must trigger
+      // the **first sync** (regardless of ping success): "confirm identity first, then sync once immediately".
       const hadIdentity = beforeName !== null;
       void adapter.connection.ping().then(
         async (r) => {
@@ -72,28 +74,28 @@ export class ConnectionRuntimeController {
           );
           const user = adapter.connection.getCurrentUser();
           await this.persistConnectionUser(connectionId, user);
-          // 触发重分类/首次同步：活动连接且（身份变化 含首次取得/换号，或本就无身份需补首轮）。
+          // Trigger reclassification/first sync: active connection and (identity changed, including first acquisition/account switch, or had no identity and needs the first round).
           if (isActive && (!hadIdentity || (user?.name ?? null) !== beforeName)) {
             void this.poller.tick();
           }
         },
         (err: unknown) => {
           this.logger.warn({ err, connectionId }, 'adapter ping failed');
-          // ping 失败但活动连接本就无缓存身份（首轮被跳过）→ 仍用 PAT 兜底同步一次，避免看似没同步。
+          // ping failed but the active connection had no cached identity (first round skipped) → still sync once with the PAT as fallback, to avoid appearing not synced.
           if (isActive && !hadIdentity) void this.poller.tick();
         },
       );
     }
   }
 
-  /** 设置页改连接 / 代理后的热生效：重接线 + 归档非活动连接（本地 IO）+ 异步 ping。 */
+  /** Hot-apply after the settings page changes connections / proxy: rewire + archive non-active connections (local IO) + async ping. */
   async reconfigure(): Promise<void> {
     this.wire();
     await this.poller.archiveConnectionsExcept(this.activeConnectionIds());
     this.ping();
   }
 
-  /** 持久化某连接的 currentUser（仅身份变化时写盘，避免无谓 IO）。写盘失败不影响运行。 */
+  /** Persist a connection's currentUser (only writes to disk when identity changes, to avoid pointless IO). A write failure does not affect operation. */
   private async persistConnectionUser(
     connectionId: string,
     user: PlatformUser | null,

--- a/apps/desktop/src/main/bootstrap/index.ts
+++ b/apps/desktop/src/main/bootstrap/index.ts
@@ -1,7 +1,8 @@
 /**
- * 应用启动装配域：OS/平台启动微调 + 各运行时（pr-agent / 连接 / 窗口 / 轮询 / 镜像 / 版本检测 / splash）
- * 的 init/factory。index.ts 作为组合根从此处取用、装配；各模块只依赖 ../（context / services / utils /
- * adapters）与库包。
+ * Application startup assembly domain: OS/platform startup tweaks + init/factory for each runtime
+ * (pr-agent / connections / window / poller / mirror / version detection / splash). index.ts acts as
+ * the composition root that draws from here and assembles; each module only depends on ../ (context /
+ * services / utils / adapters) and library packages.
  */
 export { applyOsStartupTweaks } from './os-startup-tweaks.js';
 export { PrAgentRuntime } from './pragent-runtime.js';

--- a/apps/desktop/src/main/bootstrap/os-startup-tweaks.ts
+++ b/apps/desktop/src/main/bootstrap/os-startup-tweaks.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { app } from 'electron';
 
-// 常见 CLI 安装目录：覆盖 pip --user / npm global / homebrew(Apple Silicon + Intel)。
+// Common CLI install dirs: covers pip --user / npm global / homebrew (Apple Silicon + Intel).
 const COMMON_CLI_DIRS = [
   path.join(os.homedir(), '.local', 'bin'),
   '/usr/local/bin',
@@ -12,15 +12,19 @@ const COMMON_CLI_DIRS = [
 ];
 
 /**
- * macOS GUI（Finder / Dock / LaunchServices）启动的 app 由 launchd 给出**最小 PATH**
- * （`/usr/bin:/bin:/usr/sbin:/sbin`），**不读用户 shell 配置**（`.zshrc` / `.zprofile`）。
- * 而本机 CLI（claude / codex）常装在 `~/.local/bin`、homebrew 等**只由 shell 往 PATH 里加**的
- * 目录——于是嵌入式 python 的 `shutil.which(...)` 找不到命令、本地 CLI provider 失效，但从终端
- * `npm run dev` 启动却正常（继承了已加载配置的终端 PATH）。Windows 不受影响（GUI 进程继承用户 PATH）。
+ * An app launched by the macOS GUI (Finder / Dock / LaunchServices) is given a **minimal PATH** by
+ * launchd (`/usr/bin:/bin:/usr/sbin:/sbin`) and **does not read the user's shell config** (`.zshrc` /
+ * `.zprofile`). But local CLIs (claude / codex) are often installed in `~/.local/bin`, homebrew, and
+ * other dirs that **only the shell adds to PATH** — so the embedded python's `shutil.which(...)` can't
+ * find the command and the local CLI provider fails, yet launching via `npm run dev` from a terminal
+ * works fine (it inherits the terminal PATH with config already loaded). Windows is unaffected (GUI
+ * processes inherit the user PATH).
  *
- * 把常见目录前置进 `process.env.PATH`（去重，只补原 PATH 缺失的，保持原有顺序在后）；之后所有子进程
- * （嵌入式 python 及其 spawn 的 CLI）都经 `{ ...process.env }` 继承到。静态目录已覆盖最常见的安装位置；
- * 不跑登录 shell 解析（避免启动期子进程 / 超时 / 噪声）。仅由 applyMacStartupTweaks 调用。
+ * Prepend the common dirs into `process.env.PATH` (deduplicated, only filling in what the original PATH
+ * lacks, keeping the original order after); afterward all child processes (the embedded python and the
+ * CLIs it spawns) inherit them via `{ ...process.env }`. The static dirs already cover the most common
+ * install locations; no login-shell resolution is run (avoiding startup-time child processes / timeouts
+ * / noise). Only called by applyMacStartupTweaks.
  */
 function augmentMacPath(): void {
   const existing = (process.env.PATH ?? '').split(':').filter(Boolean);
@@ -32,24 +36,27 @@ function augmentMacPath(): void {
 }
 
 /**
- * Windows 专属启动微调：附着控制台默认本地化 OEM 页（简中 cp936/GBK），与 pino 的 UTF-8 字节对不上 →
- * dev 终端中文日志乱码；chcp 65001 把输出代码页切到 UTF-8 对齐。无控制台（打包态）chcp 静默失败、已吞，
- * 无副作用。
+ * Windows-specific startup tweak: an attached console defaults to the localized OEM page (Simplified
+ * Chinese cp936/GBK), which doesn't line up with pino's UTF-8 bytes → garbled Chinese logs in the dev
+ * terminal; chcp 65001 switches the output code page to UTF-8 to align. Without a console (packaged),
+ * chcp silently fails and is swallowed, no side effects.
  */
 function applyWindowsStartupTweaks(): void {
   try {
     execSync('chcp 65001', { stdio: 'ignore' });
   } catch {
-    /* 无控制台 / chcp 不可用：忽略，日志仍按 UTF-8 字节写出 */
+    /* no console / chcp unavailable: ignore, logs are still written as UTF-8 bytes */
   }
 }
 
 /**
- * macOS 专属启动微调：
- * - use-mock-keychain：ad-hoc 签名身份不稳定（cdhash 每次构建变），os_crypt 每次启动弹「访问钥匙串」；
- *   mock 让其走内存不碰真钥匙串。代价：cookie 加密退化为静态 key，但密钥本就明文落盘，无实质损失。
- *   有正式 Developer ID 签名后可移除。须在 app.whenReady() 之前。
- * - PATH 前置常见 CLI 目录（见 augmentMacPath）：须在 pr-agent 探测 / 运行前。
+ * macOS-specific startup tweaks:
+ * - use-mock-keychain: the ad-hoc signing identity is unstable (cdhash changes every build), so
+ *   os_crypt pops up "access keychain" on every launch; mock makes it use memory without touching the
+ *   real keychain. Cost: cookie encryption degrades to a static key, but the key was already stored in
+ *   plaintext, so no real loss. Removable once there's a proper Developer ID signature. Must be before
+ *   app.whenReady().
+ * - Prepend common CLI dirs to PATH (see augmentMacPath): must be before pr-agent probing / running.
  */
 function applyMacStartupTweaks(): void {
   app.commandLine.appendSwitch('use-mock-keychain');
@@ -57,12 +64,14 @@ function applyMacStartupTweaks(): void {
 }
 
 /**
- * 进程 / 平台启动微调（须在模块加载期、app.whenReady() 之前跑一次）：先做跨平台的进程 env 调整，再按
- * 当前平台委托各自的专属初始化（见 applyWindowsStartupTweaks / applyMacStartupTweaks）。
+ * Process / platform startup tweaks (must run once during module load, before app.whenReady()): first
+ * do cross-platform process env adjustments, then delegate to each platform's specific init based on
+ * the current platform (see applyWindowsStartupTweaks / applyMacStartupTweaks).
  *
- * 跨平台：PYTHONDONTWRITEBYTECODE=1——嵌入式 python 子进程不落 .pyc（安装目录 per-user 可写，运行期会
- * 积累上万 __pycache__/.pyc 拖慢升级卸载）；子进程经 spawn 继承本进程 env。代价：每次启动重编译（略慢），
- * 影响有限。
+ * Cross-platform: PYTHONDONTWRITEBYTECODE=1 — the embedded python child processes don't drop .pyc (the
+ * install dir is per-user writable, and at runtime it would accumulate tens of thousands of
+ * __pycache__/.pyc slowing down upgrades/uninstalls); child processes inherit this process's env via
+ * spawn. Cost: recompiles on every launch (slightly slower), limited impact.
  */
 export function applyOsStartupTweaks(): void {
   process.env.PYTHONDONTWRITEBYTECODE = '1';

--- a/apps/desktop/src/main/bootstrap/poller.ts
+++ b/apps/desktop/src/main/bootstrap/poller.ts
@@ -8,23 +8,25 @@ import { broadcast } from '../services/broadcast.js';
 import { showPollNotifications } from '../services/notifications.js';
 
 /**
- * 构造轮询器：tick 广播 poll:tick + 触发顺带副作用（onTickExtras）；PR 变更顺手 syncMirror 跟本地镜像。
- * 启动时不带连接（connections:[]），由 connections-runtime 的 wire/setConnections 注入；run/agent 等
- * 后绑定依赖（ipcControl / repoMirror）经回调与 getter 延迟取用（它们在 poller 之后才建好）。
+ * Construct the poller: each tick broadcasts poll:tick + triggers incidental side effects (onTickExtras);
+ * on PR changes it also syncMirror to keep the local mirror up to date. It starts with no connections
+ * (connections:[]), injected by connections-runtime's wire/setConnections; later-bound dependencies like
+ * run/agent (ipcControl / repoMirror) are taken lazily via callbacks and getters (they're built after
+ * the poller).
  */
 export function createPoller(deps: {
   bootstrap: BootstrapResult;
   stateStore: JsonFileStateStore;
-  /** 归档 PR 冷存储（`archived/` 根，与 state/ 平级）；退场 PR 整树搬入此处。 */
+  /** Archive PR cold storage (`archived/` root, sibling of state/); departed PRs are moved here as a whole tree. */
   archiveStore: JsonFileStateStore;
   logger: Logger;
-  /** poll tick 顺带的副作用（清理消失 PR 的 agent 操作 / 版本检测 / AutoPilot 准入），由 index 绑定。 */
+  /** Incidental side effects of the poll tick (cleaning up agent operations for disappeared PRs / version detection / AutoPilot admission), bound by index. */
   onTickExtras: () => void;
-  /** 延迟取 repoMirror（它在 poller 之后才建好）。 */
+  /** Lazily get repoMirror (it's built after the poller). */
   getRepoMirror: () => RepoMirrorManager;
-  /** 延迟取连接运行时（它在 poller 之后才建好）：通知服务据此按 connectionId 取 adapter 拉发起人头像。 */
+  /** Lazily get the connections runtime (it's built after the poller): the notification service uses it to get an adapter by connectionId to fetch the author's avatar. */
   getConnectionRuntime: () => ConnectionRuntime;
-  /** 评论变更（回复 / 提及）顺手失效该 PR 评论缓存 + 广播 comments:changed（延迟经 ipcControl）。 */
+  /** On comment changes (reply / mention), also invalidate that PR's comment cache + broadcast comments:changed (lazily via ipcControl). */
   invalidateCommentsCache: (localId: string) => void;
 }): Poller {
   const { bootstrap, stateStore, archiveStore, logger } = deps;
@@ -38,8 +40,8 @@ export function createPoller(deps: {
       broadcast('poll:tick', info);
       deps.onTickExtras();
     },
-    // 本轮新发生的提醒事件（新 PR / 被 @ / 被回复）→ 按通知配置弹系统通知（现读 bootstrap.config，与设置页热生效）。
-    // 头像经连接运行时按 connectionId 取 adapter 拉取并落盘（Windows 富 toast 用）。
+    // Newly occurring alert events this round (new PR / @-mentioned / replied) → pop system notifications per the notification config (now reads bootstrap.config, hot-applies with the settings page).
+    // Avatars are fetched via the connections runtime by getting an adapter by connectionId and written to disk (for Windows rich toasts).
     onNotify: (events) => {
       void showPollNotifications(events, bootstrap.config, logger, {
         cacheDir: bootstrap.paths.cacheDir,
@@ -47,16 +49,16 @@ export function createPoller(deps: {
           deps.getConnectionRuntime().adapters.find((a) => a.connectionId === id)?.adapter ?? null,
         logger,
       });
-      // 评论类事件（回复 / 提及）= 该 PR 评论已变 → 失效缓存 + 广播 comments:changed，刷新已打开视图。
-      // 与系统通知是否真正弹出无关（通知设置可能关）：只要轮询发现评论变更就刷新当前打开的 Diff / 活动时间线。
+      // Comment-type events (reply / mention) = that PR's comments changed → invalidate cache + broadcast comments:changed, refreshing the already-open view.
+      // Independent of whether the system notification actually pops (notification setting may be off): as long as polling finds a comment change, refresh the currently open Diff / activity timeline.
       const commentPrIds = new Set(
         events.filter((e) => e.kind !== 'new_pr').map((e) => e.localId),
       );
       for (const localId of commentPrIds) deps.invalidateCommentsCache(localId);
     },
-    // PR 新增 / 内容变更时顺手 syncMirror 跟上本地镜像，让用户随后点开 PR 省一趟 fetch。失败不阻断 poll
-    //（mirror 有自己的全局队列 + 错误隔离）。identity 字段映射：poller 用 group/repo，repo-mirror 仍保留
-    // Bitbucket-shaped projectKey/repoSlug（跟 git 路径布局一致，沿用便于排障）。
+    // When a PR is added / its content changes, also syncMirror to keep the local mirror up to date, saving the user a fetch when they later open the PR. Failure doesn't block poll
+    // (the mirror has its own global queue + error isolation). identity field mapping: poller uses group/repo, repo-mirror still keeps
+    // Bitbucket-shaped projectKey/repoSlug (matches the git path layout, kept for easier troubleshooting).
     onPrsChanged: (repos) => {
       for (const r of repos) {
         const conn = bootstrap.config.connections.find((c) => c.id === r.connectionId);

--- a/apps/desktop/src/main/bootstrap/pragent-runtime.ts
+++ b/apps/desktop/src/main/bootstrap/pragent-runtime.ts
@@ -6,16 +6,19 @@ import { app } from 'electron';
 import type { Logger } from 'pino';
 
 /**
- * pr-agent 运行时：解析嵌入式解释器路径 + kick-off 探测（构造即开跑、不 await），结果异步回填。探测**不放
- * 在建窗关键路径**——它走 spawn 探测（auto 回退 local-cli 最坏 5s），await 会把首帧推迟数秒；改 kick-off
- * 与 whenReady + 渲染层加载并发跑。bridge 由探测异步回填，故以 class 持有可变态。
- * - probe：app:prAgentStatus 据此 await 拿最终状态（boot 时序通常已完成）。
- * - getBridge()：pragent run 入口读，未就绪时为 null → 走「未就绪」提示。
+ * pr-agent runtime: resolves the embedded interpreter path + kicks off the probe (starts on
+ * construction, not awaited), result backfilled asynchronously. The probe is **kept off the
+ * window-creation critical path**—it runs a spawn probe (auto fallback to local-cli, worst case 5s),
+ * and awaiting it would delay the first paint by seconds; instead the kick-off runs concurrently with
+ * whenReady + renderer load. The bridge is backfilled asynchronously by the probe, so a class holds
+ * the mutable state.
+ * - probe: app:prAgentStatus awaits this for the final status (usually already done by boot time).
+ * - getBridge(): read at the pragent run entry, null when not ready → falls back to a "not ready" prompt.
  */
 export class PrAgentRuntime {
-  /** 嵌入式解释器绝对路径（探测层据此判 embedded 是否可用，文件不存在则回退 local-cli）。 */
+  /** Absolute path to the embedded interpreter (the probe layer uses it to judge embedded availability; falls back to local-cli if the file is missing). */
   readonly embeddedPythonPath: string;
-  /** 探测 promise（构造逻辑保证恒 resolve、不 reject）。 */
+  /** Probe promise (construction logic guarantees it always resolves, never rejects). */
   readonly probe: Promise<PrAgentStatus>;
   private bridge: PrAgentBridge | null = null;
 
@@ -27,16 +30,16 @@ export class PrAgentRuntime {
     this.probe = this.kickoffProbe();
   }
 
-  /** 探测完成前为 null。 */
+  /** null until the probe completes. */
   getBridge(): PrAgentBridge | null {
     return this.bridge;
   }
 
   /**
-   * 嵌入式 pr-agent 运行时的解释器绝对路径。
-   * - dev：`apps/desktop/vendor/pragent/...`（app.getAppPath() = apps/desktop）
-   * - 打包：`<resources>/pragent/...`（electron-builder extraResources）
-   * - `MEEBOX_PRAGENT_PYTHON` env 覆盖兜底
+   * Absolute path to the interpreter of the embedded pr-agent runtime.
+   * - dev: `apps/desktop/vendor/pragent/...` (app.getAppPath() = apps/desktop)
+   * - packaged: `<resources>/pragent/...` (electron-builder extraResources)
+   * - `MEEBOX_PRAGENT_PYTHON` env override fallback
    */
   private static resolveEmbeddedPython(): string {
     const override = process.env.MEEBOX_PRAGENT_PYTHON;

--- a/apps/desktop/src/main/bootstrap/repo-mirror.ts
+++ b/apps/desktop/src/main/bootstrap/repo-mirror.ts
@@ -6,8 +6,10 @@ import { broadcast } from '../services/broadcast.js';
 import { buildProxyEnv } from '../utils/proxy.js';
 
 /**
- * 构造本地仓库镜像管理器：clone url 经连接运行时按 host 取 adapter 求得（设置页改连接热生效，读 runtime 引用）；
- * 进度广播 sync:progress；出站代理 getter 每次远端 clone/fetch 求值（改代理即生效）。
+ * Constructs the local repo mirror manager: the clone url is resolved via the connection runtime by
+ * looking up the adapter by host (connection changes in settings take effect live, by reading the
+ * runtime reference); progress is broadcast on sync:progress; the outbound proxy getter is evaluated
+ * on every remote clone/fetch (proxy changes take effect immediately).
  */
 export function createRepoMirror(deps: {
   bootstrap: BootstrapResult;

--- a/apps/desktop/src/main/bootstrap/splash.ts
+++ b/apps/desktop/src/main/bootstrap/splash.ts
@@ -3,11 +3,12 @@ import path from 'node:path';
 import { readFileSync } from 'node:fs';
 
 /**
- * 读取品牌 logo 并转成 base64 data URI，内联进 splash data URL（splash 是独立 data URL
- * 文档，无法走 file:// 相对路径引用资源，故必须内联）。两路探测：
- * - 打包态：`<resources>/icon.png`（electron-builder extraResources copy）
- * - dev：仓库 `assets/icons/icon.png`
- * 两路都读不到（如 LFS 未拉取）则返回 null，splash 优雅回退为纯 spinner。
+ * Reads the brand logo and converts it to a base64 data URI, inlined into the splash data URL (the
+ * splash is a standalone data URL document and cannot reference resources via file:// relative paths,
+ * so inlining is required). Two candidate paths are detected:
+ * - packaged: `<resources>/icon.png` (electron-builder extraResources copy)
+ * - dev: repo `assets/icons/icon.png`
+ * If neither can be read (e.g. LFS not pulled), returns null and the splash gracefully falls back to a plain spinner.
  */
 function resolveSplashLogo(): string | null {
   const candidates = [
@@ -17,36 +18,41 @@ function resolveSplashLogo(): string | null {
   for (const p of candidates) {
     try {
       const buf = readFileSync(p);
-      // LFS 指针文件不是合法 PNG（无 \x89PNG magic）→ 跳过，避免 splash 显示裂图
+      // An LFS pointer file is not a valid PNG (no \x89PNG magic) → skip, to avoid a broken image in the splash
       if (buf.length < 8 || buf[0] !== 0x89 || buf[1] !== 0x50) continue;
       return `data:image/png;base64,${buf.toString('base64')}`;
     } catch {
-      /* 试下一个候选 */
+      /* try the next candidate */
     }
   }
   return null;
 }
 
-// 闪屏明暗两套配色，跟随有效主题、对齐默认的 2026 主题（底 / 文字取 2026 editor background / foreground，
-// accent 仍用语义 accent —— chrome-sync 不覆盖 accent）：
-// 暗 = dark-2026 底 #121314 + 文字 #BBBEBF + $vscode-blue-700 accent；浅 = light-2026 底 #FFFFFF + 深文字 + $vscode-blue-800。
+// Splash dark/light color sets, following the effective theme and aligned with the default 2026 theme
+// (bg / text taken from 2026 editor background / foreground, accent still uses the semantic accent —
+// chrome-sync does not override accent):
+// dark = dark-2026 bg #121314 + text #BBBEBF + $vscode-blue-700 accent; light = light-2026 bg #FFFFFF + dark text + $vscode-blue-800.
 const SPLASH_COLORS = {
   dark: { bg: '#121314', text: '#BBBEBF', sub: '#6f7172', ring: 'rgba(255,255,255,.16)', accent: '#0e639c' },
   light: { bg: '#FFFFFF', text: '#202020', sub: '#6e6e6e', ring: 'rgba(0,0,0,.14)', accent: '#005fb8' },
 };
 
 /**
- * 启动闪屏：独立的无边框轻量窗口，加载内联 data URL（品牌 logo + 纯 CSS spinner），
- * 几十 ms 即可呈现，遮住主窗口首帧前的渲染层加载空窗。主窗口 ready-to-show 时关闭。
- * logo 经 base64 内联（见 resolveSplashLogo），data URL 自包含、dev/打包行为一致。
- * 配色随有效主题（`dark`）切换，避免浅色主题下启动闪屏仍是深色。
+ * Startup splash: a standalone frameless lightweight window loading an inline data URL (brand logo +
+ * pure-CSS spinner), presentable within tens of ms, covering the blank renderer-load gap before the
+ * main window's first paint. Closed when the main window is ready-to-show.
+ * The logo is inlined via base64 (see resolveSplashLogo); the data URL is self-contained, with
+ * identical dev/packaged behavior. Colors switch with the effective theme (`dark`), to avoid a dark
+ * splash under a light theme.
  */
 export function createSplash(dark: boolean): BrowserWindow {
   const c = dark ? SPLASH_COLORS.dark : SPLASH_COLORS.light;
   const width = 280;
   const height = 240;
-  // 与主窗口同源：按光标所在显示器的 workArea 居中（workArea 已扣掉 mac 菜单栏 / 刘海）。不用
-  // Electron 的 center:true——它按整屏 bounds（含顶部不可用区）算中点、且固定主显示器，会让 splash 偏高、多屏错位。
+  // Same approach as the main window: center within the workArea of the display under the cursor
+  // (workArea already excludes the mac menu bar / notch). Do not use Electron's center:true—it computes
+  // the midpoint from the full-screen bounds (including the unusable top area) and pins to the primary
+  // display, which makes the splash sit too high and misalign across multiple screens.
   const area = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
   const x = Math.round(area.x + (area.width - width) / 2);
   const y = Math.round(area.y + (area.height - height) / 2);

--- a/apps/desktop/src/main/bootstrap/updater.ts
+++ b/apps/desktop/src/main/bootstrap/updater.ts
@@ -4,13 +4,16 @@ import type { Logger } from 'pino';
 import { checkForUpdate } from '../utils/update-check.js';
 import { publishUpdateResult } from '../utils/update-state.js';
 
-// 至多每小时一次（复用 poller 周期，不另起定时器）。
+// At most once per hour (reuses the poller cycle, no separate timer).
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
- * 版本更新检测节流器：由 poller tick 顺带调 runIfDue，内部时间戳门控至多每小时一次。lastCheckMs 初值取
- * 构造时刻 → 首次检测落在启动后约 1h，刻意不在启动瞬间检测（避免占冷启动网络 / 打断启动）。仅检测 + 提示：
- * 有新版才广播给所有窗口；失败静默（绝不推任何 IPC，对用户零打扰）。节流状态是实例字段，故以 class 封装。
+ * Version-update check throttler: the poller tick incidentally calls runIfDue, and an internal
+ * timestamp gates it to at most once per hour. lastCheckMs is initialized to the construction moment →
+ * the first check lands about 1h after startup, deliberately not checking at the startup instant (to
+ * avoid taking cold-start network / interrupting startup). Detect + prompt only: broadcasts to all
+ * windows only when a new version exists; failures are silent (never pushes any IPC, zero user
+ * disturbance). The throttle state is an instance field, so it is wrapped in a class.
  */
 export class Updater {
   private lastCheckMs = Date.now();
@@ -20,19 +23,19 @@ export class Updater {
     private readonly logger: Logger,
   ) {}
 
-  /** 满足开关 + 距上次满 1h 时发起一次检测。时间戳在 await 前更新，避免窗口内下一次 tick 重复发起。 */
+  /** Fires a check when the toggle is on and 1h has elapsed since the last one. The timestamp is updated before the await, to avoid the next tick within the window firing again. */
   async runIfDue(): Promise<void> {
     if (!this.bootstrap.config.update.check_enabled) return;
     if (Date.now() - this.lastCheckMs < UPDATE_CHECK_INTERVAL_MS) return;
     this.lastCheckMs = Date.now();
     try {
       const result = await checkForUpdate(app.getVersion(), this.bootstrap.config.proxy);
-      // 获取失败（网络 / 解析 / 超时 / 限流，ok=false）：只记 debug，**绝不推任何 IPC** → 用户无感。
+      // Fetch failure (network / parse / timeout / rate-limit, ok=false): only log debug, **never push any IPC** → user unaware.
       if (!result.ok) {
         this.logger.debug({ error: result.error }, 'update check failed (silent, no prompt)');
         return;
       }
-      // 交给单一真相源：缓存结果，仅在确有新版时广播（与设置页手动检查共用同一路径）。
+      // Hand off to the single source of truth: cache the result, broadcast only when a new version truly exists (shares the same path as the settings-page manual check).
       publishUpdateResult(result);
       if (result.hasUpdate) {
         this.logger.info(
@@ -41,7 +44,7 @@ export class Updater {
         );
       }
     } catch (err) {
-      // 兜底：checkForUpdate 约定不抛；万一抛了也吞掉，绝不冒泡成任何用户可见行为。
+      // Fallback: checkForUpdate is contracted not to throw; swallow it even if it does, never bubbling into any user-visible behavior.
       this.logger.debug({ err }, 'update check threw (silent, no prompt)');
     }
   }

--- a/apps/desktop/src/main/bootstrap/window-manager.ts
+++ b/apps/desktop/src/main/bootstrap/window-manager.ts
@@ -12,49 +12,57 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// 默认窗口尺寸（无本地记录时）。最小尺寸保证核心三栏（sidebar 240 + file-tree 180 + diff 内容）在
-// chat-pane 折叠态下仍可用；高度兜住 pr-header + tabs + diff + statusbar。单位均为 DIP（设备无关像素）。
+// Default window size (when there is no local record). The minimum size guarantees the core three
+// columns (sidebar 240 + file-tree 180 + diff content) remain usable with the chat-pane collapsed;
+// the height accommodates pr-header + tabs + diff + statusbar. Units are all DIP (device-independent pixels).
 const DEFAULT_SIZE = { width: 1280, height: 800 };
 const MIN_SIZE = { width: 960, height: 600 };
 
-// 自绘标题栏右侧的系统窗控按钮（Windows titleBarOverlay）配色：与 .app-titlebar 背景（--bg-app）同色，
-// 接缝无感；symbol 取主文字色。明暗两套，跟随有效主题（nativeTheme.shouldUseDarkColors）。值对齐 palette
-// 暗/浅 bg-app（$vscode-gray-850 / $vscode-gray-30）与主文字（$vscode-gray-200 / $vscode-gray-840）。
+// Colors of the system window-control buttons on the right of the self-drawn title bar (Windows
+// titleBarOverlay): same color as the .app-titlebar background (--bg-app), so the seam is invisible;
+// the symbol takes the primary text color. Dark/light sets, following the effective theme
+// (nativeTheme.shouldUseDarkColors). Values align with palette dark/light bg-app
+// ($vscode-gray-850 / $vscode-gray-30) and primary text ($vscode-gray-200 / $vscode-gray-840).
 const TITLE_BAR_OVERLAY = {
   dark: { color: '#1e1e1e', symbolColor: '#cccccc' },
   light: { color: '#f8f8f8', symbolColor: '#1f1f20' },
 };
-// 渲染层派生的窗控配色（跟随具体主题的 --bg-app/--text-primary，hex）；null 时按 nativeTheme 深浅取通用色兜底。
+// Renderer-derived window-control colors (following the specific theme's --bg-app/--text-primary, hex); when null, falls back to generic colors by nativeTheme dark/light.
 let overlayColors: { color: string; symbolColor: string } | null = null;
-/** 通用深/浅窗控配色（无渲染层派生色时的兜底，按 nativeTheme 有效深浅）。 */
+/** Generic dark/light window-control colors (fallback when there is no renderer-derived color, by nativeTheme effective dark/light). */
 function genericOverlayColors(): { color: string; symbolColor: string } {
   return nativeTheme.shouldUseDarkColors ? TITLE_BAR_OVERLAY.dark : TITLE_BAR_OVERLAY.light;
 }
-/** 当前窗控 overlay（渲染层派生色优先，否则通用色）+ 高度（与 .app-titlebar 一致 36px）。 */
+/** Current window-control overlay (renderer-derived color first, otherwise generic color) + height (36px, matching .app-titlebar). */
 function currentOverlay(): { color: string; symbolColor: string; height: number } {
   return { ...(overlayColors ?? genericOverlayColors()), height: 36 };
 }
 /**
- * 由渲染层在主题应用后经 IPC 调用：把当前主题派生的窗控配色（color=--bg-app、symbolColor=--text-primary）
- * 设给所有窗口；传 null 回退通用深/浅色。使窗控按钮与具体主题的标题栏底色精确同色，而非仅通用深/浅。
+ * Called by the renderer via IPC after the theme is applied: sets the current theme-derived
+ * window-control colors (color=--bg-app, symbolColor=--text-primary) on all windows; passing null
+ * falls back to generic dark/light colors. Makes the window-control buttons exactly match the specific
+ * theme's title-bar background, rather than only generic dark/light.
  */
 export function setWindowControlColors(colors: { color: string; symbolColor: string } | null): void {
   overlayColors = colors;
-  if (process.platform === 'darwin') return; // macOS 无 titleBarOverlay
+  if (process.platform === 'darwin') return; // macOS has no titleBarOverlay
   for (const win of BrowserWindow.getAllWindows()) {
     if (win.isDestroyed()) continue;
     try {
       win.setTitleBarOverlay(currentOverlay());
     } catch {
-      /* 平台不支持 setTitleBarOverlay → 忽略 */
+      /* platform does not support setTitleBarOverlay → ignore */
     }
   }
 }
 
 /**
- * 解析建窗尺寸/位置：把期望尺寸（本地记录优先，回退默认）clamp 进**当前显示器工作区**，并据此压低最小
- * 尺寸——否则高 DPI 缩放后工作区（DIP）可能小于默认/最小值，窗口被撑大溢出屏幕（issue：缩放后默认尺寸超屏）。
- * 取光标所在显示器（多屏更贴合「在哪开窗」），按其工作区居中，保证整窗在屏内（不持久化 x/y，仅建窗定位）。
+ * Resolves the window size/position: clamps the desired size (local record first, falling back to
+ * default) into the **current display's work area**, and lowers the minimum size accordingly—otherwise
+ * under high-DPI scaling the work area (DIP) may be smaller than the default/minimum, and the window
+ * gets stretched off-screen (issue: default size exceeds screen after scaling). Takes the display under
+ * the cursor (on multi-screen this better matches "where to open"), centers within its work area, and
+ * guarantees the whole window stays on-screen (does not persist x/y, only positions at creation).
  */
 function resolveWindowBounds(state: WindowState): {
   x: number;
@@ -75,25 +83,27 @@ function resolveWindowBounds(state: WindowState): {
 }
 
 /**
- * 主窗口管理：建窗（恢复尺寸 + 自绘标题栏 + 外链路由 + 首帧显示/关 splash）+ resize/move/close 防抖回写。
- * windowState 是实例可变状态（跨多次 create——如 macOS activate 重建——保持最新），故以 class 封装；
- * 异步载入由 loadWindowManager 完成（构造同步、不持异步）。
+ * Main window manager: window creation (restore size + self-drawn title bar + external-link routing +
+ * first-paint show/close splash) + debounced write-back on resize/move/close.
+ * windowState is instance-mutable state (kept up to date across multiple create calls—e.g. macOS
+ * activate re-creation), so it is wrapped in a class; async loading is done by loadWindowManager
+ * (construction is synchronous, holds nothing async).
  */
 export class WindowManager {
   constructor(
     private readonly stateStore: JsonFileStateStore,
-    /** state 目录绝对路径；关窗同步落盘兜底用（见 writeWindowStateSync）。 */
+    /** Absolute path of the state directory; used for the synchronous write-to-disk fallback on window close (see writeWindowStateSync). */
     private readonly stateDir: string,
     private readonly logger: Logger,
-    /** 进程启动时刻，用于度量到首帧（ready-to-show）的启动耗时。 */
+    /** Process start moment, used to measure the startup elapsed time to the first paint (ready-to-show). */
     private readonly startMs: number,
-    /** 当前窗口状态（尺寸/最大化）；随 resize/maximize/close 回写。 */
+    /** Current window state (size/maximized); written back on resize/maximize/close. */
     private windowState: WindowState,
   ) {}
 
-  /** 创建主窗口（首个传 splash，主界面首帧就绪时关闭它；macOS activate 再建时不传）。 */
+  /** Creates the main window (the first call passes splash, closed when the main UI's first paint is ready; macOS activate re-creation does not pass it). */
   create(splash?: BrowserWindow): void {
-    // 尺寸/位置：本地记录优先、回退默认，并按当前显示器工作区 clamp + 居中（高 DPI 缩放下防溢出屏幕）。
+    // Size/position: local record first, falling back to default, and clamped + centered within the current display's work area (prevents overflowing the screen under high-DPI scaling).
     const bounds = resolveWindowBounds(this.windowState);
     const win = new BrowserWindow({
       x: bounds.x,
@@ -103,15 +113,16 @@ export class WindowManager {
       minWidth: bounds.minWidth,
       minHeight: bounds.minHeight,
       show: false,
-      // 首帧前的窗口底色与 app 一致，避免显示瞬间白闪
+      // Window background before the first paint matches the app, to avoid a white flash at the display instant
       backgroundColor: '#1e1e1e',
-      // 无边框 + 自绘标题栏（VS Code 风）：macOS 保留红绿灯并下移到自绘标题栏内；Windows/Linux 用
-      // titleBarOverlay 让系统继续画窗控按钮，渲染层只接管中间标题区。高度需与 .app-titlebar 一致（36px）。
+      // Frameless + self-drawn title bar (VS Code style): macOS keeps the traffic lights and shifts them
+      // down into the self-drawn title bar; Windows/Linux use titleBarOverlay to let the system keep
+      // drawing the window-control buttons, with the renderer taking over only the middle title area. Height must match .app-titlebar (36px).
       titleBarStyle: 'hidden',
       ...(process.platform === 'darwin'
         ? { trafficLightPosition: { x: 12, y: 11 } }
         : { titleBarOverlay: currentOverlay() }),
-      // dev 下显式给窗口图标；打包态窗口/任务栏图标走 exe 内嵌（electron-builder），故仅 dev 设置。
+      // In dev, explicitly set the window icon; in packaged mode the window/taskbar icon comes from the exe embed (electron-builder), so only set it in dev.
       icon: app.isPackaged
         ? undefined
         : path.join(app.getAppPath(), '../../assets/icons/icon.ico'),
@@ -123,13 +134,13 @@ export class WindowManager {
       },
     });
 
-    // 快照当前窗口状态。getNormalBounds 取「非最大化」尺寸，故最大化时记录的仍是还原后的正常大小；
-    // 最大化态另存布尔位，下次启动据此恢复。
+    // Snapshot the current window state. getNormalBounds takes the "non-maximized" size, so what is
+    // recorded while maximized is still the restored normal size; the maximized state is stored separately as a boolean, restored on next startup.
     const snapshot = (): WindowState => {
       const b = win.getNormalBounds();
       return { width: b.width, height: b.height, maximized: win.isMaximized() };
     };
-    // 记住窗口大小 / 最大化：尺寸 resize 防抖回写，最大化切换即时回写（离散、低频）。写盘失败不影响使用。
+    // Remember window size / maximized: size resize is written back debounced, maximize toggles are written back immediately (discrete, low frequency). Write failures do not affect usage.
     let saveTimer: ReturnType<typeof setTimeout> | undefined;
     const persist = (): void => {
       if (win.isDestroyed()) return;
@@ -142,11 +153,11 @@ export class WindowManager {
       if (saveTimer) clearTimeout(saveTimer);
       saveTimer = setTimeout(persist, 400);
     };
-    // 不监听 move：仅存尺寸（不存 x/y），位置变化无需回写。
+    // Do not listen to move: only size is stored (not x/y), so position changes need no write-back.
     win.on('resize', scheduleSave);
     win.on('maximize', persist);
     win.on('unmaximize', persist);
-    // 关窗同步落盘：close 后进程即退出，异步写来不及 flush（最大化 / resize 后秒关会丢状态）→ 同步写兜底。
+    // Synchronous write-to-disk on close: after close the process exits immediately, and an async write cannot flush in time (closing within a second of maximize / resize would lose state) → synchronous write fallback.
     win.on('close', () => {
       if (win.isDestroyed()) return;
       if (saveTimer) clearTimeout(saveTimer);
@@ -158,8 +169,8 @@ export class WindowManager {
       }
     });
 
-    // 主界面首帧就绪：恢复最大化态 → 显示主窗口 → 关闭 splash，并记录进程启动→首帧耗时。
-    // maximize 必须放到这里：建窗后即调用会让无边框窗口在内容就绪前以空白态抢先出现（盖过/早于 splash）。
+    // Main UI first paint ready: restore maximized state → show main window → close splash, and record the process-start→first-paint elapsed time.
+    // maximize must go here: calling it right after window creation would make the frameless window appear prematurely in a blank state before content is ready (covering/preceding the splash).
     win.once('ready-to-show', () => {
       if (this.windowState.maximized) win.maximize();
       win.show();
@@ -170,23 +181,24 @@ export class WindowManager {
       );
     });
 
-    // 'auto' 主题下 OS 深浅变化时 nativeTheme 发 'updated'：按当前 overlay（渲染层派生色优先，否则通用色）
-    // 重置窗控配色兜底（macOS 无 titleBarOverlay，不注册）。具体主题的精确配色由渲染层经 setWindowControlColors
-    // 主动推送（见 useGlobalTheme），此处仅在渲染层未推送时按 nativeTheme 深浅回退。
+    // Under the 'auto' theme, nativeTheme emits 'updated' on OS dark/light changes: reset the
+    // window-control colors as a fallback by the current overlay (renderer-derived color first, otherwise
+    // generic color) (macOS has no titleBarOverlay, not registered). The specific theme's exact colors are
+    // actively pushed by the renderer via setWindowControlColors (see useGlobalTheme); here it only falls back by nativeTheme dark/light when the renderer has not pushed.
     if (process.platform !== 'darwin') {
       const onThemeUpdated = (): void => {
         if (win.isDestroyed()) return;
         try {
           win.setTitleBarOverlay(currentOverlay());
         } catch {
-          /* 平台不支持 setTitleBarOverlay → 忽略 */
+          /* platform does not support setTitleBarOverlay → ignore */
         }
       };
       nativeTheme.on('updated', onThemeUpdated);
       win.on('closed', () => nativeTheme.off('updated', onThemeUpdated));
     }
 
-    // 把 <a target="_blank"> / window.open 都路由到 OS 默认浏览器，不在 Electron 内开新窗口。
+    // Route both <a target="_blank"> / window.open to the OS default browser, not opening new windows inside Electron.
     win.webContents.setWindowOpenHandler(({ url }) => {
       void shell.openExternal(url);
       return { action: 'deny' };
@@ -200,10 +212,10 @@ export class WindowManager {
   }
 }
 
-/** 载入窗口状态（缺失/损坏 → 空对象，回退默认尺寸）并构造 WindowManager。 */
+/** Loads the window state (missing/corrupt → empty object, falling back to default size) and constructs the WindowManager. */
 export async function loadWindowManager(deps: {
   stateStore: JsonFileStateStore;
-  /** state 目录绝对路径（= JsonFileStateStore 的根目录）；关窗同步落盘用。 */
+  /** Absolute path of the state directory (= JsonFileStateStore's root); used for the synchronous write-to-disk on window close. */
   stateDir: string;
   logger: Logger;
   startMs: number;

--- a/apps/desktop/src/main/controllers/agent.ts
+++ b/apps/desktop/src/main/controllers/agent.ts
@@ -17,11 +17,11 @@ import { getContext } from '../services/context.js';
 import type { IpcController } from './types.js';
 
 /*
- * Agent 交互域 controllers：规则匹配 / 评审编排 / 自由规划 / 会话与台账读取 / pr-agent run 队列
+ * Agent interaction-domain controllers: rule matching / review orchestration / free planning / session and ledger reads / pr-agent run queue
  */
 
 /**
- * 查 PR 当前命中的规则（ask 工具不接规则；无命中回 null）。
+ * Look up the rules a PR currently matches (the ask tool takes no rules; returns null on no match).
  */
 export const matchRuleForPr: IpcController<'rules:matchForPr'> = async (_event, req) => {
   if (req.tool === 'ask') return [];
@@ -46,7 +46,7 @@ export const matchRuleForPr: IpcController<'rules:matchForPr'> = async (_event, 
 };
 
 /**
- * 评审微流程（describe→review→条件追问→总结），收尾落「评审总结」。
+ * Review micro-flow (describe→review→conditional follow-up→summary), finishing by writing the "review summary".
  */
 export const runReview: IpcController<'agent:run'> = async (_event, req) => {
   const ctx = getContext();
@@ -54,7 +54,7 @@ export const runReview: IpcController<'agent:run'> = async (_event, req) => {
 };
 
 /**
- * 自由规划 Agent（自然语言「对话即委派」）。
+ * Free-planning Agent (natural-language "conversation as delegation").
  */
 export const runPlanning: IpcController<'agent:ask'> = async (_event, req) => {
   const ctx = getContext();
@@ -66,7 +66,7 @@ export const runPlanning: IpcController<'agent:ask'> = async (_event, req) => {
 };
 
 /**
- * 运行期间追加一条用户消息：有 Agent 在跑则入队（下一周期并入重排），否则起一轮自由规划兜底。
+ * Append a user message during a run: if an Agent is running, enqueue it (merged into the reorder next cycle); otherwise start a free-planning round as fallback.
  */
 export const enqueueMessage: IpcController<'agent:enqueueMessage'> = async (_event, req) => {
   const ctx = getContext();
@@ -74,13 +74,13 @@ export const enqueueMessage: IpcController<'agent:enqueueMessage'> = async (_eve
 };
 
 /**
- * 暂停某 PR 的 Agent 运行（思考 / 执行任意阶段即时中止）。
+ * Pause a PR's Agent run (immediate abort at any thinking / execution stage).
  */
 export const stopAgent: IpcController<'agent:stop'> = (_event, req) =>
   getContext().orchestrator.stop(req.localId);
 
 /**
- * 读指定 PR 已落盘的 Agent 会话（跨 PR 切换、重启后恢复）。
+ * Read a given PR's persisted Agent session (restored across PR switches and restarts).
  */
 export const getSession: IpcController<'agent:getSession'> = async (_event, req) => {
   const ctx = getContext();
@@ -88,7 +88,7 @@ export const getSession: IpcController<'agent:getSession'> = async (_event, req)
 };
 
 /**
- * 读指定 PR 的多轮对话消息。
+ * Read a given PR's multi-turn conversation messages.
  */
 export const getConversation: IpcController<'agent:getConversation'> = async (_event, req) => {
   const ctx = getContext();
@@ -96,7 +96,7 @@ export const getConversation: IpcController<'agent:getConversation'> = async (_e
 };
 
 /**
- * 读指定 PR 的 Agent 过程步骤（transcript）。
+ * Read a given PR's Agent process steps (transcript).
  */
 export const getTranscript: IpcController<'agent:getTranscript'> = async (_event, req) => {
   const ctx = getContext();
@@ -104,13 +104,13 @@ export const getTranscript: IpcController<'agent:getTranscript'> = async (_event
 };
 
 /**
- * 批量读 AutoPilot 台账：仅返回 decision=review 且有建议者的 recommendation（PR 列表徽标用）。
+ * Batch-read AutoPilot ledgers: return only recommendation where decision=review and a recommender exists (used for PR list badges).
  */
 export const getAutopilotLedgers: IpcController<'agent:autopilotLedgers'> = async (_event, req) => {
   const ctx = getContext();
   const out: Record<string, AgentRecommendationVerdict> = {};
   for (const id of req.localIds) {
-    // 已关闭 PR 列表的台账徽标须从归档存储读（其台账随 PR 树搬入冷存储）。
+    // Ledger badges for the closed-PR list must be read from archive storage (their ledgers move into cold storage along with the PR tree).
     const ledger = await getAutopilotLedger(await ctx.pr.storeForPr(id), id);
     if (ledger?.decision === 'review' && ledger.recommendation) {
       out[id] = ledger.recommendation;
@@ -120,11 +120,11 @@ export const getAutopilotLedgers: IpcController<'agent:autopilotLedgers'> = asyn
 };
 
 /*
- * pr-agent run 队列（评审工具执行层；agent:run / AutoPilot 与用户手动 run 共用同一队列）
+ * pr-agent run queue (review-tool execution layer; agent:run / AutoPilot and user manual runs share the same queue)
  */
 
 /**
- * 触发一次 run（队列调度）。/ask 必须带 question，提前校验避免排队后才报错。
+ * Trigger one run (queue-scheduled). /ask must carry a question; validate early to avoid erroring only after queuing.
  */
 export const runPragent: IpcController<'pragent:run'> = async (_event, req) => {
   const ctx = getContext();
@@ -147,18 +147,18 @@ export const runPragent: IpcController<'pragent:run'> = async (_event, req) => {
 };
 
 /**
- * 取消一个 run（active SIGKILL / waiting 出队）。
+ * Cancel a run (active SIGKILL / waiting dequeue).
  */
 export const cancelPragent: IpcController<'pragent:cancel'> = (_event, req) =>
   getContext().runQueue.cancel(req.runId);
 
 /**
- * 当前队列快照（启动 / 重连兜底）。
+ * Current queue snapshot (startup / reconnect fallback).
  */
 export const getQueue: IpcController<'pragent:queue'> = () => getContext().runQueue.snapshot();
 
 /**
- * 列某 PR 历史 run（游标分页）。
+ * List a PR's run history (cursor pagination).
  */
 export const listRuns: IpcController<'pragent:listRuns'> = async (_event, req) => {
   const ctx = getContext();
@@ -169,7 +169,7 @@ export const listRuns: IpcController<'pragent:listRuns'> = async (_event, req) =
 };
 
 /**
- * 单条 run 查询。
+ * Query a single run.
  */
 export const getRun: IpcController<'pragent:getRun'> = async (_event, req) => {
   const ctx = getContext();
@@ -177,7 +177,7 @@ export const getRun: IpcController<'pragent:getRun'> = async (_event, req) => {
 };
 
 /**
- * 清某 PR 全部 run 历史，并一并清 Agent 会话 + AutoPilot 台账（广播 ★ 徽标即时消失）。
+ * Clear all of a PR's run history, and clear the Agent session + AutoPilot ledger together (broadcast so the ★ badge disappears immediately).
  */
 export const clearRuns: IpcController<'pragent:clearRuns'> = async (_event, req) => {
   const ctx = getContext();
@@ -189,7 +189,7 @@ export const clearRuns: IpcController<'pragent:clearRuns'> = async (_event, req)
 };
 
 /**
- * 删除单条 run 记录（仅该 run，不动 Agent 会话 / 台账 / ★ 徽标）。renderer 乐观从列表移除。
+ * Delete a single run record (only that run; leaves the Agent session / ledger / ★ badge untouched). The renderer optimistically removes it from the list.
  */
 export const deleteRun: IpcController<'pragent:deleteRun'> = async (_event, req) => {
   const ctx = getContext();

--- a/apps/desktop/src/main/controllers/app.ts
+++ b/apps/desktop/src/main/controllers/app.ts
@@ -13,35 +13,35 @@ import { getLastUpdateResult, publishUpdateResult } from '../utils/update-state.
 import type { IpcController } from './types.js';
 
 /*
- * GUI 框架交互域 controllers：应用信息 / 框架窗口 / 外部打开 / 对话框 / 日志回传 / 连接与头像
+ * GUI shell interaction-domain controllers: app info / shell window / external open / dialogs / log relay / connections and avatars
  */
 
 /**
- * 应用 / 运行时版本信息（关于页）。
+ * App / runtime version info (About page).
  */
 export const readAppInfo: IpcController<'app:info'> = () => buildAppInfo(getContext().bootstrap);
 
 /**
- * 关键目录路径（config / agent / 日志）。
+ * Key directory paths (config / agent / logs).
  */
 export const readAppPaths: IpcController<'app:paths'> = () => getContext().bootstrap.paths;
 
 /**
- * 渲染层在主题应用后推送窗控按钮配色（跟随具体主题的 --bg-app/--text-primary）；null 回退通用深/浅。
+ * The renderer pushes window-control button colors after applying a theme (follows the specific theme's --bg-app/--text-primary); null falls back to generic dark/light.
  */
 export const setWindowControlColors: IpcController<'window:setControlColors'> = (_event, req) => {
   applyWindowControlColors(req);
 };
 
 /**
- * pr-agent 探测状态（是否就绪）。
+ * pr-agent probe status (whether it is ready).
  */
 export const readPrAgentStatus: IpcController<'app:prAgentStatus'> = () =>
   getContext().getPrAgentStatus();
 
 let rendererLogger: Logger | undefined;
 /**
- * 渲染层错误 / 未捕获异常转发到 main，按级别写 renderer scope 日志（落同一份 meebox.log）。
+ * Renderer errors / uncaught exceptions are forwarded to main and written to the renderer-scope log by level (into the same meebox.log).
  */
 export const writeRendererLog: IpcController<'log:write'> = (_event, req) => {
   rendererLogger ??= getContext().logger.child({ scope: 'renderer' });
@@ -63,19 +63,19 @@ export const writeRendererLog: IpcController<'log:write'> = (_event, req) => {
 };
 
 /**
- * 各连接 ping 后缓存（当前用户 + display_name），Header / 状态栏用。
+ * Per-connection post-ping cache (current user + display_name), used by the Header / status bar.
  */
 export const listConnections: IpcController<'app:connections'> = () => {
   const { bootstrap, connectionRuntime } = getContext();
   return buildConnectionSummaries(bootstrap, connectionRuntime.adapters);
 };
 
-// 头像两级缓存：进程内 Map（含 null 负缓存）+ 磁盘文件（TTL 7 天，按 mtime 判过期）。
+// Two-level avatar cache: in-process Map (including null negative cache) + disk file (TTL 7 days, expiry judged by mtime).
 const AVATAR_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const avatarMem = new Map<string, { dataUrl: string } | null>();
 
 /**
- * 按 (connectionId, slug) 拉头像 dataUrl：内存 → 磁盘 → 远端，失败回 null。
+ * Fetch the avatar dataUrl by (connectionId, slug): memory → disk → remote, returning null on failure.
  */
 export const getUserAvatar: IpcController<'app:userAvatar'> = async (_event, req) => {
   const { logger, connectionRuntime, bootstrap } = getContext();
@@ -86,7 +86,7 @@ export const getUserAvatar: IpcController<'app:userAvatar'> = async (_event, req
   const hash = crypto.createHash('sha256').update(memKey).digest('hex').slice(0, 24);
   const filePath = path.join(avatarDir, `${hash}.bin`);
 
-  // 1) 磁盘 cache 命中且未过期？命中不打日志 (高频路径，避免日志噪音)
+  // 1) Disk cache hit and not expired? Do not log on hit (high-frequency path, avoid log noise)
   try {
     const stat = await fs.stat(filePath);
     const age = Date.now() - stat.mtimeMs;
@@ -97,13 +97,13 @@ export const getUserAvatar: IpcController<'app:userAvatar'> = async (_event, req
       avatarMem.set(memKey, result);
       return result;
     }
-    // 过期：删了重拉。删失败也没关系（writeFile 会覆盖）
+    // Expired: delete and re-fetch. A failed delete is fine (writeFile will overwrite)
     await fs.unlink(filePath).catch(() => undefined);
   } catch {
-    // 文件不存在 / 读失败 → 走 fetch
+    // File missing / read failed → go to fetch
   }
 
-  // 2) 没缓存 / 已过期：去远端拉
+  // 2) No cache / expired: fetch from remote
   const adapter = connectionRuntime.adapters.find(
     (a) => a.connectionId === req.connectionId,
   )?.adapter;
@@ -121,7 +121,7 @@ export const getUserAvatar: IpcController<'app:userAvatar'> = async (_event, req
       avatarMem.set(memKey, null);
       return null;
     }
-    // 落盘：best-effort，写失败不影响响应
+    // Persist to disk: best-effort, a write failure does not affect the response
     try {
       await fs.mkdir(avatarDir, { recursive: true });
       await fs.writeFile(filePath, img.bytes);
@@ -144,7 +144,7 @@ export const getUserAvatar: IpcController<'app:userAvatar'> = async (_event, req
 };
 
 /**
- * OS 默认编辑器打开 config.yaml。
+ * Open config.yaml in the OS default editor.
  */
 export const openConfigFile: IpcController<'app:openConfigFile'> = async () => {
   const err = await shell.openPath(getContext().bootstrap.paths.configFile);
@@ -152,8 +152,8 @@ export const openConfigFile: IpcController<'app:openConfigFile'> = async () => {
 };
 
 /**
- * 文件管理器打开当前生效的 Agent 目录。先「用时补齐」上下文模版（ensureAgentDir 幂等、含建目录），
- * 这样直接打开（未跑过任何评审时）也能看到 SOUL/AGENTS 等文件，而非空目录。
+ * Open the currently effective Agent directory in the file manager. First lazily fill in the context templates (ensureAgentDir is idempotent and creates the directory),
+ * so opening it directly (when no review has ever run) still shows SOUL/AGENTS and other files rather than an empty directory.
  */
 export const openAgentDir: IpcController<'app:openAgentDir'> = async () => {
   const dir = await getContext().ensureAgentDir();
@@ -162,21 +162,21 @@ export const openAgentDir: IpcController<'app:openAgentDir'> = async () => {
 };
 
 /**
- * 打开 DevTools（分离窗口）——需访问发起调用的 webContents。
+ * Open DevTools (detached window) — needs access to the calling webContents.
  */
 export const openDevTools: IpcController<'app:openDevTools'> = (event) => {
   event.sender.openDevTools({ mode: 'detach' });
 };
 
 /**
- * 设置应用角标计数（本期仅 macOS dock）。renderer 已据 PR 列表 + 通知配置派生「待回应」计数，主进程仅落地。
+ * Set the app badge count (currently macOS dock only). The renderer already derives the "awaiting response" count from the PR list + notification config; the main process only applies it.
  */
 export const setBadgeCount: IpcController<'app:setBadgeCount'> = (_event, req) => {
   applyBadgeCount(req.count);
 };
 
 /**
- * 手动检测更新：受 check_enabled 门控；结果交单一真相源缓存 + 有新版广播。
+ * Manual update check: gated by check_enabled; the result is handed to the single-source-of-truth cache + broadcast when a new version exists.
  */
 export const checkUpdate: IpcController<'app:checkUpdate'> = async () => {
   const { bootstrap } = getContext();
@@ -194,12 +194,12 @@ export const checkUpdate: IpcController<'app:checkUpdate'> = async () => {
 };
 
 /**
- * 读 main 缓存的最近一次更新检测结果（不发请求）。
+ * Read the main-cached most recent update-check result (issues no request).
  */
 export const getUpdateStatus: IpcController<'app:getUpdateStatus'> = () => getLastUpdateResult();
 
 /**
- * 系统浏览器打开外链（白名单仅放行 http(s)，防 file:// / javascript: 注入）。
+ * Open an external link in the system browser (allowlist permits only http(s), guarding against file:// / javascript: injection).
  */
 export const openExternal: IpcController<'app:openExternal'> = async (_event, req) => {
   if (!/^https?:\/\//.test(req.url)) return;
@@ -207,9 +207,9 @@ export const openExternal: IpcController<'app:openExternal'> = async (_event, re
 };
 
 /**
- * 打开 macOS「系统设置 → 通知」面板，引导用户授予 / 开启通知权限（macOS 在系统层管控通知授权、应用无法
- * 代为开启）。非 macOS 为 no-op。通知面板的 pane id 随系统版本不同（Ventura+ 改名），逐个回退；全失败则
- * 退到系统设置根。
+ * Open the macOS "System Settings → Notifications" panel to guide the user to grant / enable notification permission (macOS manages notification authorization at the system level; the app cannot
+ * enable it on the user's behalf). No-op on non-macOS. The notifications panel's pane id varies by system version (renamed in Ventura+), so fall back one by one; if all fail,
+ * fall back to the System Settings root.
  */
 export const openNotificationSettings: IpcController<
   'app:openNotificationSettings'
@@ -217,25 +217,25 @@ export const openNotificationSettings: IpcController<
   if (process.platform !== 'darwin') return;
   const panes = [
     'x-apple.systempreferences:com.apple.Notifications-Settings.extension', // Ventura(13)+
-    'x-apple.systempreferences:com.apple.preference.notifications', // 旧版
-    'x-apple.systempreferences:', // 兜底：系统设置根
+    'x-apple.systempreferences:com.apple.preference.notifications', // older versions
+    'x-apple.systempreferences:', // fallback: System Settings root
   ];
   for (const url of panes) {
     try {
       await shell.openExternal(url);
       return;
     } catch {
-      // 该 pane id 在当前系统版本不识别 → 尝试下一个
+      // This pane id is not recognized on the current system version → try the next one
     }
   }
 };
 
 /**
- * 系统原生目录选择对话框——需绑定到发起调用的窗口。
+ * Native OS directory-picker dialog — must be bound to the calling window.
  */
 export const pickDirectory: IpcController<'dialog:pickDirectory'> = async (event, req) => {
   const win = BrowserWindow.fromWebContents(event.sender) ?? undefined;
-  // 标题由前端按 UI 语言提供（目录选择属交互领域文案，统一在渲染层 i18n 维护，主进程不再 localize）。
+  // The title is provided by the frontend per UI language (directory picking is interaction-domain text, maintained uniformly by renderer i18n; the main process no longer localizes it).
   const result = win
     ? await dialog.showOpenDialog(win, {
         title: req.title,

--- a/apps/desktop/src/main/controllers/config.ts
+++ b/apps/desktop/src/main/controllers/config.ts
@@ -9,16 +9,16 @@ import { testProxyConnectivity } from '../utils/proxy.js';
 import type { IpcController } from './types.js';
 
 /*
- * 配置操作域 controllers：读 / 写 config.yaml（含热生效与草稿暂存）及连接 / 代理试连
+ * Config operation-domain controllers: read / write config.yaml (including hot-reload and draft staging) and connection / proxy test connections
  */
 
 /**
- * 读当前内存配置。
+ * Read the current in-memory config.
  */
 export const readConfig: IpcController<'config:read'> = () => getContext().bootstrap.config;
 
 /**
- * 写 repos_dir（重启生效）。
+ * Write repos_dir (takes effect on restart).
  */
 export const setReposDir: IpcController<'config:setReposDir'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -31,7 +31,7 @@ export const setReposDir: IpcController<'config:setReposDir'> = async (_event, r
 };
 
 /**
- * 写 UI 语言并即时生效：内存同步 + 主进程 i18n changeLanguage。
+ * Write the UI language and apply it immediately: in-memory sync + main-process i18n changeLanguage.
  */
 export const setLanguage: IpcController<'config:setLanguage'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -43,9 +43,9 @@ export const setLanguage: IpcController<'config:setLanguage'> = async (_event, r
 };
 
 /**
- * 写外观（全局主题 = Monaco 主题 + 等宽字体 + 字号）；内存同步。主题切换由 renderer 即时完成；主进程据
- * 主题设 nativeTheme.themeSource，让原生窗口 chrome（Windows 细边框 / 窗控按钮深浅）跟随——'auto' 主题
- * 交回 OS（'system'），其余固定浅 / 深。窗控按钮配色由 WindowManager 监听 nativeTheme 'updated' 重置。
+ * Write appearance (global theme = Monaco theme + monospace font + font size); in-memory sync. Theme switching is done instantly by the renderer; the main process sets
+ * nativeTheme.themeSource from the theme so native window chrome (Windows thin border / window-control button light-dark) follows — the 'auto' theme
+ * is handed back to the OS ('system'), the rest fixed light / dark. Window-control button colors are reset by WindowManager listening to nativeTheme 'updated'.
  */
 export const setEditorAppearance: IpcController<'config:setEditorAppearance'> = async (
   _event,
@@ -72,7 +72,7 @@ export const setEditorAppearance: IpcController<'config:setEditorAppearance'> = 
 };
 
 /**
- * 写 LLM Provider 配置；内存同步，下次 pragent:run 用新值。
+ * Write LLM Provider config; in-memory sync, the next pragent:run uses the new values.
  */
 export const setLlm: IpcController<'config:setLlm'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -86,9 +86,9 @@ export const setLlm: IpcController<'config:setLlm'> = async (_event, req) => {
 };
 
 /**
- * 写 agent 配置（含 agent.dir）；内存同步即热生效——effectiveAgentDir 现读 in-memory 配置，下次
- * 加载上下文即用新目录（无资源绑定，无需重建）。新目录的模版初始化不在此做，交由「用时补齐」
- * （ensureAgentDir，见 context.ts）保证，避免把初始化绑死在设置交互这一条路径上。
+ * Write agent config (including agent.dir); in-memory sync means hot-reload — effectiveAgentDir now reads the in-memory config, and the next
+ * context load uses the new directory (no resource binding, no rebuild needed). Template initialization for the new directory is not done here; it is guaranteed by lazy fill-in
+ * (ensureAgentDir, see context.ts), to avoid binding initialization to this single settings-interaction path.
  */
 export const setAgent: IpcController<'config:setAgent'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -99,7 +99,7 @@ export const setAgent: IpcController<'config:setAgent'> = async (_event, req) =>
 };
 
 /**
- * 写消息通知配置（总开关 + 分类型系统通知 + dock 角标）；内存同步，下轮 poll 弹通知 / renderer 推角标即用新值。
+ * Write message-notification config (master switch + per-type system notifications + dock badge); in-memory sync, the next poll popping notifications / renderer pushing the badge uses the new values.
  */
 export const setNotifications: IpcController<'config:setNotifications'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -110,7 +110,7 @@ export const setNotifications: IpcController<'config:setNotifications'> = async 
 };
 
 /**
- * 翻转 AutoPilot 开关；关→开时立即 poll 一轮按准入规则评估。
+ * Toggle the AutoPilot switch; on off→on, immediately run one poll to evaluate against the admission rules.
  */
 export const setAutopilotEnabled: IpcController<'agent:setAutopilotEnabled'> = async (
   _event,
@@ -131,7 +131,7 @@ export const setAutopilotEnabled: IpcController<'agent:setAutopilotEnabled'> = a
 };
 
 /**
- * 写连接列表 + 启用连接，热重建 adapter/poller 并立即 poll 一轮。
+ * Write the connection list + active connection, hot-rebuild the adapter/poller and immediately run one poll.
  */
 export const setConnections: IpcController<'config:setConnections'> = async (_event, req) => {
   const { bootstrap, logger, poller, reconfigureConnections } = getContext();
@@ -152,7 +152,7 @@ export const setConnections: IpcController<'config:setConnections'> = async (_ev
 };
 
 /**
- * 写代理配置，热重建 adapter（REST 经代理即时生效）。
+ * Write proxy config, hot-rebuild the adapter (REST via proxy takes effect immediately).
  */
 export const setProxy: IpcController<'config:setProxy'> = async (_event, req) => {
   const { bootstrap, logger, reconfigureConnections } = getContext();
@@ -167,13 +167,13 @@ export const setProxy: IpcController<'config:setProxy'> = async (_event, req) =>
 };
 
 /**
- * 用给定代理试连，验证可用性；不写配置。
+ * Test-connect with the given proxy to verify usability; does not write config.
  */
 export const testProxy: IpcController<'config:testProxy'> = (_event, req) =>
   testProxyConnectivity(req.proxy);
 
 /**
- * 用草稿 url/token 临时起 adapter ping，不落配置；失败归一成 ok:false + reason。
+ * Spin up a temporary adapter ping with draft url/token, without persisting config; failures normalize to ok:false + reason.
  */
 export const testConnection: IpcController<'config:testConnection'> = async (_event, req) => {
   try {
@@ -189,8 +189,8 @@ export const testConnection: IpcController<'config:testConnection'> = async (_ev
 };
 
 /**
- * 写本地 API 服务监听配置（开关 / host / port / token）；内存同步后热重建监听器（停旧起新）。
- * token 由请求体携带（设置页保存当前值）；单独「重新生成 token」走 generateServiceToken。
+ * Write local API service listener config (switch / host / port / token); after in-memory sync, hot-rebuild the listener (stop old, start new).
+ * The token is carried in the request body (the settings page saves the current value); the standalone "regenerate token" goes through generateServiceToken.
  */
 export const setService: IpcController<'config:setService'> = async (_event, req) => {
   const { bootstrap, logger, reconfigureApiServer } = getContext();
@@ -205,16 +205,16 @@ export const setService: IpcController<'config:setService'> = async (_event, req
 };
 
 /**
- * 生成一枚高强度随机 bearer token（32 字节 → base64url，43 字符，字符集 [A-Za-z0-9-_]，URL / 请求头安全）
- * 并返回，**不落盘**——由前端置入设置草稿，随底栏「保存」经 config:setService 生效；不保存则丢弃
- * （与 host / port 同为草稿制）。
+ * Generate and return a high-strength random bearer token (32 bytes → base64url, 43 chars, charset [A-Za-z0-9-_], URL / header safe),
+ * **without persisting** — the frontend places it into the settings draft and it takes effect via config:setService on the footer "Save"; discarded if not saved
+ * (draft-based like host / port).
  */
 export const generateServiceToken: IpcController<'config:generateServiceToken'> = () => {
   return { token: randomBytes(32).toString('base64url') };
 };
 
 /**
- * 配置过程中把连接 + LLM 草稿写盘防丢失，但不更新内存 config、不 reconfigure（不生效）。
+ * During configuration, write connection + LLM drafts to disk to avoid loss, but do not update the in-memory config and do not reconfigure (does not take effect).
  */
 export const autosaveDraft: IpcController<'config:autosaveDraft'> = async (_event, req) => {
   const { bootstrap, logger } = getContext();
@@ -232,7 +232,7 @@ export const autosaveDraft: IpcController<'config:autosaveDraft'> = async (_even
 };
 
 /**
- * 写轮询间隔（clamp 60~900）并热替换 poller 定时器，无需重启。
+ * Write the polling interval (clamp 60~900) and hot-swap the poller timer, no restart needed.
  */
 export const setPoller: IpcController<'config:setPoller'> = async (_event, req) => {
   const { bootstrap, logger, poller } = getContext();
@@ -248,7 +248,7 @@ export const setPoller: IpcController<'config:setPoller'> = async (_event, req) 
 };
 
 /**
- * 写评审任务并发数（clamp 1~8）并热替换 run 队列上限，无需重启。
+ * Write the review-task concurrency (clamp 1~8) and hot-swap the run queue limit, no restart needed.
  */
 export const setMaxConcurrency: IpcController<'config:setMaxConcurrency'> = async (_event, req) => {
   const { bootstrap, logger, runQueue } = getContext();

--- a/apps/desktop/src/main/controllers/pr.ts
+++ b/apps/desktop/src/main/controllers/pr.ts
@@ -34,11 +34,11 @@ import { getContext } from '../services/context.js';
 import type { IpcController } from './types.js';
 
 /*
- * PR 操作域 controllers：评论 / 列表 / 状态 / 合并 / 镜像 / diff / 草稿
+ * PR operation-domain controllers: comments / list / status / merge / mirror / diff / drafts
  */
 
 /**
- * 对已有评论发回复，成功后清评论缓存 + 广播 comments:changed 让 UI 重拉。
+ * Reply to an existing comment; on success clear the comments cache + broadcast comments:changed so the UI re-fetches.
  */
 export const replyComment: IpcController<'comments:reply'> = async (_event, req) => {
   const ctx = getContext();
@@ -55,7 +55,7 @@ export const replyComment: IpcController<'comments:reply'> = async (_event, req)
 };
 
 /**
- * 在 PR 上新建一条 summary（顶层、不锚文件）评论，成功后清评论缓存 + 广播 comments:changed 让 UI 重拉。
+ * Create a new summary (top-level, not file-anchored) comment on the PR; on success clear the comments cache + broadcast comments:changed so the UI re-fetches.
  */
 export const createComment: IpcController<'comments:create'> = async (_event, req) => {
   const ctx = getContext();
@@ -71,7 +71,7 @@ export const createComment: IpcController<'comments:create'> = async (_event, re
 };
 
 /**
- * 删除自己作者的远端评论（带 version 乐观锁）。失败原文抛给 renderer；成功后清缓存 + 广播。
+ * Delete a remote comment authored by yourself (with a version optimistic lock). Failures are rethrown verbatim to the renderer; on success clear the cache + broadcast.
  */
 export const deleteComment: IpcController<'comments:delete'> = async (_event, req) => {
   const ctx = getContext();
@@ -87,7 +87,7 @@ export const deleteComment: IpcController<'comments:delete'> = async (_event, re
 };
 
 /**
- * 编辑自己作者评论 body（带 version 乐观锁）。返回 updated 仅作乐观参考；清缓存 + 广播。
+ * Edit the body of a comment authored by yourself (with a version optimistic lock). The returned updated is only an optimistic reference; clear the cache + broadcast.
  */
 export const editComment: IpcController<'comments:edit'> = async (_event, req) => {
   const ctx = getContext();
@@ -105,7 +105,7 @@ export const editComment: IpcController<'comments:edit'> = async (_event, req) =
 };
 
 /**
- * 切换当前用户对一条评论的 emoji 反应（add 加 / 取下）。成功后清评论缓存 + 广播 comments:changed。
+ * Toggle the current user's emoji reaction on a comment (add / remove). On success clear the comments cache + broadcast comments:changed.
  */
 export const toggleReaction: IpcController<'comments:toggleReaction'> = async (_event, req) => {
   const ctx = getContext();
@@ -123,9 +123,9 @@ export const toggleReaction: IpcController<'comments:toggleReaction'> = async (_
 };
 
 /**
- * 上传图片作为评论附件，返回可插入正文的 markdown；不支持的平台（GitHub）返回 null。
- * bytes 由 renderer 经 IPC 传 ArrayBuffer，这里转 Uint8Array 交 adapter 上传。不清缓存（仅产出 markdown，
- * 评论尚未发布）。
+ * Upload an image as a comment attachment, returning markdown insertable into the body; unsupported platforms (GitHub) return null.
+ * bytes come from the renderer via IPC as an ArrayBuffer, converted to Uint8Array here and handed to the adapter to upload. Does not clear the cache (only produces markdown,
+ * the comment is not yet published).
  */
 export const uploadAttachment: IpcController<'comments:uploadAttachment'> = async (_event, req) => {
   const ctx = getContext();
@@ -139,7 +139,7 @@ export const uploadAttachment: IpcController<'comments:uploadAttachment'> = asyn
 };
 
 /**
- * 拉评论内嵌图片（私有实例需带 PAT，renderer 无法直接 fetch）→ 经 main 代理回 dataUrl。不缓存。
+ * Fetch a comment's embedded image (private instances need a PAT, the renderer cannot fetch it directly) → proxied through main back to a dataUrl. Not cached.
  */
 export const fetchAttachment: IpcController<'comments:fetchAttachment'> = async (_event, req) => {
   try {
@@ -147,7 +147,7 @@ export const fetchAttachment: IpcController<'comments:fetchAttachment'> = async 
     const pr = await ctx.pr.findPrOrThrow(req.localId);
     const adapter = ctx.pr.adapterFor(pr);
     if (!adapter) return null;
-    // 传 pr.repo 给 adapter — Bitbucket 的 attachment: 协议需要 repo 上下文拼 URL
+    // Pass pr.repo to the adapter — Bitbucket's attachment: protocol needs repo context to build the URL
     const res = await adapter.media.getAttachment(req.url, pr.repo);
     if (!res) return null;
     const base64 = Buffer.from(res.bytes).toString('base64');
@@ -158,7 +158,7 @@ export const fetchAttachment: IpcController<'comments:fetchAttachment'> = async 
 };
 
 /**
- * 只展示当前活动连接的 PR（状态库可能仍存切换前其他连接的历史 PR）。
+ * Show only the current active connection's PRs (the state store may still hold historical PRs from other connections before the switch).
  */
 export const listPrs: IpcController<'prs:list'> = async () => {
   const ctx = getContext();
@@ -168,7 +168,7 @@ export const listPrs: IpcController<'prs:list'> = async () => {
 };
 
 /**
- * 列已归档（退场）PR：「已关闭」视图用，只读浏览。同样仅展示当前活动连接的条目。
+ * List archived (exited) PRs: used by the "closed" view, read-only browsing. Also shows only the current active connection's entries.
  */
 export const listArchivedPrs: IpcController<'prs:listArchived'> = async () => {
   const ctx = getContext();
@@ -178,11 +178,11 @@ export const listArchivedPrs: IpcController<'prs:listArchived'> = async () => {
 };
 
 /**
- * 按 URL 打开当前平台的 PR（审查未正式被请求参与的他人 PR）：
- * ① 解析链接为 {group,repo,remoteId}，对不上当前平台形态 → PR_URL_INVALID；
- * ② 用确定性 localId 查索引：已存在则直接返回其所在范围（活跃 / 归档）让前端定位；
- * ③ 否则远端拉取单个 PR（鉴权：403 → PR_FORBIDDEN、404 → PR_NOT_FOUND），存入归档冷存储 +
- *    写索引条目（archivedAt=now，随归档生命周期 grace 到期清理），仓库镜像沿用打开详情时的懒拉取。
+ * Open a PR of the current platform by URL (reviewing someone else's PR you were not formally asked to participate in):
+ * ① Parse the link into {group,repo,remoteId}; if it doesn't match the current platform's shape → PR_URL_INVALID;
+ * ② Look up the index by deterministic localId: if it already exists, return its scope (active / archived) so the frontend can locate it;
+ * ③ Otherwise fetch the single PR from remote (auth: 403 → PR_FORBIDDEN, 404 → PR_NOT_FOUND), store it in the archive cold storage +
+ *    write an index entry (archivedAt=now, cleaned up on grace expiry per the archive lifecycle); the repo mirror reuses the lazy pull done when opening details.
  */
 export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) => {
   const ctx = getContext();
@@ -207,7 +207,7 @@ export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) =
   };
   const localId = prHashId(identity);
 
-  // 已知则直接定位（不重复拉取）：活跃 → 'active'（带其发现分类，供前端落到能展示它的 tab）、归档 → 'archived'。
+  // If known, locate directly (no re-fetch): active → 'active' (with its discovery filters, so the frontend lands on a tab that can show it), archived → 'archived'.
   const existing = (await readPrIndex(ctx.stateStore))?.prs[localId];
   if (existing) {
     if (existing.archivedAt) return { localId, location: 'archived', discoveryFilters: [] } as const;
@@ -215,7 +215,7 @@ export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) =
     return { localId, location: 'active', discoveryFilters: meta?.pr.discoveryFilters ?? [] } as const;
   }
 
-  // 远端拉取（鉴权）。403/404 归一成错误码；其它错误（网络 / 5xx）原样冒泡由前端兜底展示。
+  // Remote fetch (auth). 403/404 normalize to error codes; other errors (network / 5xx) bubble up verbatim for the frontend to fall back on.
   let pr;
   try {
     pr = await adapter.prs.getSinglePullRequest(
@@ -229,7 +229,7 @@ export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) =
     throw err;
   }
 
-  // 存入归档冷存储（与「已关闭」同管理 / 同生命周期）。索引条目 archivedAt=now → grace 到期自动清理。
+  // Store in the archive cold storage (managed / lifecycled the same as "closed"). Index entry archivedAt=now → auto-cleaned on grace expiry.
   const now = new Date().toISOString();
   const stored: StoredPullRequest = {
     ...pr,
@@ -242,7 +242,7 @@ export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) =
     lastSeenAt: now,
   };
   await writePrMeta(ctx.archiveStore, localId, stored);
-  // 紧邻写前重读索引做 read-modify-write，尽量缩小与 poll 重写索引的竞态窗口。
+  // Re-read the index right before writing for a read-modify-write, to minimize the race window with poll rewriting the index.
   const fresh = (await readPrIndex(ctx.stateStore)) ?? { schema_version: 1, prs: {} };
   const next: PrIndexFile = {
     schema_version: 1,
@@ -262,19 +262,19 @@ export const openPrByUrl: IpcController<'prs:openByUrl'> = async (_event, req) =
 };
 
 /**
- * 立即跑一轮 poll。
+ * Immediately run one poll.
  */
 export const refreshPrs: IpcController<'prs:refresh'> = () => getContext().poller.tick();
 
 /**
- * Poller 最近一次完成时间（启动初始化用）。
+ * The Poller's most recent completion time (used for startup initialization).
  */
 export const getLastSync: IpcController<'prs:lastSync'> = () => ({
   at: getContext().poller.getLastPollAt(),
 });
 
 /**
- * 设审阅状态：先写远端（失败前端不变），远端 OK 后落本地。
+ * Set review status: write remote first (on failure the frontend is unchanged), and persist locally after the remote is OK.
  */
 export const setPrStatus: IpcController<'prs:setLocalStatus'> = async (_event, req) => {
   const ctx = getContext();
@@ -295,13 +295,13 @@ export const setPrStatus: IpcController<'prs:setLocalStatus'> = async (_event, r
 };
 
 /**
- * 标记 PR 已读：推进已读水位 + 清未读标记（纯本地状态，无远端调用）。
+ * Mark a PR read: advance the read watermark + clear the unread flag (pure local state, no remote call).
  */
 export const markRead: IpcController<'prs:markRead'> = (_event, req) =>
   markPrRead(getContext().stateStore, req.localId);
 
 /**
- * 合并 PR；不在此落本地，靠 renderer refresh → poll 软删收尾，避免本地与远端各执一词。
+ * Merge a PR; do not persist locally here, relying on renderer refresh → poll soft-delete to finish, to avoid local and remote disagreeing.
  */
 export const mergePr: IpcController<'prs:merge'> = async (_event, req) => {
   const ctx = getContext();
@@ -314,7 +314,7 @@ export const mergePr: IpcController<'prs:merge'> = async (_event, req) => {
 };
 
 /**
- * 确保 PR 所属 repo 镜像就位（快速路径命中即 noop）。
+ * Ensure the PR's repo mirror is in place (fast-path hit is a noop).
  */
 export const syncRepo: IpcController<'repo:sync'> = async (_event, req) => {
   const ctx = getContext();
@@ -323,8 +323,8 @@ export const syncRepo: IpcController<'repo:sync'> = async (_event, req) => {
 };
 
 /**
- * 列出变更文件（先确保镜像）。默认 PR merge-base..head 全部变更；传 base/head 则列该范围
- * （如某 commit 的 parent..sha），用于「查看特定 commit」。
+ * List changed files (ensure the mirror first). Defaults to all changes in PR merge-base..head; if base/head are passed, list that range
+ * (e.g. a commit's parent..sha), used for "view a specific commit".
  */
 export const listChangedFiles: IpcController<'diff:listChangedFiles'> = async (_event, req) => {
   const ctx = getContext();
@@ -337,8 +337,8 @@ export const listChangedFiles: IpcController<'diff:listChangedFiles'> = async (_
 };
 
 /**
- * 列出合并会冲突的文件（文件树据此标三角警示）。仅当远端判定 PR 有冲突（pr.hasConflict）才实际跑
- * 本地 merge-tree 试合并——目标分支 tip ⟂ 源 head；无冲突的 PR 直接返回空，省一次试合并。
+ * List files that would conflict on merge (the file tree marks a triangle warning from this). Only when the remote judges the PR has a conflict (pr.hasConflict) does it actually run
+ * a local merge-tree trial merge — target branch tip ⟂ source head; a conflict-free PR returns empty directly, saving a trial merge.
  */
 export const listConflictFiles: IpcController<'diff:listConflictFiles'> = async (_event, req) => {
   const ctx = getContext();
@@ -350,8 +350,8 @@ export const listConflictFiles: IpcController<'diff:listConflictFiles'> = async 
 };
 
 /**
- * 读 base / head 一侧文件内容。默认 PR merge-base / head；传 base/head 则按指定范围
- * （commit 视图：base=parent、head=commit）。
+ * Read the file content on the base / head side. Defaults to PR merge-base / head; if base/head are passed, use the specified range
+ * (commit view: base=parent, head=commit).
  */
 export const getFileContent: IpcController<'diff:getFileContent'> = async (_event, req) => {
   const ctx = getContext();
@@ -365,7 +365,7 @@ export const getFileContent: IpcController<'diff:getFileContent'> = async (_even
 };
 
 /**
- * 仅读评论缓存条数（tab 角标懒展示），不打远端。
+ * Read only the comment cache count (lazy display for the tab badge), without hitting remote.
  */
 export const getCommentCountCached: IpcController<'diff:commentCountCached'> = async (
   _event,
@@ -377,16 +377,16 @@ export const getCommentCountCached: IpcController<'diff:commentCountCached'> = a
   return { count: cache.comments.length };
 };
 
-// In-flight dedup: 打开 PR 时多个组件并行调 listComments(force:true)，合并到同一 Promise，远端只打一次。
+// In-flight dedup: when opening a PR, multiple components call listComments(force:true) in parallel; merge into the same Promise so remote is hit only once.
 const listCommentsInFlight = new Map<string, Promise<PrComment[]>>();
 
 /**
- * 拉评论：cache + pr_updated_at stale 比对；force=true 跳缓存。同 localId in-flight 去重。
+ * Fetch comments: cache + pr_updated_at staleness comparison; force=true skips the cache. Dedups in-flight per localId.
  */
 export const listComments: IpcController<'diff:listComments'> = async (_event, req) => {
   const ctx = getContext();
   const pr = await ctx.pr.findPrOrThrow(req.localId);
-  // per-PR 缓存按归档状态路由（已关闭 PR 的缓存落归档存储，不写活跃存储以免被对账误删）。
+  // Route the per-PR cache by archive status (a closed PR's cache goes to archive storage, not the active store, to avoid being mistakenly deleted during reconciliation).
   const store = await ctx.pr.storeForPr(pr.localId);
   const cache = await readCommentsCache(store, pr.localId);
   if (!req.force && cache && !isCommentsCacheStale(cache, pr.updatedAt)) {
@@ -395,10 +395,10 @@ export const listComments: IpcController<'diff:listComments'> = async (_event, r
   const existing = listCommentsInFlight.get(pr.localId);
   if (existing) return existing;
   const adapter = ctx.pr.adapterForOrThrow(pr);
-  // dedup 要求把 in-flight Promise **同步**存进 map 后再 await：故显式构造 Promise（内部用 async
-  // IIFE 顺序 await）并 set，再 return。不能整体写成顶层 async 函数体内直接 await——首个 await 挂起前
-  // Promise 还没注册进 map，落在这窗口内的并发请求就会各自再打一次远端。.finally 绑在 Promise 上做
-  // 清理（与具体 await 方无关，成功 / 失败都摘除 map 项）。
+  // Dedup requires storing the in-flight Promise into the map **synchronously** before awaiting: so explicitly construct the Promise (using an async
+  // IIFE that awaits in sequence) and set it, then return. It cannot be written as a direct await in a top-level async function body — before the first await suspends,
+  // the Promise is not yet registered in the map, so concurrent requests falling in that window would each hit remote again. .finally is bound on the Promise for
+  // cleanup (independent of the specific awaiter; removes the map entry on both success and failure).
   const fetchPromise = (async () => {
     const raw = await adapter.comments.listPullRequestComments(
       { projectKey: pr.repo.projectKey, repoSlug: pr.repo.repoSlug },
@@ -419,13 +419,13 @@ export const listComments: IpcController<'diff:listComments'> = async (_event, r
 };
 
 /**
- * 拉 commits（不缓存，量少 + 进 commits 标签页 / 活动时间线才拉）。
+ * Fetch commits (not cached, small volume + fetched only when entering the commits tab / activity timeline).
  *
- * 平台 `/commits` 端点返回 `target..source` 全集——长期分支 / fork 同步分支历史上反复把别的分支
- * merge 进源分支，会把大量 merge 提交与合入的他人提交一并带出，淹没本 PR 真正引入的提交。这里用本地
- * 镜像按 first-parent 主干算出「本 PR 自产提交」SHA 集合做交集过滤（与提交数角标同口径，见
- * {@link RepoMirrorManager.listIntroducedCommitShas}）。镜像未就位 / 算不出 → 退回未过滤的平台列表，
- * 至少不丢信息。
+ * The platform `/commits` endpoint returns the full `target..source` set — long-lived branches / fork-sync branches repeatedly
+ * merge other branches into the source branch over their history, dragging in many merge commits and other people's merged-in commits, drowning out the commits this PR truly introduced. Here the local
+ * mirror computes the "PR's own commits" SHA set along the first-parent trunk for intersection filtering (same criterion as the commit-count badge, see
+ * {@link RepoMirrorManager.listIntroducedCommitShas}). If the mirror is not in place / cannot be computed → fall back to the unfiltered platform list,
+ * at least losing no information.
  */
 export const listCommits: IpcController<'diff:listCommits'> = async (_event, req) => {
   const ctx = getContext();
@@ -453,8 +453,8 @@ export const listCommits: IpcController<'diff:listCommits'> = async (_event, req
 };
 
 /**
- * 拉评审决断活动事件（approve / needs-work / unapprove / dismiss）。不缓存，量小；
- * 进活动时间线时与评论 / 提交归并。平台取不到历史决断时 adapter 返回 []。
+ * Fetch review-decision activity events (approve / needs-work / unapprove / dismiss). Not cached, small volume;
+ * merged with comments / commits when entering the activity timeline. When the platform cannot retrieve historical decisions, the adapter returns [].
  */
 export const listActivity: IpcController<'diff:listActivity'> = async (_event, req) => {
   const ctx = getContext();
@@ -467,8 +467,8 @@ export const listActivity: IpcController<'diff:listActivity'> = async (_event, r
 };
 
 /**
- * 本地 git 算 PR 引入提交数（base=merge-base，first-parent 主干口径，与 listCommits 过滤集一致，
- * 排除合入的目标提交与历史 merge 带进的他人提交）；镜像未齐返回 null。
+ * Local git computes the PR's introduced commit count (base=merge-base, first-parent trunk criterion, consistent with the listCommits filter set,
+ * excluding merged-in target commits and other people's commits dragged in by historical merges); returns null if the mirror is not complete.
  */
 export const getCommitCount: IpcController<'diff:commitCount'> = async (_event, req) => {
   const ctx = getContext();
@@ -480,7 +480,7 @@ export const getCommitCount: IpcController<'diff:commitCount'> = async (_event, 
 };
 
 /**
- * head 侧 blame；PR 引入行单独返回供 BlameColumn 画色带占位。
+ * head-side blame; PR-introduced lines are returned separately for BlameColumn to draw color-band placeholders.
  */
 export const getBlame: IpcController<'diff:getBlame'> = async (_event, req) => {
   const ctx = getContext();
@@ -499,7 +499,7 @@ export const getBlame: IpcController<'diff:getBlame'> = async (_event, req) => {
 };
 
 /**
- * 本地所有 repo 镜像总占用字节数（按 host|projectKey|repoSlug 去重）。
+ * Total bytes used by all local repo mirrors (deduped by host|projectKey|repoSlug).
  */
 export const getTotalSize: IpcController<'repo:getTotalSize'> = async () => {
   const ctx = getContext();
@@ -523,7 +523,7 @@ export const getTotalSize: IpcController<'repo:getTotalSize'> = async () => {
 };
 
 /**
- * 列某 PR 全部草稿。
+ * List all of a PR's drafts.
  */
 export const getDrafts: IpcController<'drafts:list'> = async (_event, req) => {
   const ctx = getContext();
@@ -531,7 +531,7 @@ export const getDrafts: IpcController<'drafts:list'> = async (_event, req) => {
 };
 
 /**
- * 创建草稿；IPC 边界再挡一道 origin/source 约束避免脏数据进盘。
+ * Create a draft; the IPC boundary enforces the origin/source constraint again to keep dirty data off disk.
  */
 export const addDraft: IpcController<'drafts:create'> = async (_event, req) => {
   const ctx = getContext();
@@ -548,7 +548,7 @@ export const addDraft: IpcController<'drafts:create'> = async (_event, req) => {
 };
 
 /**
- * 部分更新草稿（pending 编辑 body 自动转 edited；找不到返回 null）。
+ * Partially update a draft (editing a pending body auto-transitions it to edited; returns null if not found).
  */
 export const patchDraft: IpcController<'drafts:update'> = async (_event, req) => {
   const ctx = getContext();
@@ -559,7 +559,7 @@ export const patchDraft: IpcController<'drafts:update'> = async (_event, req) =>
 };
 
 /**
- * 删除草稿。
+ * Delete a draft.
  */
 export const removeDraft: IpcController<'drafts:delete'> = async (_event, req) => {
   const ctx = getContext();
@@ -567,13 +567,13 @@ export const removeDraft: IpcController<'drafts:delete'> = async (_event, req) =
   ctx.broadcast('drafts:changed', { localId: req.localId });
 };
 
-/** finding 关闭关系：列出本 PR 全部（复评 /ask 取代/撤销原 finding 的关闭记录）。 */
+/** finding closure relations: list all for this PR (closure records where a re-review /ask supersedes/revokes the original finding). */
 export const getFindingClosures: IpcController<'findingClosures:list'> = async (_event, req) => {
   const ctx = getContext();
   return listFindingClosures(await ctx.pr.storeForPr(req.localId), req.localId);
 };
 
-/** 记一条关闭关系（复评卡片的「采纳并关闭原 / 关闭原」动作）；广播让 finding 卡片重拉换关闭态。 */
+/** Record a closure relation (the re-review card's "adopt and close original / close original" action); broadcast so finding cards re-fetch and switch to the closed state. */
 export const addClosure: IpcController<'findingClosures:create'> = async (_event, req) => {
   const ctx = getContext();
   const created = await addFindingClosure(await ctx.pr.storeForPr(req.localId), req.localId, {
@@ -586,7 +586,7 @@ export const addClosure: IpcController<'findingClosures:create'> = async (_event
   return created;
 };
 
-/** 撤销关闭（finding 卡片的「撤销关闭」动作）。 */
+/** Revoke a closure (the finding card's "undo close" action). */
 export const removeClosure: IpcController<'findingClosures:delete'> = async (_event, req) => {
   const ctx = getContext();
   await removeFindingClosure(
@@ -599,8 +599,8 @@ export const removeClosure: IpcController<'findingClosures:delete'> = async (_ev
 };
 
 /**
- * 批量发布草稿：逐条 publishInlineComment，单条失败不中断；成功即删本地草稿。
- * 整批跑完广播 drafts:changed；有任一成功则 force-refresh 评论 + 广播 comments:changed。
+ * Batch-publish drafts: publishInlineComment one by one, a single failure does not interrupt; on success delete the local draft.
+ * After the whole batch runs, broadcast drafts:changed; if any succeeded, force-refresh comments + broadcast comments:changed.
  */
 export const publishDraftBatch: IpcController<'drafts:publishBatch'> = async (_event, req) => {
   const ctx = getContext();
@@ -608,7 +608,7 @@ export const publishDraftBatch: IpcController<'drafts:publishBatch'> = async (_e
   const adapter = ctx.pr.adapterForOrThrow(pr);
   const store = await ctx.pr.storeForPr(req.localId);
 
-  // 拉一次当前草稿池：localId → id → draft，避免循环里反复 listDrafts 的 O(N²) IO
+  // Fetch the current draft pool once: localId → id → draft, avoiding O(N²) IO from repeated listDrafts in the loop
   const allDrafts = await listDrafts(store, req.localId);
   const draftById = new Map(allDrafts.map((d) => [d.id, d]));
 
@@ -620,15 +620,15 @@ export const publishDraftBatch: IpcController<'drafts:publishBatch'> = async (_e
       results.push({ draftId, ok: false, error: errorCodeMessage(ERROR_CODES.PR_DRAFT_NOT_FOUND) });
       continue;
     }
-    // rejected 不发（用户决断不发）。posted 不守卫：发布成功即删本地草稿，不存历史 posted 态。
+    // rejected is not sent (the user decided not to send). posted is not guarded: on successful publish the local draft is deleted, no historical posted state is kept.
     if (draft.status === 'rejected') {
       results.push({ draftId, ok: false, error: errorCodeMessage(ERROR_CODES.PR_DRAFT_REJECTED) });
       continue;
     }
     try {
-      // ReviewDraftAnchor → PrCommentAnchor：side 保守映射 new→added / old→removed；
-      // 多行落 endLine（评论出现在标注范围下方，不打断从上往下阅读）。命中 context 行
-      // Bitbucket 回 400，错误收进 results 给用户看。
+      // ReviewDraftAnchor → PrCommentAnchor: side maps conservatively new→added / old→removed;
+      // multi-line lands on endLine (the comment appears below the annotated range, not interrupting top-down reading). Hitting a context line
+      // makes Bitbucket return 400; the error is collected into results for the user to see.
       const posted = await adapter.comments.publishInlineComment(
         { projectKey: pr.repo.projectKey, repoSlug: pr.repo.repoSlug },
         pr.remoteId,
@@ -640,7 +640,7 @@ export const publishDraftBatch: IpcController<'drafts:publishBatch'> = async (_e
         },
         draft.body,
       );
-      // 发布成功 = 本地草稿使命完成，直接删掉（远端评论由下面 force-refresh 拉回承接显示）。
+      // Successful publish = the local draft's mission is done, delete it directly (the remote comment is pulled back and takes over display via the force-refresh below).
       await deleteDraft(store, req.localId, draftId);
       anyPublished = true;
       results.push({ draftId, ok: true, postedRemoteId: posted.remoteId });

--- a/apps/desktop/src/main/controllers/types.ts
+++ b/apps/desktop/src/main/controllers/types.ts
@@ -2,14 +2,14 @@ import type { IpcMainInvokeEvent } from 'electron';
 import type { IpcChannelName, IpcChannels } from '@meebox/ipc';
 
 /**
- * IPC controller 的类型：原生 `ipcMain.handle` 监听器形态 `(event, req)`，直接
- * `ipcMain.handle('channel', controller)` 注册、无包装层。通道字符串与 controller 的匹配由
- * ipcMain.handle 的宽松签名兜不住，靠注册处命名 + 注释保证。
+ * Type of an IPC controller: the native `ipcMain.handle` listener shape `(event, req)`, registered directly via
+ * `ipcMain.handle('channel', controller)` with no wrapper layer. The match between the channel string and the controller is not
+ * caught by ipcMain.handle's loose signature; it is guaranteed by naming + comments at the registration site.
  *
- * @template K 通道名（约束 `extends IpcChannelName` 必需：req/response 由 `IpcChannels[K]` 索引取出）。
- * @param event electron IpcMainInvokeEvent；仅少数需窗口上下文的 controller 用（对话框 / DevTools），其余以 `_event` 占位。
- * @param req 该通道的强类型请求体。
- * @returns 该通道的 response（同步或异步）。
+ * @template K Channel name (the `extends IpcChannelName` constraint is required: req/response are indexed out of `IpcChannels[K]`).
+ * @param event electron IpcMainInvokeEvent; used only by the few controllers needing window context (dialogs / DevTools), the rest use `_event` as a placeholder.
+ * @param req The channel's strongly-typed request body.
+ * @returns The channel's response (sync or async).
  */
 export type IpcController<K extends IpcChannelName> = (
   event: IpcMainInvokeEvent,

--- a/apps/desktop/src/main/i18n/index.ts
+++ b/apps/desktop/src/main/i18n/index.ts
@@ -6,27 +6,30 @@ import jaJP from './locales/ja-JP.json';
 import deDE from './locales/de-DE.json';
 
 /**
- * 主进程国际化（独立的 i18next 实例，纯 Node，无 React）。
+ * Main process i18n (standalone i18next instance, pure Node, no React).
  *
- * - 与渲染层各持一份资源：main 的面向用户文本（dialog 标题、抛给渲染层并最终在
- *   toast/界面展示的错误消息）走这里。
- * - 语言在启动时由 `bootstrap.config.language` 一次性定下（`initMainI18n`）。
- *   main 进程的文案不随设置实时切换——改语言后重启生效，符合主进程文案的性质。
- * - key 命名沿用「区域命名空间」：dialog / prAgent / drafts / proxy / update。
+ * - Holds its own copy of resources separate from the renderer: main's user-facing text
+ *   (dialog titles, error messages thrown to the renderer and ultimately shown in toast/UI)
+ *   goes through here.
+ * - Language is fixed once at startup by `bootstrap.config.language` (`initMainI18n`).
+ *   Main process text does not switch live with settings—changing the language takes effect
+ *   after restart, fitting the nature of main process text.
+ * - key naming follows the "area namespace" convention: dialog / prAgent / drafts / proxy / update.
  */
 
 const instance: I18n = createInstance();
 
-// 当前生效语言：由 initMainI18n 定档（传入的已是 resolveLanguage 解析后的有效值）。
-// 供 pr-agent 响应语言（CONFIG__RESPONSE_LANGUAGE）等与 UI 保持一致地复用。
+// Currently effective language: fixed by initMainI18n (the passed value is already the effective
+// result resolved by resolveLanguage). Reused to keep pr-agent response language
+// (CONFIG__RESPONSE_LANGUAGE) etc. consistent with the UI.
 let currentLanguage: SupportedLanguage = 'en-US';
 
-/** 主进程当前生效语言，供 pr-agent 响应语言等复用，保证与 UI 一致。 */
+/** Main process currently effective language, reused for pr-agent response language etc., kept consistent with the UI. */
 export function getMainLanguage(): SupportedLanguage {
   return currentLanguage;
 }
 
-/** 启动时调用一次：按已解析的有效语言（resolveLanguage 的结果）初始化主进程 i18n。 */
+/** Called once at startup: initialize main process i18n with the resolved effective language (result of resolveLanguage). */
 export function initMainI18n(language: string): void {
   currentLanguage = matchSupportedLanguage(language) ?? 'en-US';
   void instance.init({
@@ -37,7 +40,7 @@ export function initMainI18n(language: string): void {
       'de-DE': { translation: deDE },
     },
     lng: currentLanguage,
-    // 兜底取 en-US（国际化标准，与渲染层一致）：缺 key 回退英文而非中文。
+    // Fallback to en-US (i18n standard, consistent with the renderer): missing key falls back to English rather than Chinese.
     fallbackLng: 'en-US',
     load: 'currentOnly',
     interpolation: { escapeValue: false },
@@ -46,16 +49,17 @@ export function initMainI18n(language: string): void {
 }
 
 /**
- * 运行时切换主进程语言（设置页 / 首启向导即时改语言时调用）。所有 locale 已静态打包，
- * changeLanguage 同步生效；同步更新 currentLanguage，使 getMainLanguage()（pr-agent 响应
- * 语言）随之。已弹出的 dialog 不回溯，新产生的文案与下次 run 用新语言。
+ * Switch the main process language at runtime (called when changing language live from settings /
+ * first-run wizard). All locales are statically bundled, so changeLanguage takes effect synchronously;
+ * updates currentLanguage in sync so getMainLanguage() (pr-agent response language) follows.
+ * Already-shown dialogs are not retroactively updated; newly produced text and the next run use the new language.
  */
 export function setMainLanguage(language: string): void {
   currentLanguage = matchSupportedLanguage(language) ?? 'en-US';
   void instance.changeLanguage(currentLanguage);
 }
 
-/** 主进程翻译函数。未 init 时退化为返回 key（不抛错，保证健壮）。 */
+/** Main process translation function. Degrades to returning the key before init (no throw, keeps it robust). */
 export const t: TFunction = ((key: string, options?: Record<string, unknown>) =>
   instance.isInitialized ? instance.t(key, options) : key) as TFunction;
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -24,11 +24,12 @@ import { registerIpcHandlers } from './ipc.js';
 import { ApiServer } from './services/api-server/index.js';
 import { readConnectionStates } from './utils/connection-state.js';
 
-// 进程（模块加载）起点：用于度量到主窗口首帧（ready-to-show）的启动耗时。
+// Process (module load) start point: used to measure startup time to the main window's first frame (ready-to-show).
 const PROCESS_START_MS = Date.now();
 
-// registerIpcHandlers 返回的运行时控制句柄：退出时据此中止所有进行中的 pr-agent run（触发其
-// 子进程树清理，见 before-quit）；poll tick 顺带做 AutoPilot 准入与清理已消失 PR 的在跑操作。
+// Runtime control handle returned by registerIpcHandlers: on exit, used to abort all in-progress pr-agent runs
+// (triggering their child process tree cleanup, see before-quit); the poll tick also does AutoPilot admission and
+// cleanup of in-flight operations on PRs that have disappeared.
 type IpcControl = {
   abortAllActiveRuns: () => number;
   runAutopilotIfDue: () => void;
@@ -37,15 +38,16 @@ type IpcControl = {
 };
 
 /**
- * 应用组合根：持有各子系统实例（fields），分域初始化（workspace/日志 → 各 runtime → 连接/poller/IPC →
- * 窗口 → 启动轮询）并挂接 app 生命周期。唯一入口 main()：进程微调 → 单例锁 → new App().run()。
- * 各 runtime 的构造/工厂均在 bootstrap/ 域内，本类只负责装配与生命周期编排。
+ * Application composition root: holds each subsystem instance (fields), initializes by domain (workspace/logging →
+ * each runtime → connections/poller/IPC → window → start polling) and hooks into the app lifecycle. Single entry
+ * main(): process tweaks → single-instance lock → new App().run(). Each runtime's construction/factory lives within
+ * the bootstrap/ domain; this class only handles assembly and lifecycle orchestration.
  */
 class App {
   private bootstrap!: BootstrapResult;
   private logger!: Logger;
   private stateStore!: JsonFileStateStore;
-  /** 归档 PR 冷存储（`archived/` 根，与 state/ 平级）；退场 PR 整树搬入、按 grace 期清理。 */
+  /** Archived PR cold storage (`archived/` root, sibling of state/); exiting PRs are moved in as a whole tree, cleaned by grace period. */
   private archiveStore!: JsonFileStateStore;
   private poller!: Poller;
   private repoMirror!: RepoMirrorManager;
@@ -54,31 +56,33 @@ class App {
   private conns!: ConnectionRuntimeController;
   private windowManager!: WindowManager;
   private ipcControl?: IpcControl;
-  /** 本地 API 服务监听器（默认关闭；按 config.service 决定是否 listen）。 */
+  /** Local API service listener (off by default; config.service decides whether to listen). */
   private apiServer?: ApiServer;
   private quitCleanupDone = false;
 
   constructor(private readonly startMs: number) {}
 
   /**
-   * 唯一启动序列：挂接生命周期 → 分域初始化；任一阶段抛错则记 fatal 并退出。
+   * The single startup sequence: hook into the lifecycle → initialize by domain; if any stage throws, log fatal and exit.
    */
   async run(): Promise<void> {
     this.registerLifecycle();
     try {
       await this.bootstrapCore();
       this.initRuntimes();
-      // 清扫上次会话残留的原子写临时文件（进程在 write↔rename 之间退出留下的孤儿 tmp）。
-      // 启动早期、任何写入之前清扫，单写者前提下安全（见 JsonFileStateStore.sweepStaleTmpFiles）。
+      // Sweep atomic-write temp files left over from the last session (orphan tmp left when the process exited
+      // between write↔rename). Swept early at startup, before any write, safe under the single-writer premise
+      // (see JsonFileStateStore.sweepStaleTmpFiles).
       await this.stateStore
         .sweepStaleTmpFiles()
         .catch((err: unknown) => this.logger.warn({ err }, 'state-store: tmp sweep failed'));
-      // 归档冷存储同样清扫上次会话残留的原子写 tmp（搬迁中途退出可能留下孤儿）。
+      // Archive cold storage likewise sweeps atomic-write tmp left over from the last session (exiting mid-migration may leave orphans).
       await this.archiveStore
         .sweepStaleTmpFiles()
         .catch((err: unknown) => this.logger.warn({ err }, 'archive-store: tmp sweep failed'));
-      // 归档孤儿清扫：统一索引丢失 / 重建后，归档数据失去索引条目、按索引遍历的硬清够不到 → 永久孤儿。
-      // 启动期（任何写入之前）按「索引无条目 + 目录 mtime 超 grace」无索引兜底回收（见 docs/arch/99-core/01-state-storage）。
+      // Archive orphan sweep: after the unified index is lost / rebuilt, archived data loses its index entries and the
+      // index-driven hard cleanup can't reach it → permanent orphans. At startup (before any write), reclaim via an
+      // index-less fallback keyed on "no index entry + directory mtime past grace" (see docs/arch/99-core/01-state-storage).
       await sweepOrphanedArchivedPrs({
         stateStore: this.stateStore,
         archiveStore: this.archiveStore,
@@ -95,16 +99,17 @@ class App {
   }
 
   /**
-   * ① workspace 落定 + i18n 定档 + 日志就绪 + Agent 目录脚手架 + macOS PATH 补全 + 全局兜底。
+   * ① Settle workspace + fix i18n + ready logging + scaffold Agent dir + macOS PATH completion + global fallback.
    */
   private async bootstrapCore(): Promise<void> {
     this.bootstrap = await ensureWorkspace();
-    // 主进程 i18n 定档（dialog 标题、错误消息等面向用户文本）。config.language 为空时
-    // 按操作系统偏好语言解析、无合适项回落英语；结果同时供 pr-agent 响应语言复用，与 UI 一致。
+    // Fix main process i18n (user-facing text such as dialog titles, error messages). When config.language is empty,
+    // resolve by the OS preferred language and fall back to English if there's no match; the result is also reused for
+    // the pr-agent response language, consistent with the UI.
     initMainI18n(
       resolveLanguage(this.bootstrap.config.language, app.getPreferredSystemLanguages()),
     );
-    // pretty 仅非打包态开：dev 控制台单行 + ISO8601 + 上色；打包态保持原始 JSON。
+    // pretty only on in non-packaged mode: dev console single-line + ISO8601 + colored; packaged mode keeps raw JSON.
     this.logger = await createLogger({
       logsDir: this.bootstrap.paths.logsDir,
       pretty: !app.isPackaged,
@@ -114,10 +119,12 @@ class App {
       'meebox main process started',
     );
 
-    // Agent 目录脚手架：补齐**生效目录**的模版（用户配置的 agent.dir 优先，未配置回落默认 agent/——与
-    // ipc.ts effectiveAgentDir 同口径）。此前误用默认目录，配置了自定义目录时该目录不会被初始化、启动加载
-    // 到空目录。幂等（已存在不覆盖），使首次使用即有 SOUL/AGENTS 等上下文文件可读。失败不阻断启动
-    // （运行期 loadAgentContext 仍会按缺失文件降级 + warn）。改 agent.dir 后的补齐见 config.setAgent。
+    // Agent dir scaffold: fill in the template for the **effective directory** (user-configured agent.dir takes
+    // priority, falls back to the default agent/ when unconfigured—same basis as ipc.ts effectiveAgentDir). Previously
+    // the default directory was mistakenly used, so a configured custom directory wouldn't be initialized and startup
+    // would load an empty directory. Idempotent (won't overwrite what exists), so context files like SOUL/AGENTS are
+    // readable on first use. Failure doesn't block startup (at runtime loadAgentContext still degrades on missing files
+    // + warns). For filling in after changing agent.dir, see config.setAgent.
     const agentDir = this.bootstrap.config.agent.dir || this.bootstrap.paths.agentDir;
     void scaffoldAgentDir(agentDir)
       .then((created) => {
@@ -127,7 +134,7 @@ class App {
         this.logger.warn({ err }, 'scaffold agent dir failed');
       });
 
-    // main 进程全局兜底：未捕获异常 / 未处理 rejection 至少留一条日志，不静默崩溃。
+    // Main process global fallback: leave at least one log for uncaught exceptions / unhandled rejections, no silent crash.
     process.on('uncaughtException', (err) => {
       this.logger.fatal({ err }, 'uncaughtException');
     });
@@ -137,23 +144,24 @@ class App {
   }
 
   /**
-   * ② pr-agent 运行时（解释器 + kick-off 探测）+ 版本更新器 + 状态存储。
+   * ② pr-agent runtime (interpreter + kick-off probe) + version updater + state store.
    */
   private initRuntimes(): void {
-    // pr-agent 运行时：解析嵌入式解释器 + kick-off 探测（不 await，不阻塞建窗首帧），结果异步回填。
+    // pr-agent runtime: resolve embedded interpreter + kick-off probe (not awaited, doesn't block the window's first frame), result backfilled asynchronously.
     this.prAgent = new PrAgentRuntime(this.bootstrap, this.logger);
-    // 版本更新器：由 poller tick 顺带调 runIfDue（至多每小时一次，复用 poller 周期、不另起定时器）。
+    // Version updater: runIfDue is called along with the poller tick (at most once per hour, reusing the poller cycle, no separate timer).
     this.updater = new Updater(this.bootstrap, this.logger);
     this.stateStore = new JsonFileStateStore(this.bootstrap.paths.stateDir, this.logger);
     this.archiveStore = new JsonFileStateStore(this.bootstrap.paths.archivedDir, this.logger);
   }
 
   /**
-   * ③ 连接级本地状态 → poller → 连接运行时（接线）→ repoMirror → IPC handlers。
+   * ③ Connection-level local state → poller → connection runtime (wiring) → repoMirror → IPC handlers.
    */
   private async initConnectionsAndIpc(): Promise<void> {
-    // 载入连接级本地状态（含上次 ping 的 currentUser）。缺失（首跑）/ 损坏 → 降级空表 + warn；后果仅首轮
-    // poll 无预热身份，待异步 ping 补到 currentUser 后自动重分类，功能不受损（接线 / ping 见 connections-runtime）。
+    // Load connection-level local state (including currentUser from the last ping). Missing (first run) / corrupt →
+    // degrade to an empty table + warn; the only consequence is the first poll has no pre-warmed identity, which is
+    // auto-reclassified once the async ping fills in currentUser, without loss of function (wiring / ping see connections-runtime).
     const connectionStates = await readConnectionStates(this.stateStore).catch((err: unknown) => {
       this.logger.warn(
         { err },
@@ -168,20 +176,20 @@ class App {
       archiveStore: this.archiveStore,
       logger: this.logger,
       onTickExtras: () => {
-        // 本轮已被移除 / purge 的 PR：终止其上仍在执行的 agent 操作（先于 AutoPilot，避免给已消失的 PR 起新评审）。
+        // PRs removed / purged this round: terminate agent operations still running on them (before AutoPilot, to avoid starting new reviews for disappeared PRs).
         this.ipcControl?.terminateAgentsForGonePrs();
-        // 顺带做版本更新检测：内部时间戳门控成每小时至多一次，复用 poller 周期、不另起定时器。
+        // Also do version update detection: internally timestamp-gated to at most once per hour, reusing the poller cycle, no separate timer.
         void this.updater.runIfDue();
-        // AutoPilot 预评审：满足开关 + 最小间隔 + 候选时跑一遍 pass（内部门控，复用 poller 周期）。
+        // AutoPilot pre-review: when switch + minimum interval + candidates are met, run a pass (internally gated, reusing the poller cycle).
         this.ipcControl?.runAutopilotIfDue();
       },
       getRepoMirror: () => this.repoMirror,
       getConnectionRuntime: () => this.conns.runtime,
-      // 评论类提醒（回复 / 提及）顺手失效该 PR 评论缓存 + 广播 comments:changed，让正打开它的视图即时重拉。
+      // Comment-type alerts (reply / mention) also invalidate that PR's comment cache + broadcast comments:changed, so a view currently showing it refetches immediately.
       invalidateCommentsCache: (localId) => this.ipcControl?.invalidateCommentsCache(localId),
     });
 
-    // 连接运行时（接线 / ping / 热重配）：依赖已建好的 poller；repoMirror 经 conns.runtime 读 adapterByHost。
+    // Connection runtime (wiring / ping / hot reconfigure): depends on the already-built poller; repoMirror reads adapterByHost via conns.runtime.
     this.conns = new ConnectionRuntimeController(
       this.bootstrap,
       this.stateStore,
@@ -196,14 +204,15 @@ class App {
       connectionRuntime: this.conns.runtime,
     });
 
-    // 建窗前同步把连接接好（无网络）：构建 adapters、用本地持久化身份预热 currentUser、喂 poller。
-    // 这样 app:connections 与首轮判 approved 都不依赖网络；ping 留到建窗后全异步刷新。
+    // Wire connections synchronously before creating the window (no network): build adapters, pre-warm currentUser with
+    // locally persisted identity, feed the poller. This way app:connections and the first-round approved check don't
+    // depend on network; ping is left to refresh fully asynchronously after the window is created.
     this.conns.wire();
 
     this.ipcControl = registerIpcHandlers({
       bootstrap: this.bootstrap,
       logger: this.logger,
-      // 惰性读取：探测异步回填后，handler 调用时才取到最新值（注册时探测可能尚未完成）
+      // Lazy read: after the probe backfills asynchronously, the handler picks up the latest value only when called (the probe may not be done at registration time)
       getPrAgentStatus: () => this.prAgent.probe,
       getPrAgentBridge: () => this.prAgent.getBridge(),
       embeddedPythonPath: this.prAgent.embeddedPythonPath,
@@ -213,48 +222,50 @@ class App {
       connectionRuntime: this.conns.runtime,
       reconfigureConnections: () => this.conns.reconfigure(),
       repoMirror: this.repoMirror,
-      // 惰性引用：ApiServer 在 registerIpcHandlers 之后才构造（其请求处理依赖此刻才安装的
-      // ControllerContext 单例）；闭包在 config:setService 调用时才取最新实例。
+      // Lazy reference: ApiServer is constructed only after registerIpcHandlers (its request handling depends on the
+      // ControllerContext singleton installed only at this moment); the closure picks up the latest instance only when config:setService is called.
       reconfigureApiServer: () => this.apiServer?.reconfigure() ?? Promise.resolve(),
     });
 
-    // 本地 API 服务监听器：ControllerContext 已由 registerIpcHandlers 安装，可安全处理请求。
-    // 按 config.service 决定是否实际 listen（默认关闭）；监听失败为非致命（内部已兜底记录）。
+    // Local API service listener: ControllerContext is already installed by registerIpcHandlers, so requests can be handled safely.
+    // config.service decides whether to actually listen (off by default); a listen failure is non-fatal (internally logged as a fallback).
     this.apiServer = new ApiServer({ bootstrap: this.bootstrap, logger: this.logger });
     await this.apiServer.start();
   }
 
   /**
-   * ④ whenReady 后的原生 chrome（菜单/Dock 图标/深色）+ splash + 主窗口 + activate 重建。
+   * ④ Native chrome after whenReady (menu/Dock icon/dark) + splash + main window + activate rebuild.
    */
   private async initWindow(): Promise<void> {
-    // 不要 Electron 默认菜单栏（File/Edit/View/...），meebox 自己提供工具栏
+    // No Electron default menu bar (File/Edit/View/...), meebox provides its own toolbar
     Menu.setApplicationMenu(null);
 
     await app.whenReady();
 
-    // dev 下 Dock 图标走通用 Electron.app（未经 electron-builder 烤 icns）→ 手动设成 mac 专用图标。
-    // 打包态 Dock 图标由 bundle 的 icns 决定，无需且不应在此覆盖。仅 mac 有 app.dock。
+    // In dev the Dock icon uses the generic Electron.app (not baked into icns by electron-builder) → manually set the mac-specific icon.
+    // In packaged mode the Dock icon is decided by the bundle's icns, no need and should not override here. Only mac has app.dock.
     if (process.platform === 'darwin' && !app.isPackaged) {
       app.dock?.setIcon(path.join(app.getAppPath(), '../../assets/icons/icon-mac.png'));
     }
 
-    // Windows toast 通知需 AppUserModelId 与安装包 appId 一致，否则系统可能不显示 / 归属错乱。
-    // dev 另用 .dev 后缀：AUMID 是 Windows 任务栏图标/分组/固定的持久缓存键，dev 跑的是自带
-    // 默认图标的 electron.exe，若与打包态共用同一 AUMID，会把 Electron 图标缓存到该键上 →
-    // 正式版安装后仍复用旧缓存、任务栏显示 Electron 图标。分开即互不污染。
+    // Windows toast notifications require AppUserModelId to match the installer's appId, otherwise the system may not
+    // show them / attribute them wrongly. dev uses a .dev suffix: AUMID is Windows's persistent cache key for taskbar
+    // icon/grouping/pinning, and dev runs electron.exe with its own default icon; sharing the same AUMID with packaged
+    // mode would cache the Electron icon under that key → the released build after install still reuses the old cache
+    // and shows the Electron icon in the taskbar. Separating them keeps them from polluting each other.
     if (process.platform === 'win32') {
       app.setAppUserModelId(
         app.isPackaged ? 'com.huhamhire.code-meeseeks' : 'com.huhamhire.code-meeseeks.dev',
       );
     }
 
-    // 原生窗口 chrome 跟随全局主题：Windows 据 nativeTheme 设 DWMWA_USE_IMMERSIVE_DARK_MODE（原生
-    // 细边框 / 窗控按钮深浅）。themeSource 由主题反推——'auto' 主题交回 OS（'system'），其余固定浅 / 深。
-    // 窗控按钮配色由 WindowManager 监听 nativeTheme 'updated' 同步（见 window-manager）。
+    // Native window chrome follows the global theme: Windows sets DWMWA_USE_IMMERSIVE_DARK_MODE based on nativeTheme
+    // (native thin border / window-control button light-dark). themeSource is inferred back from the theme—the 'auto'
+    // theme hands it back to the OS ('system'), the rest are fixed light / dark. Window-control button colors are synced
+    // by WindowManager listening to nativeTheme 'updated' (see window-manager).
     nativeTheme.themeSource = editorThemeNativeSource(this.bootstrap.config.appearance.editor_theme);
 
-    // 主窗口管理（载入窗口状态 + 建窗 + 尺寸回写）。
+    // Main window management (load window state + create window + write back size).
     this.windowManager = await loadWindowManager({
       stateStore: this.stateStore,
       stateDir: this.bootstrap.paths.stateDir,
@@ -262,8 +273,9 @@ class App {
       startMs: this.startMs,
     });
 
-    // 先弹轻量 splash（data URL，几十 ms 即可见），遮住主窗口首帧前的 ~2s 加载空窗。主窗口 ready-to-show
-    // 时关闭它。配色跟随有效主题（shouldUseDarkColors 已据上面的 themeSource 解析 'system'）。
+    // Pop a lightweight splash first (data URL, visible within tens of ms) to cover the ~2s loading blank before the main
+    // window's first frame. Close it when the main window is ready-to-show. Colors follow the effective theme
+    // (shouldUseDarkColors already resolves 'system' based on the themeSource above).
     const splash = createSplash(nativeTheme.shouldUseDarkColors);
     this.windowManager.create(splash);
 
@@ -273,15 +285,15 @@ class App {
   }
 
   /**
-   * ⑤ 启动关键路径已无网络：归档（本地 IO）后启动 poller，再异步 ping 刷新远端身份。
+   * ⑤ The startup critical path is already network-free: after archiving (local IO), start the poller, then async ping to refresh remote identity.
    */
   private async startPolling(): Promise<void> {
     await this.poller.archiveConnectionsExcept(this.conns.activeConnectionIds());
-    // 活动连接是否已有缓存身份（conns.wire 已用本地持久化身份预热）：
-    // - 有 → poller 立即跑首轮（me 就绪，分类正确）；
-    // - 无 → **不跑 me=null 的半成品首轮**，只装定时器；首次同步改由下面 conns.ping 在 ping
-    //   确认身份后立即触发（无身份的活动连接 ping settle 后必 tick 一次）。
-    // 这样「首次启动 / state 缺失」时也是「先确认身份，再同步一次」，避免首轮全标 pending 或看似没同步。
+    // Whether the active connection already has a cached identity (conns.wire pre-warmed with locally persisted identity):
+    // - Yes → poller runs the first round immediately (me is ready, classification correct);
+    // - No → **don't run a half-baked first round with me=null**, only install the timer; the first sync is instead
+    //   triggered by conns.ping below right after ping confirms identity (an active connection with no identity must tick once after ping settles).
+    // This way "first startup / missing state" is also "confirm identity first, then sync once", avoiding a first round that marks everything pending or looks like it didn't sync.
     const activeHasIdentity = this.conns.runtime.adapters.some(
       (a) =>
         a.connectionId === this.bootstrap.config.active_connection_id &&
@@ -296,26 +308,27 @@ class App {
       },
       'poller started',
     );
-    // ping 全异步刷新远端身份（不在启动关键路径）：刷新/持久化 currentUser，身份变化则补一轮 poll。
-    // 这是「本地无身份记录」（首跑 / state 缺失）时的兜底来源；ping 慢或不可达都不影响已启动的 UI。
+    // ping refreshes remote identity fully asynchronously (not on the startup critical path): refreshes/persists
+    // currentUser, and does an extra poll round if identity changes. This is the fallback source when there's "no local
+    // identity record" (first run / missing state); a slow or unreachable ping doesn't affect the already-started UI.
     this.conns.ping();
   }
 
   /**
-   * app 级生命周期：退出清理（停轮询 + 终止在跑 run 的子进程树）、关窗退出、二次启动聚焦。
+   * App-level lifecycle: exit cleanup (stop polling + terminate the child process tree of running runs), quit on window close, focus on second launch.
    */
   private registerLifecycle(): void {
-    // 退出清理：停轮询 + 终止所有进行中的 pr-agent run 的子进程树（python + litellm 等孙进程）。
-    // 不清理会留孤儿进程锁住安装目录 → 升级时 NSIS 报「应用无法关闭」。
+    // Exit cleanup: stop polling + terminate the child process tree of all in-progress pr-agent runs (python + litellm and other grandchild processes).
+    // Not cleaning up leaves orphan processes locking the install directory → NSIS reports "the app cannot be closed" during upgrade.
     app.on('before-quit', (event) => {
       if (this.poller) this.poller.stop();
-      // 停本地 API 监听（停止接收新连接）；fire-and-forget，关闭很快、不阻塞退出。
+      // Stop the local API listener (stop accepting new connections); fire-and-forget, closes quickly, doesn't block exit.
       void this.apiServer?.stop();
       if (this.quitCleanupDone) return;
       const aborted = this.ipcControl?.abortAllActiveRuns() ?? 0;
-      if (aborted === 0) return; // 无进行中 run，直接退出
-      // 有 run 在跑：abort 已触发各自 exec 的 killTree（win32=taskkill /T /F，异步）。延后真正退出，
-      // 给 taskkill 跑完，避免主进程先退出、孙进程没杀干净。
+      if (aborted === 0) return; // No in-progress run, exit directly
+      // Runs are in progress: abort has triggered each exec's killTree (win32=taskkill /T /F, async). Defer the actual
+      // exit to let taskkill finish, avoiding the main process exiting first while grandchild processes aren't fully killed.
       event.preventDefault();
       this.quitCleanupDone = true;
       if (this.logger) {
@@ -328,7 +341,7 @@ class App {
       if (process.platform !== 'darwin') app.quit();
     });
 
-    // 二次启动（用户再点图标 / 命令行再拉起）→ 聚焦已有窗口，最小化则先还原。
+    // Second launch (user clicks the icon again / relaunches from command line) → focus the existing window, restore first if minimized.
     app.on('second-instance', () => {
       const win = BrowserWindow.getAllWindows()[0];
       if (win) {
@@ -340,11 +353,12 @@ class App {
 }
 
 /**
- * 进程入口：
- * ① OS/平台启动微调（须在 whenReady 前；含 Windows 控制台编码 / macOS keychain + PATH 补全）。
- * ② 单例锁——同一时刻只允许一个实例，多实例会共享同一份 config.yaml / repos 镜像 / state store
- *    导致写竞争，拿不到锁者直接退出（由已有实例的 second-instance 回调聚焦窗口）。
- * ③ 拿到锁则构造 App 并启动。
+ * Process entry:
+ * ① OS/platform startup tweaks (must be before whenReady; includes Windows console encoding / macOS keychain + PATH completion).
+ * ② Single-instance lock—only one instance allowed at a time; multiple instances would share the same config.yaml /
+ *    repos mirror / state store causing write contention, so whoever fails to get the lock exits directly (the existing
+ *    instance's second-instance callback focuses the window).
+ * ③ If the lock is acquired, construct App and start.
  */
 function main(): void {
   applyOsStartupTweaks();

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -15,11 +15,13 @@ import { RunQueue } from './services/pr-agent/index.js';
 export type { RegisterDeps } from './services/context.js';
 
 /**
- * 注册全部 IPC handler。薄入口：构建共享上下文 → 建两个跨域 service（run 队列 / Agent 编排）
- * → 合成 controller 上下文并安装为进程级单例 → 按业务领域逐个绑定通道 → 返回运行时控制句柄。
+ * Register all IPC handlers. Thin entry: build the shared context → create two cross-domain services (run queue / Agent
+ * orchestration) → compose the controller context and install it as a process-level singleton → bind channels one by
+ * one per business domain → return the runtime control handle.
  *
- * controller 是原生 ipcMain.handle 监听器（具名函数 `(event, req) => …`，见 controllers/<域>.ts），
- * 依赖经 getContext() 取用、不带 ctx 参数；下方直接 `ipcMain.handle('channel', controller)` 注册，无包装层。
+ * A controller is a native ipcMain.handle listener (named function `(event, req) => …`, see controllers/<domain>.ts),
+ * with dependencies taken via getContext() and no ctx parameter; below they're registered directly as
+ * `ipcMain.handle('channel', controller)`, with no wrapper layer.
  */
 export function registerIpcHandlers(deps: RegisterDeps): {
   abortAllActiveRuns: () => number;
@@ -28,133 +30,135 @@ export function registerIpcHandlers(deps: RegisterDeps): {
   invalidateCommentsCache: (localId: string) => void;
 } {
   const base = createServiceContext(deps);
-  // run 队列：pragent:run（PR 域）、Agent 编排、AutoPilot 三方共用。
+  // run queue: shared by pragent:run (PR domain), Agent orchestration, and AutoPilot.
   const runQueue = new RunQueue(base);
-  // Agent 编排：复用 run 队列派发工具 run（agent 低优先级泳道）。
+  // Agent orchestration: reuses the run queue to dispatch tool runs (agent low-priority lane).
   const orchestrator = new Orchestrator(base, runQueue);
-  // controller 层统一上下文：基础上下文 + 两个跨域 service，安装为进程级单例（controller 经 getContext() 取用）。
+  // Controller-layer unified context: base context + two cross-domain services, installed as a process-level singleton (controllers take it via getContext()).
   const ctx: ControllerContext = { ...base, runQueue, orchestrator };
   setControllerContext(ctx);
 
   /*
-   * GUI 框架交互
-   * 应用信息 / 窗口 / 外部打开 / 对话框 / 日志回传 / 连接与头像
+   * GUI framework interaction
+   * App info / window / external open / dialog / log relay / connections and avatars
    */
-  ipcMain.handle('app:info', app.readAppInfo); // 应用 / 运行时版本信息（关于页）
-  ipcMain.handle('app:paths', app.readAppPaths); // 关键目录路径（config / agent / 日志）
-  ipcMain.handle('app:prAgentStatus', app.readPrAgentStatus); // pr-agent 探测状态（是否就绪）
-  ipcMain.handle('log:write', app.writeRendererLog); // 渲染层日志回传落盘
-  ipcMain.handle('window:setControlColors', app.setWindowControlColors); // 渲染层推送主题派生窗控配色
-  ipcMain.handle('app:connections', app.listConnections); // 当前活动连接摘要（Header / 状态栏）
-  ipcMain.handle('app:userAvatar', app.getUserAvatar); // 用户头像（内存 + 磁盘两级缓存）
-  ipcMain.handle('app:openConfigFile', app.openConfigFile); // 打开 config.yaml
-  ipcMain.handle('app:openAgentDir', app.openAgentDir); // 打开 Agent 目录
-  ipcMain.handle('app:openDevTools', app.openDevTools); // 打开 DevTools（分离窗口）
-  ipcMain.handle('app:setBadgeCount', app.setBadgeCount); // 设应用角标计数（macOS dock）
-  ipcMain.handle('app:checkUpdate', app.checkUpdate); // 手动检查更新
-  ipcMain.handle('app:getUpdateStatus', app.getUpdateStatus); // 读缓存的更新检测结果（水合）
-  ipcMain.handle('app:openExternal', app.openExternal); // 系统浏览器打开外链
-  ipcMain.handle('app:openNotificationSettings', app.openNotificationSettings); // macOS 打开系统通知设置
-  ipcMain.handle('dialog:pickDirectory', app.pickDirectory); // 原生目录选择对话框
+  ipcMain.handle('app:info', app.readAppInfo); // App / runtime version info (About page)
+  ipcMain.handle('app:paths', app.readAppPaths); // Key directory paths (config / agent / logs)
+  ipcMain.handle('app:prAgentStatus', app.readPrAgentStatus); // pr-agent probe status (whether ready)
+  ipcMain.handle('log:write', app.writeRendererLog); // Relay renderer logs to disk
+  ipcMain.handle('window:setControlColors', app.setWindowControlColors); // Renderer pushes theme-derived window-control colors
+  ipcMain.handle('app:connections', app.listConnections); // Current active connection summary (Header / status bar)
+  ipcMain.handle('app:userAvatar', app.getUserAvatar); // User avatar (two-level memory + disk cache)
+  ipcMain.handle('app:openConfigFile', app.openConfigFile); // Open config.yaml
+  ipcMain.handle('app:openAgentDir', app.openAgentDir); // Open Agent directory
+  ipcMain.handle('app:openDevTools', app.openDevTools); // Open DevTools (detached window)
+  ipcMain.handle('app:setBadgeCount', app.setBadgeCount); // Set app badge count (macOS dock)
+  ipcMain.handle('app:checkUpdate', app.checkUpdate); // Manually check for updates
+  ipcMain.handle('app:getUpdateStatus', app.getUpdateStatus); // Read cached update-check result (hydration)
+  ipcMain.handle('app:openExternal', app.openExternal); // Open external link in system browser
+  ipcMain.handle('app:openNotificationSettings', app.openNotificationSettings); // macOS open system notification settings
+  ipcMain.handle('dialog:pickDirectory', app.pickDirectory); // Native directory picker dialog
 
   /*
-   * PR 操作
-   * 评论 / 列表 / 状态 / 合并 / 镜像 / diff / 草稿 / pr-agent run 队列
+   * PR operations
+   * Comments / list / status / merge / mirror / diff / drafts / pr-agent run queue
    */
-  ipcMain.handle('comments:reply', pr.replyComment); // 回复评论
-  ipcMain.handle('comments:create', pr.createComment); // 新建 summary 评论
-  ipcMain.handle('comments:delete', pr.deleteComment); // 删除自己的评论
-  ipcMain.handle('comments:edit', pr.editComment); // 编辑自己的评论
-  ipcMain.handle('comments:toggleReaction', pr.toggleReaction); // 切换评论 emoji 反应
-  ipcMain.handle('comments:uploadAttachment', pr.uploadAttachment); // 上传评论图片附件
-  ipcMain.handle('comments:fetchAttachment', pr.fetchAttachment); // 拉评论内嵌图片（代理带 PAT）
-  ipcMain.handle('prs:list', pr.listPrs); // PR 列表（仅活动连接）
-  ipcMain.handle('prs:listArchived', pr.listArchivedPrs); // 已关闭（归档）PR 列表（只读浏览）
-  ipcMain.handle('prs:openByUrl', pr.openPrByUrl); // 按 URL 打开当前平台 PR（定位 / 拉取存档）
-  ipcMain.handle('prs:refresh', pr.refreshPrs); // 立即轮询刷新
-  ipcMain.handle('prs:lastSync', pr.getLastSync); // 最近一次同步时间
-  ipcMain.handle('prs:setLocalStatus', pr.setPrStatus); // 设置审阅状态（先远端后本地）
-  ipcMain.handle('prs:markRead', pr.markRead); // 标记 PR 已读（推进未读水位）
-  ipcMain.handle('prs:merge', pr.mergePr); // 合并 PR
-  ipcMain.handle('repo:sync', pr.syncRepo); // 同步 PR 所属 repo 本地镜像
-  ipcMain.handle('diff:listChangedFiles', pr.listChangedFiles); // 变更文件列表
-  ipcMain.handle('diff:listConflictFiles', pr.listConflictFiles); // 合并冲突文件列表（文件树警示）
-  ipcMain.handle('diff:getFileContent', pr.getFileContent); // 文件内容（base / head 一侧）
-  ipcMain.handle('diff:commentCountCached', pr.getCommentCountCached); // 评论数角标（仅缓存）
-  ipcMain.handle('diff:listComments', pr.listComments); // 拉评论（缓存 + in-flight 去重）
-  ipcMain.handle('diff:listCommits', pr.listCommits); // 提交列表
-  ipcMain.handle('diff:listActivity', pr.listActivity); // 评审决断活动事件（时间线）
-  ipcMain.handle('diff:commitCount', pr.getCommitCount); // 提交数角标（本地 git）
-  ipcMain.handle('diff:getBlame', pr.getBlame); // blame + PR 引入行
-  ipcMain.handle('repo:getTotalSize', pr.getTotalSize); // 本地镜像总占用（设置页）
-  ipcMain.handle('drafts:list', pr.getDrafts); // 草稿列表
-  ipcMain.handle('drafts:create', pr.addDraft); // 新建草稿
-  ipcMain.handle('drafts:update', pr.patchDraft); // 更新草稿
-  ipcMain.handle('drafts:delete', pr.removeDraft); // 删除草稿
-  ipcMain.handle('drafts:publishBatch', pr.publishDraftBatch); // 批量发布草稿到远端
-  ipcMain.handle('findingClosures:list', pr.getFindingClosures); // finding 关闭关系列表
-  ipcMain.handle('findingClosures:create', pr.addClosure); // 复评取代/撤销 → 关闭原 finding
-  ipcMain.handle('findingClosures:delete', pr.removeClosure); // 撤销关闭
+  ipcMain.handle('comments:reply', pr.replyComment); // Reply to a comment
+  ipcMain.handle('comments:create', pr.createComment); // Create a summary comment
+  ipcMain.handle('comments:delete', pr.deleteComment); // Delete your own comment
+  ipcMain.handle('comments:edit', pr.editComment); // Edit your own comment
+  ipcMain.handle('comments:toggleReaction', pr.toggleReaction); // Toggle a comment emoji reaction
+  ipcMain.handle('comments:uploadAttachment', pr.uploadAttachment); // Upload a comment image attachment
+  ipcMain.handle('comments:fetchAttachment', pr.fetchAttachment); // Fetch a comment inline image (proxied with PAT)
+  ipcMain.handle('prs:list', pr.listPrs); // PR list (active connection only)
+  ipcMain.handle('prs:listArchived', pr.listArchivedPrs); // Closed (archived) PR list (read-only browsing)
+  ipcMain.handle('prs:openByUrl', pr.openPrByUrl); // Open a current-platform PR by URL (locate / fetch archive)
+  ipcMain.handle('prs:refresh', pr.refreshPrs); // Poll and refresh immediately
+  ipcMain.handle('prs:lastSync', pr.getLastSync); // Most recent sync time
+  ipcMain.handle('prs:setLocalStatus', pr.setPrStatus); // Set review status (remote first, then local)
+  ipcMain.handle('prs:markRead', pr.markRead); // Mark PR read (advance unread watermark)
+  ipcMain.handle('prs:merge', pr.mergePr); // Merge PR
+  ipcMain.handle('repo:sync', pr.syncRepo); // Sync the local mirror of the PR's repo
+  ipcMain.handle('diff:listChangedFiles', pr.listChangedFiles); // Changed files list
+  ipcMain.handle('diff:listConflictFiles', pr.listConflictFiles); // Merge conflict files list (file tree warning)
+  ipcMain.handle('diff:getFileContent', pr.getFileContent); // File content (base / head side)
+  ipcMain.handle('diff:commentCountCached', pr.getCommentCountCached); // Comment count badge (cache only)
+  ipcMain.handle('diff:listComments', pr.listComments); // Fetch comments (cache + in-flight dedup)
+  ipcMain.handle('diff:listCommits', pr.listCommits); // Commit list
+  ipcMain.handle('diff:listActivity', pr.listActivity); // Review-decision activity events (timeline)
+  ipcMain.handle('diff:commitCount', pr.getCommitCount); // Commit count badge (local git)
+  ipcMain.handle('diff:getBlame', pr.getBlame); // blame + PR-introduced lines
+  ipcMain.handle('repo:getTotalSize', pr.getTotalSize); // Total local mirror usage (settings page)
+  ipcMain.handle('drafts:list', pr.getDrafts); // Draft list
+  ipcMain.handle('drafts:create', pr.addDraft); // Create a draft
+  ipcMain.handle('drafts:update', pr.patchDraft); // Update a draft
+  ipcMain.handle('drafts:delete', pr.removeDraft); // Delete a draft
+  ipcMain.handle('drafts:publishBatch', pr.publishDraftBatch); // Batch publish drafts to remote
+  ipcMain.handle('findingClosures:list', pr.getFindingClosures); // finding closure relations list
+  ipcMain.handle('findingClosures:create', pr.addClosure); // Re-review supersede/revoke → close the original finding
+  ipcMain.handle('findingClosures:delete', pr.removeClosure); // Undo closure
 
   /*
-   * 配置操作
-   * 读写 config.yaml（热生效 / 草稿暂存）及连接 / 代理试连
+   * Config operations
+   * Read/write config.yaml (hot effect / draft staging) and connection / proxy test connections
    */
-  ipcMain.handle('config:read', config.readConfig); // 读当前内存配置
-  ipcMain.handle('config:setReposDir', config.setReposDir); // 设仓库目录（重启生效）
-  ipcMain.handle('config:setLanguage', config.setLanguage); // 设 UI 语言（热生效）
-  ipcMain.handle('config:setEditorAppearance', config.setEditorAppearance); // 设全局主题 + 字体（前端即时生效，主进程据主题设原生 themeSource）
-  ipcMain.handle('config:setLlm', config.setLlm); // 设 LLM Provider 配置
-  ipcMain.handle('config:setAgent', config.setAgent); // 设 Agent 配置（含 agent.dir）
-  ipcMain.handle('config:setNotifications', config.setNotifications); // 设消息通知配置（系统通知 + dock 角标）
-  ipcMain.handle('agent:setAutopilotEnabled', config.setAutopilotEnabled); // AutoPilot 开关
-  ipcMain.handle('config:setConnections', config.setConnections); // 设连接（热重建 adapter/poller）
-  ipcMain.handle('config:setProxy', config.setProxy); // 设代理（热重建 adapter）
-  ipcMain.handle('config:testProxy', config.testProxy); // 试连代理（不写配置）
-  ipcMain.handle('config:testConnection', config.testConnection); // 试连连接（不写配置）
-  ipcMain.handle('config:autosaveDraft', config.autosaveDraft); // 连接 / LLM 草稿存盘（不生效）
-  ipcMain.handle('config:setPoller', config.setPoller); // 设轮询间隔（热替换定时器）
-  ipcMain.handle('config:setMaxConcurrency', config.setMaxConcurrency); // 设评审并发数（热替换队列上限）
-  ipcMain.handle('config:setService', config.setService); // 设本地 API 服务监听（热重建监听器）
-  ipcMain.handle('config:generateServiceToken', config.generateServiceToken); // 重新生成 API bearer token
+  ipcMain.handle('config:read', config.readConfig); // Read current in-memory config
+  ipcMain.handle('config:setReposDir', config.setReposDir); // Set repos directory (takes effect on restart)
+  ipcMain.handle('config:setLanguage', config.setLanguage); // Set UI language (hot effect)
+  ipcMain.handle('config:setEditorAppearance', config.setEditorAppearance); // Set global theme + font (frontend takes effect immediately, main process sets native themeSource per theme)
+  ipcMain.handle('config:setLlm', config.setLlm); // Set LLM Provider config
+  ipcMain.handle('config:setAgent', config.setAgent); // Set Agent config (including agent.dir)
+  ipcMain.handle('config:setNotifications', config.setNotifications); // Set notification config (system notifications + dock badge)
+  ipcMain.handle('agent:setAutopilotEnabled', config.setAutopilotEnabled); // AutoPilot switch
+  ipcMain.handle('config:setConnections', config.setConnections); // Set connections (hot-rebuild adapter/poller)
+  ipcMain.handle('config:setProxy', config.setProxy); // Set proxy (hot-rebuild adapter)
+  ipcMain.handle('config:testProxy', config.testProxy); // Test proxy connection (doesn't write config)
+  ipcMain.handle('config:testConnection', config.testConnection); // Test connection (doesn't write config)
+  ipcMain.handle('config:autosaveDraft', config.autosaveDraft); // Save connection / LLM draft to disk (doesn't take effect)
+  ipcMain.handle('config:setPoller', config.setPoller); // Set poll interval (hot-swap timer)
+  ipcMain.handle('config:setMaxConcurrency', config.setMaxConcurrency); // Set review concurrency (hot-swap queue cap)
+  ipcMain.handle('config:setService', config.setService); // Set local API service listening (hot-rebuild listener)
+  ipcMain.handle('config:generateServiceToken', config.generateServiceToken); // Regenerate API bearer token
 
   /*
-   * Agent 交互
-   * 规则匹配 / 评审编排 / 自由规划 / 会话与台账读取 / pr-agent run 队列
+   * Agent interaction
+   * Rule matching / review orchestration / free planning / session and ledger reads / pr-agent run queue
    */
-  ipcMain.handle('rules:matchForPr', agent.matchRuleForPr); // 查 PR 命中的规则
-  ipcMain.handle('agent:run', agent.runReview); // 一键评审编排（describe→review→总结）
-  ipcMain.handle('agent:ask', agent.runPlanning); // 自由规划 Agent（对话即委派）
-  ipcMain.handle('agent:enqueueMessage', agent.enqueueMessage); // 运行中追加用户消息（入队 / 起新轮）
-  ipcMain.handle('agent:stop', agent.stopAgent); // 停止某 PR 的 Agent 运行
-  ipcMain.handle('agent:getSession', agent.getSession); // 读已落盘评审会话
-  ipcMain.handle('agent:getConversation', agent.getConversation); // 读多轮对话消息
-  ipcMain.handle('agent:getTranscript', agent.getTranscript); // 读 Agent 过程步骤
-  ipcMain.handle('agent:autopilotLedgers', agent.getAutopilotLedgers); // 批量读 AutoPilot 评审台账
-  ipcMain.handle('pragent:run', agent.runPragent); // 触发一次 pr-agent run（入队）
-  ipcMain.handle('pragent:cancel', agent.cancelPragent); // 取消一个 run
-  ipcMain.handle('pragent:queue', agent.getQueue); // 队列快照（active + waiting）
-  ipcMain.handle('pragent:listRuns', agent.listRuns); // 历史 run 列表（游标分页）
-  ipcMain.handle('pragent:getRun', agent.getRun); // 单条 run 查询
-  ipcMain.handle('pragent:clearRuns', agent.clearRuns); // 清空 run 历史 + Agent 会话 / 台账
-  ipcMain.handle('pragent:deleteRun', agent.deleteRun); // 删除单条 run 记录
+  ipcMain.handle('rules:matchForPr', agent.matchRuleForPr); // Look up rules a PR matches
+  ipcMain.handle('agent:run', agent.runReview); // One-click review orchestration (describe→review→summarize)
+  ipcMain.handle('agent:ask', agent.runPlanning); // Free-planning Agent (conversation is delegation)
+  ipcMain.handle('agent:enqueueMessage', agent.enqueueMessage); // Append a user message while running (enqueue / start a new round)
+  ipcMain.handle('agent:stop', agent.stopAgent); // Stop the Agent run for a PR
+  ipcMain.handle('agent:getSession', agent.getSession); // Read a persisted review session
+  ipcMain.handle('agent:getConversation', agent.getConversation); // Read multi-round conversation messages
+  ipcMain.handle('agent:getTranscript', agent.getTranscript); // Read Agent process steps
+  ipcMain.handle('agent:autopilotLedgers', agent.getAutopilotLedgers); // Batch read AutoPilot review ledgers
+  ipcMain.handle('pragent:run', agent.runPragent); // Trigger one pr-agent run (enqueue)
+  ipcMain.handle('pragent:cancel', agent.cancelPragent); // Cancel a run
+  ipcMain.handle('pragent:queue', agent.getQueue); // Queue snapshot (active + waiting)
+  ipcMain.handle('pragent:listRuns', agent.listRuns); // Historical run list (cursor pagination)
+  ipcMain.handle('pragent:getRun', agent.getRun); // Query a single run
+  ipcMain.handle('pragent:clearRuns', agent.clearRuns); // Clear run history + Agent sessions / ledgers
+  ipcMain.handle('pragent:deleteRun', agent.deleteRun); // Delete a single run record
 
   base.logger.debug('IPC handlers registered');
 
   return {
     /**
-     * 应用退出时调用：中止所有进行中的 run。每个 run 的 AbortController.abort() 会触发 exec 的
-     * onAbort → killTree（进程树级杀），连带终止 python 及其 litellm 等孙进程，避免孤儿进程锁住
-     * 安装目录导致升级安装失败。返回被中止的 run 数，供调用方决定是否需要短暂等待 taskkill 跑完。
+     * Called on app exit: abort all in-progress runs. Each run's AbortController.abort() triggers exec's
+     * onAbort → killTree (process-tree-level kill), also terminating python and its grandchild processes like litellm,
+     * avoiding orphan processes locking the install directory and causing upgrade install failures. Returns the number
+     * of aborted runs, so the caller can decide whether it needs to wait briefly for taskkill to finish.
      */
     abortAllActiveRuns: () => runQueue.abortAllActiveRuns(),
-    /** 每次 poll tick 由 index.ts 调用：满足开关 + 候选时跑一遍 AutoPilot pass。 */
+    /** Called by index.ts on each poll tick: when switch + candidates are met, run one AutoPilot pass. */
     runAutopilotIfDue: () => orchestrator.runAutopilotIfDue(),
-    /** 每次 poll tick 由 index.ts 调用：终止已被移除 / purge 的 PR 上仍在执行的 agent 操作。 */
+    /** Called by index.ts on each poll tick: terminate agent operations still running on PRs that were removed / purged. */
     terminateAgentsForGonePrs: () => void orchestrator.terminateAgentsForGonePrs(),
     /**
-     * 轮询发现某 PR 评论变更（回复 / 提及）时由 index.ts 调用：清该 PR 评论缓存 + 广播 comments:changed，
-     * 让正打开该 PR 的 Diff 内嵌评论 / 活动时间线即时重拉（轮询期评论变更此前只弹通知、不刷新已打开视图）。
+     * Called by index.ts when polling finds a PR's comments changed (reply / mention): clear that PR's comment cache +
+     * broadcast comments:changed, so the Diff inline comments / activity timeline currently showing that PR refetch
+     * immediately (comment changes during polling previously only popped a notification, without refreshing the open view).
      */
     invalidateCommentsCache: (localId: string) => void ctx.pr.invalidateCommentsCache(localId),
   };

--- a/apps/desktop/src/main/services/agent/flows/autopilot.ts
+++ b/apps/desktop/src/main/services/agent/flows/autopilot.ts
@@ -16,9 +16,12 @@ import type { OrchestratorRuntime } from '../runtime.js';
 import { runReviewForPr } from './review.js';
 
 /**
- * 跑一遍 AutoPilot pass（busy 锁置位 / 复位包住全程）。仅由 Orchestrator.runAutopilotIfDue 通过准入后触发。
- * 候选准入（硬性门控，自上而下）：① 仅「待我评审 + 待处理」；② 已有 describe/review 产出（成功 / 进行中）
- * → 已评审过 / 评审中，排除；③ 本版本已被判 skip 的台账去重。再按 batch_size 截断，批量判定后并行编排评审。
+ * Runs one AutoPilot pass (the busy lock set / reset wraps the whole run). Only triggered by
+ * Orchestrator.runAutopilotIfDue after passing admission.
+ * Candidate admission (hard gates, top-down): (1) only "review-requested + pending"; (2) already has
+ * describe/review output (succeeded / in progress) → already reviewed / reviewing, excluded; (3) ledger
+ * dedup for this version already judged skip. Then truncate by batch_size, batch-judge, and orchestrate
+ * reviews in parallel.
  */
 export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void> {
   const { bootstrap, stateStore, ensureAgentDir, logger } = runtime.ctx;
@@ -27,10 +30,11 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
   try {
     const prs = await listStoredPullRequests(stateStore);
     const candidates: StoredPullRequest[] = [];
-    // 准入漏斗计数（用于 0 候选时定位卡在哪一道闸——便于排查「为何不再触发」）。
-    let reviewReqPending = 0; // 命中「待我评审 + 待处理」
-    let alreadyReviewed = 0; // 其中已有 describe/review 产出（成功 / 进行中）而被排除
-    let skipDeduped = 0; // 其中本版本已被判定跳过而被排除
+    // Admission funnel counters (to locate which gate blocked when there are 0 candidates — helps debug
+    // "why does it no longer trigger").
+    let reviewReqPending = 0; // matched "review-requested + pending"
+    let alreadyReviewed = 0; // among those, excluded for already having describe/review output (succeeded / in progress)
+    let skipDeduped = 0; // among those, excluded for already being judged skip this version
     for (const pr of prs) {
       if (candidates.length >= ap.batch_size) break;
       if (!pr.discoveryFilters.includes('review-requested')) continue;
@@ -48,7 +52,7 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
       candidates.push(pr);
     }
     if (candidates.length === 0) {
-      // 仍在按周期评估，只是当前无新合格 PR——把漏斗计数打出来，避免被误读成「没在跑」。
+      // Still evaluating on schedule, just no new eligible PR right now — log the funnel counters to avoid being misread as "not running".
       logger.info(
         { total: prs.length, reviewReqPending, alreadyReviewed, skipDeduped },
         'autopilot pass: no eligible candidates',
@@ -59,9 +63,11 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
     const agentContext = await loadAgentContext(await ensureAgentDir(), {
       onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
     });
-    // 第一步 judge 的背景输入：逐候选判「纯分支合并」。判定**以实际提交结构为准**——拉一次 commits API
-    // 看「提交是否全为 merge」；分支名只作 sourceMainline 背景信号、不单独定论。并行跑，整体约一轮 round-trip。
-    // 失败不阻断（无 commits → inconclusive、按非合并处理，仍带 sourceMainline 信号交 judge 权衡）。
+    // Background input for the first judge step: classify each candidate as "pure branch merge". The
+    // decision is **based on the actual commit structure** — one commits API call to see "whether all
+    // commits are merges"; the branch name is only a sourceMainline background signal, never decisive alone.
+    // Runs in parallel, roughly one round-trip overall.
+    // Failure does not block (no commits → inconclusive, treated as non-merge, still carrying the sourceMainline signal for the judge to weigh).
     const branchMergeByPr = new Map<string, BranchMergeVerdict>();
     await Promise.all(
       candidates.map(async (p) => {
@@ -86,7 +92,7 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
     );
 
     await runtime.withAgentChat(async (chat) => {
-      // 批量判定（例外规则来自 AGENTS.md；分支信息 + 分支合并信号作背景输入）。
+      // Batch judgment (exception rules come from AGENTS.md; branch info + branch-merge signal as background input).
       const { decisions } = await judgeAutopilotBatch(chat, {
         candidates: candidates.map((p) => {
           const v = branchMergeByPr.get(p.localId);
@@ -103,12 +109,12 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
         agentsRules: agentContext.files.agents,
       });
       const byId = new Map(candidates.map((p) => [p.localId, p] as const));
-      // 先落「跳过」决策（无工具开销，顺序写盘即可）；收集「评审」决策（连同其执行计划）待并行编排。
+      // Persist "skip" decisions first (no tool cost, sequential write is fine); collect "review" decisions (along with their execution plan) for parallel orchestration.
       const toReview: Array<{ pr: StoredPullRequest; plan?: ReviewPlan }> = [];
       for (const d of decisions) {
         const pr = byId.get(d.prLocalId);
         if (!pr) continue;
-        // 每条决策都记日志（含 review/skip + 原因 + 计划 + 分支合并信号），便于排查「judge 是否在按规则跑」。
+        // Log every decision (with review/skip + reason + plan + branch-merge signal) to help debug "whether the judge runs by the rules".
         logger.info(
           {
             prLocalId: pr.localId,
@@ -129,13 +135,13 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
           });
           continue;
         }
-        // d.plan 省略 → 微流程走默认全集；规则驱动计划的注入点（见 JudgeDecision.plan）。
+        // d.plan omitted → micro-flow uses the default full set; the injection point for rule-driven plans (see JudgeDecision.plan).
         toReview.push({ pr, plan: d.plan });
       }
-      // 多 PR 评审并行编排：各编排 await 自己的工具 run 时彼此不挡，让 run-queue 并发尽量被填满。
+      // Parallel orchestration of multi-PR reviews: each orchestration awaits its own tool run without blocking the others, filling up run-queue concurrency as much as possible.
       await Promise.all(
         toReview.map(async ({ pr, plan }) => {
-          // AutoPilot 后台评审无 AbortController，但同样标记「执行中」——纯思考阶段也在 PR 列表项显示。
+          // AutoPilot background review has no AbortController, but is still marked "running" — the pure thinking phase also shows on the PR list item.
           runtime.markRunning(pr.localId);
           try {
             const session = await runReviewForPr(
@@ -147,7 +153,7 @@ export async function autopilotPass(runtime: OrchestratorRuntime): Promise<void>
               true,
               plan,
             );
-            // done：落「评审总结」消息 + 台账（含 verdict）+ 广播（与手动评审一致）。失败 / 暂停不落台账。
+            // done: persist the "review summary" message + ledger (with verdict) + broadcast (same as manual review). Failure / pause does not write the ledger.
             await runtime.recordReviewSummaryMessage(pr, session);
           } finally {
             runtime.unmarkRunning(pr.localId);

--- a/apps/desktop/src/main/services/agent/flows/planning.ts
+++ b/apps/desktop/src/main/services/agent/flows/planning.ts
@@ -7,7 +7,7 @@ import { getMainLanguage } from '../../../i18n/index.js';
 import { runPlanning } from '../planning.js';
 import type { AgentChat, OrchestratorRuntime } from '../runtime.js';
 
-/** 自由规划编排（agent:ask）：现读现装配上下文 + 注册 AbortController + 标记执行中，跑规划 ReAct。 */
+/** Free planning orchestration (agent:ask): assemble context on demand + register AbortController + mark running, then run the planning ReAct. */
 export async function planningFlow(
   runtime: OrchestratorRuntime,
   pr: StoredPullRequest,
@@ -22,7 +22,7 @@ export async function planningFlow(
   const ac = new AbortController();
   runtime.registerController(pr.localId, ac);
   runtime.markRunning(pr.localId);
-  // 不记用户输入正文（避免泄漏 / 刷屏）：只记发起本身，输入已落多轮对话。
+  // Do not log the user input body (avoid leakage / flooding): log only the initiation itself; the input is already persisted to the conversation.
   logger.info({ prLocalId: pr.localId }, 'agent chat start (planning)');
   try {
     const session = await runtime.withAgentChat(
@@ -45,7 +45,7 @@ export async function planningFlow(
   }
 }
 
-/** 对一个 PR 跑自由规划（组装 PlanningDeps + 调 runner）：含中途输入 drain、计划持久化、主动记忆落盘。 */
+/** Run free planning for a PR (assemble PlanningDeps + call the runner): includes mid-run input drain, plan persistence, and proactive memory persistence. */
 export async function runPlanningForPr(
   runtime: OrchestratorRuntime,
   pr: StoredPullRequest,
@@ -57,7 +57,7 @@ export async function runPlanningForPr(
 ): Promise<AgentSession> {
   const { bootstrap, effectiveAgentDir, logger } = runtime.ctx;
   const agentCfg = bootstrap.config.agent;
-  // per-PR 存储路由：已归档（已关闭范围）PR 上的对话 / 计划落归档冷存储，不污染活跃存储。
+  // per-PR storage routing: conversation / plan for archived (closed-scope) PRs go to archive cold storage, not polluting active storage.
   const store = await runtime.ctx.pr.storeForPr(pr.localId);
   const matchedRules = pickMatchingRules(agentContext.rules, {
     projectKey: pr.repo.projectKey,
@@ -84,13 +84,15 @@ export async function runPlanningForPr(
     matchedRuleInstructions: combineRuleInstructions(matchedRules),
     language: getMainLanguage(),
     maxSteps: agentCfg.max_steps,
-    // /ask 预算：自由规划里连续 /ask 各为一次 agentic 探索、成本高，按配置「追问数量」封顶（与「自动追问」
-    // 开关无关——开关仅约束评审微流程；此处始终生效，遵循配置的追问数量上限）。
+    // /ask budget: in free planning each consecutive /ask is one agentic exploration and costly, capped by the
+    // configured "follow-up ask count" (unrelated to the "auto follow-up" switch — the switch only constrains the
+    // review micro-flow; this always applies, following the configured follow-up ask cap).
     maxFollowupAsks: agentCfg.strategy.max_followup_asks,
     signal,
     onStep: (sessionId, step) => runtime.emitStep(pr, sessionId, step),
-    // 中途输入转向：planner 每轮取出排队消息时在此落盘进会话 + 广播刷新（即时显示为用户气泡），
-    // planner 再把它们并入当轮 progress、据最新指令重排下一步。
+    // Mid-run input redirection: each round the planner pulls queued messages and here persists them to the
+    // conversation + broadcasts a refresh (instantly shown as user bubbles), then the planner merges them into the
+    // current round's progress and re-plans the next step per the latest instructions.
     drainPendingInput: async () => {
       const msgs = runtime.takePending(pr.localId);
       for (const m of msgs) {
@@ -99,14 +101,14 @@ export async function runPlanningForPr(
       if (msgs.length) runtime.ctx.broadcast('agent:conversationChanged', { prLocalId: pr.localId });
       return msgs;
     },
-    // 计划（todo）更新：planner 给出 plan 即持久化进会话 + 广播刷新计划面板；切 PR / 重启经
-    // agent:getSession 水合。
+    // Plan (todo) update: once the planner provides a plan, persist it to the conversation + broadcast a refresh of
+    // the plan panel; hydrated via agent:getSession on PR switch / restart.
     recordPlan: async (todo) => {
       await updateAgentSession(store, pr.localId, { todo });
       runtime.ctx.broadcast('agent:planUpdated', { prLocalId: pr.localId, todo });
     },
-    // 持久化 Agent 主动记下的非隐私条目到当前 Agent 目录的各可写文件（USER/MEMORY/AGENTS）；
-    // SOUL.md 永不写。下一轮 loadAgentContext 现读即生效（跨会话记忆）。
+    // Persist the non-private entries the Agent proactively noted to each writable file in the current Agent
+    // directory (USER/MEMORY/AGENTS); SOUL.md is never written. The next loadAgentContext reads it live (cross-session memory).
     recordMemory: async (notes) => {
       const dir = effectiveAgentDir();
       for (const kind of ['user', 'memory', 'agents'] as const) {

--- a/apps/desktop/src/main/services/agent/flows/review.ts
+++ b/apps/desktop/src/main/services/agent/flows/review.ts
@@ -9,9 +9,10 @@ import type { AgentChat, OrchestratorRuntime } from '../runtime.js';
 import { planningFlow } from './planning.js';
 
 /**
- * 手动评审编排（agent:run）：现读现装配上下文 + 注册 AbortController + 标记执行中，跑评审微流程，收尾把
- * 「评审总结」落多轮对话与台账。评审微流程是固定模板、无法中途转向：跑完后把运行期间排队的用户消息作为
- * 一轮自由规划接续处理（fire-and-forget，本次评审会话照常返回）。
+ * Manual review orchestration (agent:run): assemble context on demand + register AbortController + mark running,
+ * run the review micro-flow, and at the end persist the "review summary" to the conversation and ledger. The review
+ * micro-flow is a fixed template and cannot be redirected mid-run: after it finishes, the user messages queued during
+ * the run are handled as a follow-up free-planning round (fire-and-forget; this review session returns as usual).
  */
 export async function reviewFlow(
   runtime: OrchestratorRuntime,
@@ -19,11 +20,11 @@ export async function reviewFlow(
 ): Promise<AgentSession> {
   const { getPrAgentBridge, ensureAgentDir, logger } = runtime.ctx;
   if (!getPrAgentBridge()) throw new AppError(ERROR_CODES.AG_PR_AGENT_NOT_READY);
-  // 现读现装配 Agent 上下文（SOUL/AGENTS/MEMORY/USER + rules），无缓存；加载前先确保目录已初始化。
+  // Assemble the Agent context on demand (SOUL/AGENTS/MEMORY/USER + rules), no cache; ensure the directory is initialized before loading.
   const agentContext = await loadAgentContext(await ensureAgentDir(), {
     onWarn: (msg, file) => logger.warn({ file }, `agent context: ${msg}`),
   });
-  // 注册 AbortController，让停止按钮（agent:stop）能在思考 / 执行任意阶段即时中止本次评审。
+  // Register the AbortController so the stop button (agent:stop) can immediately abort this review at any thinking / execution phase.
   const ac = new AbortController();
   runtime.registerController(pr.localId, ac);
   runtime.markRunning(pr.localId);
@@ -38,13 +39,13 @@ export async function reviewFlow(
       { prLocalId: pr.localId, status: session.status, steps: session.stepCount },
       'agent review done',
     );
-    // 收尾总结计入多轮对话（assistant 评审消息）→ UI 渲染「评审总结」卡片。
+    // The wrap-up summary is added to the conversation (assistant review message) → UI renders the "review summary" card.
     await runtime.recordReviewSummaryMessage(pr, session);
   } finally {
     runtime.clearController(pr.localId);
     runtime.unmarkRunning(pr.localId);
   }
-  // 评审微流程无法中途转向：跑完后把排队的用户消息作为一轮自由规划接续处理（fire-and-forget）。
+  // The review micro-flow cannot be redirected mid-run: after it finishes, the queued user messages are handled as a follow-up free-planning round (fire-and-forget).
   const pending = runtime.takePending(pr.localId);
   if (pending.length) {
     void planningFlow(runtime, pr, pending.join('\n\n')).catch((err: unknown) => {
@@ -55,8 +56,9 @@ export async function reviewFlow(
 }
 
 /**
- * 对一个 PR 跑评审微流程（共用 enqueue 队列 / 持久化 / 步骤广播）。手动评审与 AutoPilot 背景评审共用。
- * 编排派发的 run 走 agent 低优先级泳道；修改类工具按 grants 门控（红线见 buildToolCatalog）。
+ * Run the review micro-flow for a PR (shared enqueue queue / persistence / step broadcast). Shared by manual review
+ * and AutoPilot background review.
+ * Runs dispatched by the orchestration use the agent low-priority lane; modifying tools are gated by grants (red line see buildToolCatalog).
  */
 export async function runReviewForPr(
   runtime: OrchestratorRuntime,
@@ -65,14 +67,14 @@ export async function runReviewForPr(
   chat: AgentChat,
   signal?: AbortSignal,
   autopilot = false,
-  /** 评审执行计划（仅 AutoPilot 按规则注入）；省略 → 微流程走默认全集。 */
+  /** Review execution plan (only injected by AutoPilot per rules); omitted → micro-flow uses the default full set. */
   plan?: ReviewPlan,
 ): Promise<AgentSession> {
   const agentCfg = runtime.ctx.bootstrap.config.agent;
-  // per-PR 存储路由：已归档（已关闭范围）PR 补跑评审时，会话 / run / 关闭关系都落归档冷存储。
+  // per-PR storage routing: when re-running review on an archived (closed-scope) PR, the conversation / run / closure relations all go to archive cold storage.
   const store = await runtime.ctx.pr.storeForPr(pr.localId);
-  // 自动追问关闭：评审微流程跳过 judge + asks（不判读、不条件追问），直接总结——省一次 judge LLM
-  // 调用与潜在追问开销。覆盖默认计划与 AutoPilot 规则注入计划两种来源。
+  // Auto follow-up off: the review micro-flow skips judge + asks (no interpretation, no conditional follow-up ask) and
+  // summarizes directly — saving one judge LLM call and the potential follow-up ask cost. Covers both sources: the default plan and the AutoPilot rule-injected plan.
   const effectivePlan: ReviewPlan | undefined = agentCfg.strategy.auto_followup
     ? plan
     : {
@@ -95,7 +97,7 @@ export async function runReviewForPr(
   );
   return runReview(pr, {
     stateStore: store,
-    // 编排派发的 run 走 agent 低优先级泳道：用户随时点 /review 会插到它们之前。复评 /ask 携引用上下文 + 前向链。
+    // Runs dispatched by the orchestration use the agent low-priority lane: a user clicking /review at any time jumps ahead of them. Re-review /ask carries the referenced context + forward chain.
     enqueueRun: (p, tool, question, referencedContext, referencedFinding) =>
       runtime.runQueue.enqueuePragentRun(
         p,
@@ -105,7 +107,7 @@ export async function runReviewForPr(
         referencedContext,
         referencedFinding,
       ),
-    // 复评裁决 replace/drop → 关闭被取代的原 review finding（写 FindingClosure + 广播刷新卡片）。
+    // Re-review verdict replace/drop → close the superseded original review finding (write FindingClosure + broadcast a card refresh).
     closeFinding: async (p, call) => {
       await addFindingClosure(store, p.localId, call);
       runtime.ctx.broadcast('findingClosures:changed', { localId: p.localId });

--- a/apps/desktop/src/main/services/agent/index.ts
+++ b/apps/desktop/src/main/services/agent/index.ts
@@ -1,5 +1,6 @@
 /**
- * Agent 编排域：会话 Agent（手动评审 / 自由规划 / AutoPilot）的主进程接线。Orchestrator 为对外能力入口，
- * review / planning（微流程与规划的主进程 runner）+ labels（i18n 文案注入）为域内协作件，不外暴露。
+ * Agent orchestration domain: main-process wiring for the conversational Agent (manual review / free planning /
+ * AutoPilot). Orchestrator is the outward capability entry; review / planning (the main-process runners for the
+ * micro-flow and planning) + labels (i18n text injection) are in-domain collaborators, not exposed externally.
  */
 export { Orchestrator } from './orchestrator.js';

--- a/apps/desktop/src/main/services/agent/labels.ts
+++ b/apps/desktop/src/main/services/agent/labels.ts
@@ -2,12 +2,13 @@ import type { AgentStepLabels } from '@meebox/agent';
 import { t } from '../../i18n/index.js';
 
 /**
- * 把 agent 步骤展示文案 / 总结骨架 / 中止原因从主进程 i18n 资源（locales/*.json 的 `agent.*`）解析出来，
- * 注入纯逻辑的 agent 编排器——agent 内仅留 en-US 兜底，多语言译文统一在 i18n 资源维护。
- * 经会话语言（= getMainLanguage，t() 当前语言）解析，与 UI 一致；步骤文案在生成时落地、随 transcript 持久化。
+ * Resolve agent step display text / summary skeleton / abort reason from the main-process i18n resources
+ * (`agent.*` in locales/*.json) and inject them into the pure-logic agent orchestrator — the agent keeps only the
+ * en-US fallback, and multilingual translations are maintained uniformly in the i18n resources.
+ * Resolved via the session language (= getMainLanguage, t()'s current language), consistent with the UI; step text is materialized at generation time and persisted with the transcript.
  */
 
-/** 从 i18n 资源构造步骤展示文案（judgeSevere 走 i18next 复数 count）。 */
+/** Build step display text from i18n resources (judgeSevere uses i18next plural count). */
 export function buildStepLabels(): AgentStepLabels {
   return {
     describeReview: t('agent.steps.describeReview'),
@@ -20,7 +21,7 @@ export function buildStepLabels(): AgentStepLabels {
   };
 }
 
-/** 从 i18n 资源构造评审总结三段骨架标题（概述 / 关键发现 / 建议）。 */
+/** Build the three-section review summary skeleton titles from i18n resources (overview / key findings / suggestions). */
 export function buildSummarySections(): [string, string, string] {
   return [
     t('agent.summarySections.overview'),
@@ -30,8 +31,9 @@ export function buildSummarySections(): [string, string, string] {
 }
 
 /**
- * 把 agent 返回的中止原因稳定 code 映射为本地化文案：'aborted' / 'max_steps' 经 i18n 资源；其它（failed
- * 分支的具体错误信息）原样返回。落盘前调用，使 session.terminationReason 即为目标语言文本（渲染层逐字显示）。
+ * Map the stable abort-reason code returned by the agent to localized text: 'aborted' / 'max_steps' via the i18n
+ * resources; others (the specific error message from the failed branch) are returned as-is. Called before persisting so
+ * that session.terminationReason is already target-language text (the renderer displays it verbatim).
  */
 export function mapTerminationReason(code: string | undefined): string | undefined {
   if (code === 'aborted') return t('agent.termination.aborted');

--- a/apps/desktop/src/main/services/agent/orchestrator.ts
+++ b/apps/desktop/src/main/services/agent/orchestrator.ts
@@ -22,20 +22,23 @@ import { reviewFlow } from './flows/review.js';
 import type { AgentChat, OrchestratorRuntime } from './runtime.js';
 
 /**
- * Agent 编排服务（有状态协调器）：手动评审（agent:run）、自由规划（agent:ask）、AutoPilot 后台预评审，
- * 以及随 poll tick 清理已消失 PR 的在跑操作。运行态（每 PR 的 AbortController、「执行中」集合、AutoPilot
- * busy 锁、中途输入队列）是实例可变状态，故以 class 封装并实现 OrchestratorRuntime——把状态访问 + 共享
- * helper（withAgentChat / 收尾落地 / 步骤广播等）暴露给按「一任务一文件」拆分的各 flow（见 ./flows）。
+ * Agent orchestration service (stateful coordinator): manual review (agent:run), free-form planning
+ * (agent:ask), AutoPilot background pre-review, plus cleanup of in-flight ops on PRs that have vanished
+ * on each poll tick. Runtime state (per-PR AbortController, "running" set, AutoPilot busy lock, mid-run
+ * input queue) is instance-mutable state, so it is wrapped in a class implementing OrchestratorRuntime——
+ * exposing state access + shared helpers (withAgentChat / summary landing / step broadcast, etc.) to the
+ * flows split one-task-per-file (see ./flows).
  */
 export class Orchestrator implements OrchestratorRuntime {
-  // 编排 Agent 每 PR 至多一个在跑，AbortController 供 agent:stop 即时中止——思考 / 工具执行任意阶段都能停。
+  // At most one orchestrator agent runs per PR; AbortController lets agent:stop abort instantly——can stop at any stage of thinking / tool execution.
   private readonly agentControllers = new Map<string, AbortController>();
-  // 运行中（思考或派发工具）的编排 Agent 所属 PR 集合，向 renderer 广播「执行中」。手动 run/ask 与
-  // AutoPilot 后台评审一并计入，让 PR 列表项在纯思考阶段（无活跃工具 run）也显示执行中标记。
+  // Set of PRs whose orchestrator agent is running (thinking or dispatching tools), broadcast "running" to
+  // renderer. Manual run/ask and AutoPilot background review both count, so PR list items show the running
+  // mark even in the pure-thinking stage (no active tool run).
   private readonly runningAgentPrs = new Set<string>();
-  // Agent 编排层全局单并发：一次只跑一遍 AutoPilot pass（busy 锁），防止上一遍未完又叠跑。
+  // Global single-concurrency at the agent orchestration layer: run at most one AutoPilot pass at a time (busy lock), preventing a new pass stacking on an unfinished one.
   private autopilotBusy = false;
-  // 中途输入转向：每 PR 一个待处理用户消息队列（运行中追加 → 入队，下一周期 drain 注入）。
+  // Mid-run input redirect: one pending user-message queue per PR (appended while running → enqueued, injected via drain next cycle).
   private readonly pendingInputByPr = new Map<string, string[]>();
 
   constructor(
@@ -43,14 +46,14 @@ export class Orchestrator implements OrchestratorRuntime {
     readonly runQueue: RunQueue,
   ) {}
 
-  // ── 公共 API（IPC 入口；委托给 ./flows 下按任务拆分的各 flow）──
+  // ── Public API (IPC entry points; delegates to the per-task flows under ./flows) ──
 
-  /** 对指定 PR 跑评审微流程（agent:run）。 */
+  /** Run the review micro-flow on the given PR (agent:run). */
   runReview(pr: StoredPullRequest): Promise<AgentSession> {
     return reviewFlow(this, pr);
   }
 
-  /** 对指定 PR 跑自由规划 Agent（agent:ask）。 */
+  /** Run the free-form planning agent on the given PR (agent:ask). */
   runPlanning(
     pr: StoredPullRequest,
     question: string,
@@ -60,8 +63,9 @@ export class Orchestrator implements OrchestratorRuntime {
   }
 
   /**
-   * 运行期间追加用户消息（agent:enqueueMessage）：有 Agent 在跑 → 入队，下一主 Agent 周期 drain 注入
-   * （queued=true）；无在跑 → 直接起一轮自由规划兜底（queued=false，fire-and-forget，不丢消息）。
+   * Append a user message during a run (agent:enqueueMessage): an agent is running → enqueue, injected via
+   * drain on the next main-agent cycle (queued=true); none running → directly start a free-form planning
+   * fallback (queued=false, fire-and-forget, no message dropped).
    */
   enqueueMessage(pr: StoredPullRequest, message: string): { queued: boolean } {
     const text = message.trim();
@@ -76,14 +80,14 @@ export class Orchestrator implements OrchestratorRuntime {
       );
       return { queued: true };
     }
-    // 竞态兜底：检查到没有在跑 → 直接起一轮自由规划（UI 经 step / conversation 事件更新）。
+    // Race fallback: found none running → directly start a free-form planning round (UI updates via step / conversation events).
     void this.runPlanning(pr, text).catch((err: unknown) => {
       this.ctx.logger.warn({ err, prLocalId: pr.localId }, 'enqueueMessage fallback planning failed');
     });
     return { queued: false };
   }
 
-  /** 暂停某 PR 的 Agent 运行（agent:stop）：abort 其 AbortController。 */
+  /** Pause a PR's agent run (agent:stop): abort its AbortController. */
   stop(localId: string): { ok: boolean } {
     const ac = this.agentControllers.get(localId);
     if (!ac) return { ok: false };
@@ -92,23 +96,27 @@ export class Orchestrator implements OrchestratorRuntime {
   }
 
   /**
-   * poll tick：满足开关 + 未在跑 + bridge 就绪时跑一遍 AutoPilot pass（准入门控 + 台账去重在 autopilotPass
-   * 内）。busy 锁防止上一遍未完又叠跑。见 docs/arch/02-agent/03-autopilot.md「AutoPilot」。
+   * poll tick: when switch on + not running + bridge ready, run one AutoPilot pass (admission gating +
+   * ledger dedup live inside autopilotPass). The busy lock prevents a new pass stacking on an unfinished
+   * one. See docs/arch/02-agent/03-autopilot.md "AutoPilot".
    */
   runAutopilotIfDue(): void {
     const ap = this.ctx.bootstrap.config.agent.autopilot;
     if (!ap.enabled || this.autopilotBusy || !this.ctx.getPrAgentBridge()) return;
-    // 准入通过 → fire-and-forget 异步 pass（poll tick 不阻塞）；busy 锁在 autopilotPass 内成对管理。
+    // Admission passed → fire-and-forget async pass (poll tick not blocked); busy lock managed in pairs inside autopilotPass.
     void autopilotPass(this);
   }
 
   /**
-   * poll tick 后调用：把已被 purge（彻底从索引移除）的 PR 上仍在执行的 agent 操作一律终止——PR 都没了，
-   * 继续评审无意义且浪费 LLM / 占用 worktree。
+   * Called after a poll tick: terminate any agent ops still in flight on PRs that have been purged (fully
+   * removed from the index)——the PR is gone, so continuing the review is pointless and wastes LLM /
+   * occupies a worktree.
    *
-   * 「在场」判定用**索引全集**（活跃 + 归档，readPrIndex 覆盖二者）、而非仅活跃集——否则对**已归档**（已关闭范围）
-   * PR 补跑 AI 评审时，下轮 poll 会把它误判为「已移除」而中途掐断（归档 PR 仍在索引、只是 archivedAt 非空）。
-   * 仅当条目彻底不在索引里（grace 期满硬清）才终止。
+   * "Presence" is judged against the **full index** (active + archived, readPrIndex covers both), not just
+   * the active set——otherwise, when re-running AI review on an **archived** (closed-scope) PR, the next poll
+   * would mistake it for "removed" and cut it off midway (an archived PR is still in the index, just with a
+   * non-empty archivedAt). Terminate only when an entry is entirely absent from the index (hard-cleaned
+   * after the grace period).
    */
   async terminateAgentsForGonePrs(): Promise<void> {
     const { stateStore, logger } = this.ctx;
@@ -126,7 +134,7 @@ export class Orchestrator implements OrchestratorRuntime {
     }
   }
 
-  // ── OrchestratorRuntime 实现（供 ./flows 复用的状态访问 + 共享 helper）──
+  // ── OrchestratorRuntime implementation (state access + shared helpers reused by ./flows) ──
 
   registerController(localId: string, ac: AbortController): void {
     this.agentControllers.set(localId, ac);
@@ -149,7 +157,7 @@ export class Orchestrator implements OrchestratorRuntime {
     this.autopilotBusy = busy;
   }
 
-  /** 取出并清空某 PR 的待处理用户消息队列。 */
+  /** Take and clear a PR's pending user-message queue. */
   takePending(localId: string): string[] {
     const q = this.pendingInputByPr.get(localId);
     if (!q || q.length === 0) return [];
@@ -158,8 +166,10 @@ export class Orchestrator implements OrchestratorRuntime {
   }
 
   /**
-   * 每个编排步骤的统一出口：① 后台日志（kind / tool / 用时，便于排障与离线回看；thought 与 result 不入
-   * 日志避免刷屏 + 泄漏，完整步骤已落 transcript.json）；② 广播给渲染层（agent:stepProgress）做过程化展示。
+   * Unified exit for every orchestration step: ① background log (kind / tool / elapsed, for troubleshooting
+   * and offline replay; thought and result are not logged to avoid flooding + leakage, the full step is
+   * already persisted to transcript.json); ② broadcast to the renderer (agent:stepProgress) for progressive
+   * display.
    */
   emitStep(pr: StoredPullRequest, sessionId: string, step: AgentStep): void {
     this.ctx.logger.info(
@@ -175,15 +185,17 @@ export class Orchestrator implements OrchestratorRuntime {
     this.ctx.broadcast('agent:stepProgress', { sessionId, prLocalId: pr.localId, step });
   }
 
-  /** 设置 LLM env + 临时 chat cwd + chat 函数，运行 fn，收尾清理临时目录。
-   *  signal：用户停止时 abort → 杀掉在跑的 LLM chat 子进程，让思考阶段也能立即中止（不必等模型返回）。 */
+  /** Set up LLM env + temp chat cwd + chat function, run fn, then clean up the temp dir on finish.
+   *  signal: on user stop, abort → kill the running LLM chat subprocess, so the thinking stage can also abort immediately (no need to wait for the model to return). */
   async withAgentChat<T>(fn: (chat: AgentChat) => Promise<T>, signal?: AbortSignal): Promise<T> {
     const { getPrAgentBridge, bootstrap } = this.ctx;
     const bridge = getPrAgentBridge();
     if (!bridge) throw new AppError(ERROR_CODES.AG_PR_AGENT_NOT_READY);
-    // 复用与 pr-agent run 同一套 LLM env（provider 凭据 / 模型 / 代理 / 响应语言）。代理 env 先铺底（非
-    // pr-agent 范畴）；LLM 凭据/模型 + 编排 chat 专属档（响应语言 / 低推理档 / 提示缓存）由 buildChatEnv 按
-    // 意图组装。低档与缓存仅作用于本 chat spawn：pr-agent 工具 run（/review 等）的 env 不含 → 仍满档推理。
+    // Reuse the same LLM env as a pr-agent run (provider credentials / model / proxy / response language).
+    // Proxy env is laid down first (outside pr-agent scope); LLM credentials/model + orchestration-chat
+    // specific settings (response language / low-reasoning tier / prompt cache) are assembled by buildChatEnv
+    // per intent. The low tier and cache apply only to this chat spawn: the env of pr-agent tool runs
+    // (/review etc.) does not include them → still full-tier reasoning.
     const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
     const env: Record<string, string> = {
       ...buildProxyEnv(bootstrap.config.proxy),
@@ -194,7 +206,7 @@ export class Orchestrator implements OrchestratorRuntime {
         maxModelTokens: bootstrap.config.llm.context_tokens,
       }),
     };
-    // chat 子进程落到中性临时目录（cli 模式避免吃到被评审仓库的 CLAUDE.md）。
+    // The chat subprocess runs in a neutral temp dir (in cli mode, avoids picking up the reviewed repo's CLAUDE.md).
     const chatCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'meebox-agent-chat-'));
     try {
       const chat: AgentChat = async ({ system, user, maxOutputTokens }) => {
@@ -210,13 +222,15 @@ export class Orchestrator implements OrchestratorRuntime {
   }
 
   /**
-   * 评审收尾的统一落地（手动一键评审与 AutoPilot 背景评审共用）：仅成功收尾（done）且有总结时——
-   * ① 追加一条 assistant 评审消息（UI 渲染「评审总结」卡片）；② 写评审台账（recommendation + 当前
-   *    updatedAt，给 PR 列表建议徽标 + AutoPilot 同版本去重）。失败 / 用户停止（paused）不落，便于重试。
+   * Unified landing for review summary finish (shared by manual one-click review and AutoPilot background
+   * review): only when finished successfully (done) and a summary exists——
+   * ① append one assistant review message (UI renders the "review summary" card); ② write the review ledger
+   *    (recommendation + current updatedAt, feeding the PR list suggestion badge + AutoPilot same-version
+   *    dedup). On failure / user stop (paused) nothing is landed, for easy retry.
    */
   async recordReviewSummaryMessage(pr: StoredPullRequest, session: AgentSession): Promise<void> {
     if (session.status !== 'done' || !session.summary) return;
-    // per-PR 存储路由：已归档（已关闭范围）PR 补跑评审的总结消息 / 台账落归档冷存储。
+    // per-PR storage routing: for a re-run review on an archived (closed-scope) PR, the summary message / ledger lands in archived cold storage.
     const store = await this.ctx.pr.storeForPr(pr.localId);
     await appendAgentMessage(store, pr.localId, {
       role: 'assistant',
@@ -230,17 +244,17 @@ export class Orchestrator implements OrchestratorRuntime {
       recommendation: session.recommendation?.verdict,
       at: new Date().toISOString(),
     });
-    // 通知渲染层：若正打开该 PR，重载会话让后台评审的「评审总结」卡片即时出现（手动评审自行重载，重复无害）。
+    // Notify the renderer: if this PR is open, reloading the conversation makes the background review's "review summary" card appear instantly (manual review reloads itself, so the duplicate is harmless).
     this.ctx.broadcast('agent:conversationChanged', { prLocalId: pr.localId });
   }
 
-  // ── 私有 helper ──
+  // ── Private helpers ──
 
   private broadcastAgentRunning(): void {
     this.ctx.broadcast('agent:runningChanged', { prLocalIds: [...this.runningAgentPrs] });
   }
 
-  /** 终止某 PR 上的全部 agent 操作：中止编排（agent:run/ask）+ 取消其派发的工具 run。 */
+  /** Terminate all agent ops on a PR: abort orchestration (agent:run/ask) + cancel the tool runs it dispatched. */
   private terminateAgentForPr(localId: string): void {
     this.agentControllers.get(localId)?.abort();
     this.runQueue.cancelRunsForPr(localId);

--- a/apps/desktop/src/main/services/agent/planning.ts
+++ b/apps/desktop/src/main/services/agent/planning.ts
@@ -26,9 +26,11 @@ import type { StateStore } from '@meebox/state-store';
 import { buildStepLabels, buildSummarySections, mapTerminationReason } from './labels.js';
 
 /**
- * 把自由规划编排器（runPlanningAgent）接到主进程：自然语言入口的「对话即委派」。
- * runTool 把读类工具映射到既有 pr-agent 运行队列；红线由编排器经 assertToolAllowed 把关。
- * signal 支持用户暂停（Stop）；暂停 → 会话置 paused 保态。
+ * Wires the free-form planning orchestrator (runPlanningAgent) to the main process: "conversation as
+ * delegation" from a natural-language entry point.
+ * runTool maps read tools onto the existing pr-agent run queue; red lines are gated by the orchestrator
+ * via assertToolAllowed. signal supports user pause (Stop); on pause → the session is set to paused to
+ * preserve state.
  */
 
 const STDOUT_LOG_SEP = '\n\n---\n[pr-agent stdout log]\n';
@@ -36,8 +38,10 @@ function reviewRunText(run: ReviewRun): string {
   return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
 }
 
-// 会话压缩：存储超阈值时把较早消息摘要成一条 digest、仅留最近若干条原文，控制存储与后续注入规模
-// （约定会话上下文不超 LLM 半窗：先压缩/裁剪再注入）。阈值高于注入预算，超出才触发、不频繁。
+// Conversation compaction: when storage exceeds the threshold, summarize earlier messages into a single
+// digest and keep only the most recent few verbatim, controlling storage and later injection size (the
+// convention is conversation context stays under half the LLM window: compact/trim before injecting). The
+// threshold is above the injection budget, so it triggers only when exceeded, not frequently.
 const CONVO_COMPACT_THRESHOLD_CHARS = 80000;
 const CONVO_KEEP_RECENT = 6;
 const COMPACT_SYSTEM =
@@ -45,7 +49,7 @@ const COMPACT_SYSTEM =
   'concise digest. Preserve key facts, decisions, the user’s stated preferences / 称呼, and any open ' +
   'threads. Reply in the same language as the conversation. Output plain text only, no preamble.';
 
-/** 存储超阈值时，把较早消息摘要为一条 digest 替换之；未超阈值 / 失败则原样保留。 */
+/** When storage exceeds the threshold, summarize earlier messages into a single digest and replace them; below the threshold / on failure, keep them as-is. */
 async function maybeCompactConversation(
   stateStore: PlanningDeps['stateStore'],
   chat: PlanningDeps['chat'],
@@ -66,12 +70,12 @@ async function maybeCompactConversation(
     const digest: AgentMessage = {
       role: 'assistant',
       content: `（早期对话摘要）\n${text.trim()}`,
-      // 用最早消息的时间戳，保证 digest 仍排在时间线最前。
+      // Use the earliest message's timestamp so the digest still sorts first on the timeline.
       at: older[0]?.at ?? now().toISOString(),
     };
     await writeAgentConversation(stateStore, prLocalId, [digest, ...recent]);
   } catch {
-    /* 压缩失败：保留原对话，下次再试（读时仍有预算裁剪兜底） */
+    /* Compaction failed: keep the original conversation, retry next time (read-time budget trimming still provides a fallback) */
   }
 }
 
@@ -81,24 +85,26 @@ export interface PlanningDeps {
   chat: (input: { system: string; user: string }) => Promise<PlanningToolResult>;
   agentContext: AgentContext;
   toolCatalog: ToolCatalogEntry[];
-  /** 命中规则的已拼接正文（多条经 combineRuleInstructions 拼成）；无命中传空 / null。 */
+  /** Concatenated body of matched rules (multiple joined via combineRuleInstructions); pass empty / null when no match. */
   matchedRuleInstructions?: string | null;
   language: string;
   maxSteps: number;
-  /** 本会话 /ask 数量上限（配置「追问数量」max_followup_asks）：连续 agentic 探索成本高，按此封顶。 */
+  /** /ask count cap for this session (config "follow-up count" max_followup_asks): continuous agentic exploration is costly, so cap it here. */
   maxFollowupAsks: number;
-  /** 用户选中的代码引用（隐式上下文）：注入规划 LLM 当轮提示，不进持久化用户消息。 */
+  /** User-selected code reference (implicit context): injected into the planning LLM's current-round prompt, not stored as a user message. */
   referencedContext?: string;
   signal?: AbortSignal;
   onStep?: (sessionId: string, step: AgentStep) => void;
-  /** 持久化 Agent 主动记下的非隐私条目到各可写上下文文件（USER/MEMORY/AGENTS）。 */
+  /** Persist non-private items the agent proactively noted into the writable context files (USER/MEMORY/AGENTS). */
   recordMemory?: (notes: AgentMemoryNotes) => Promise<void>;
   /**
-   * 取出运行期间排队的用户新消息（中途输入转向）：每轮顶部由 planner 调用。实现方（orchestrator）
-   * 负责持久化进会话并广播刷新；此处直接透传给 planner，由其并入当轮 progress。
+   * Take the new user messages queued during the run (mid-run input redirect): called by the planner at the
+   * top of each round. The implementer (orchestrator) is responsible for persisting them into the
+   * conversation and broadcasting a refresh; here they are passed straight through to the planner, which
+   * merges them into the current round's progress.
    */
   drainPendingInput?: () => Promise<string[]> | string[];
-  /** 计划（todo）更新回调：planner 给出 / 更新 plan 时调用，由 orchestrator 持久化 + 广播。 */
+  /** Plan (todo) update callback: called when the planner produces / updates a plan, persisted + broadcast by the orchestrator. */
   recordPlan?: (todo: AgentTodoItem[]) => void | Promise<void>;
 }
 
@@ -108,12 +114,12 @@ export async function runPlanning(
   deps: PlanningDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
-  // 多轮对话：先读既往消息（注入规划上下文），再把本轮用户输入追加为一条消息（持久化）。
+  // Multi-turn conversation: first read prior messages (inject planning context), then append this round's user input as a message (persisted).
   const history = await getAgentConversation(deps.stateStore, pr.localId);
   await appendAgentMessage(
     deps.stateStore,
     pr.localId,
-    // 带 Diff 选区引用时一并持久化，供 UI 在气泡下方折叠展示「引用的代码」。
+    // When a Diff selection reference is present, persist it alongside, for the UI to show the "referenced code" collapsed below the bubble.
     { role: 'user', content: userRequest, referencedContext: deps.referencedContext },
     now,
   );
@@ -161,7 +167,7 @@ export async function runPlanning(
       },
     );
 
-    // 把 Agent 收尾回答追加为一条助手消息（评审类带 recommendation）；暂停 / 空回答不记。
+    // Append the agent's closing answer as an assistant message (review-type carries recommendation); paused / empty answers are not recorded.
     if (result.finalText && result.terminationReason !== 'aborted') {
       await appendAgentMessage(
         deps.stateStore,
@@ -171,13 +177,13 @@ export async function runPlanning(
       );
     }
 
-    // 持久化本轮主动记忆（非隐私）到各可写文件；失败不阻断会话收尾。
+    // Persist this round's proactive memories (non-private) to the writable files; failure does not block session finish.
     const mem = result.memories;
     if (deps.recordMemory && (mem.user.length || mem.memory.length || mem.agents.length)) {
       await deps.recordMemory(mem);
     }
 
-    // 会话超阈值时压缩较早消息（best-effort，不阻断收尾）。
+    // When the conversation exceeds the threshold, compact earlier messages (best-effort, does not block finish).
     await maybeCompactConversation(deps.stateStore, deps.chat, pr.localId, now);
 
     return (
@@ -190,7 +196,7 @@ export async function runPlanning(
       })) ?? session
     );
   } catch (err) {
-    // 用户停止（abort 杀掉在跑的 chat / 工具子进程 → 抛错）→ 干净的 paused 收尾，不当失败报错。
+    // User stop (abort kills the running chat / tool subprocess → throws) → clean paused finish, not reported as a failure.
     const aborted = deps.signal?.aborted || (err instanceof Error && err.message === 'aborted');
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {

--- a/apps/desktop/src/main/services/agent/review.ts
+++ b/apps/desktop/src/main/services/agent/review.ts
@@ -14,23 +14,23 @@ import type { StateStore } from '@meebox/state-store';
 import { buildStepLabels, buildSummarySections, mapTerminationReason } from './labels.js';
 
 /**
- * 把纯逻辑的 `runReviewMicroflow` 接到主进程能力上（见 docs/arch/02-agent/01-agent.md
- * 「AutoPilot」有界微流程）：
- * - runTool：经既有 pr-agent 运行队列跑 describe/review/ask，取产物文本回喂；
- * - chat：经嵌入式运行时的独立 LLM 通道做受限判断 / 总结；
- * - 持久化 + 步骤流式：startAgentSession / appendAgentStep / updateAgentSession + onStep 广播。
+ * Wires the pure-logic `runReviewMicroflow` onto main-process capabilities (see
+ * docs/arch/02-agent/01-agent.md "AutoPilot" bounded micro-flow):
+ * - runTool: run describe/review/ask via the existing pr-agent run queue, take the artifact text and feed it back;
+ * - chat: make constrained judgments / summaries via the embedded runtime's independent LLM channel;
+ * - persistence + step streaming: startAgentSession / appendAgentStep / updateAgentSession + onStep broadcast.
  */
 
 const STDOUT_LOG_SEP = '\n\n---\n[pr-agent stdout log]\n';
 
-/** 取一次 run 的「LLM 真实产出」（剥掉 ipc 拼在后面的 pr-agent stdout 日志段）。 */
+/** Take a run's "real LLM output" (strip the pr-agent stdout log segment ipc appended at the end). */
 function reviewRunText(run: ReviewRun): string {
   return (run.stdout ?? '').split(STDOUT_LOG_SEP)[0]?.trim() ?? '';
 }
 
 export interface ReviewDeps {
   stateStore: StateStore;
-  /** 入队一个 pr-agent run，resolve 完成的 ReviewRun（与用户手动 run 共用队列）。复评 /ask 携引用上下文 + 前向链。 */
+  /** Enqueue a pr-agent run, resolving the completed ReviewRun (shares the queue with user manual runs). Re-review /ask carries reference context + forward chain. */
   enqueueRun: (
     pr: StoredPullRequest,
     tool: ReviewRunTool,
@@ -38,48 +38,49 @@ export interface ReviewDeps {
     referencedContext?: string,
     referencedFinding?: ReviewRun['referencedFinding'],
   ) => Promise<ReviewRun>;
-  /** 复评裁决 replace/drop → 关闭被取代的原 review finding（写 FindingClosure + 广播）。缺省 = 不关。 */
+  /** Re-review verdict replace/drop → close the superseded original review finding (write FindingClosure + broadcast). Default = don't close. */
   closeFinding?: (
     pr: StoredPullRequest,
     call: { runId: string; findingId: string; byAskRunId: string; verdict: AskVerdict },
   ) => Promise<void>;
-  /** 经独立 LLM 通道做一次受限对话（判严重性 / 出总结）。 */
+  /** Run one constrained conversation via the independent LLM channel (judge severity / produce summary). */
   chat: (input: { system: string; user: string }) => Promise<{ text: string; usage?: TokenUsage }>;
   agentContext: AgentContext;
-  /** 命中规则的已拼接正文（多条经 combineRuleInstructions 拼成）；无命中传空 / null。 */
+  /** Concatenated body of matched rules (multiple joined via combineRuleInstructions); pass empty / null when no match. */
   matchedRuleInstructions?: string | null;
   language: string;
-  /** 工具目录（含修改红线标注）；注入编排器系统上下文。 */
+  /** Tool catalog (with modification red-line annotations); injected into the orchestrator's system context. */
   toolCatalog?: ToolCatalogEntry[];
   maxFollowupAsks: number;
   summaryMaxChars: number;
-  /** 评审执行计划（步骤序列）；省略 / 非法时微流程回落默认全集。仅 AutoPilot 按规则注入，手动评审省略。 */
+  /** Review execution plan (step sequence); when omitted / invalid the micro-flow falls back to the default full set. Injected by rule only for AutoPilot, omitted for manual review. */
   plan?: ReviewPlan;
-  /** 步骤流式回调（广播给渲染层）。 */
+  /** Step streaming callback (broadcast to the renderer). */
   onStep?: (sessionId: string, step: AgentStep) => void;
-  /** 用户停止：透传给微流程，思考 / 执行任意阶段都能立即中止（停止按钮 → agent:stop）。 */
+  /** User stop: passed through to the micro-flow, can abort immediately at any stage of thinking / execution (stop button → agent:stop). */
   signal?: AbortSignal;
-  /** 是否 AutoPilot 后台派发：标到本次评审的**首步**上，UI 据此在步骤行打机器人 chip。 */
+  /** Whether this is an AutoPilot background dispatch: tagged onto this review's **first step**, so the UI marks a robot chip on the step row. */
   autopilot?: boolean;
 }
 
 /**
- * 对一个 PR 跑评审微流程并落盘会话。返回收尾后的 AgentSession（成功 done / 失败 failed）。
- * 微流程内部工具失败会抛错，这里兜成 failed 会话而非向上抛（背景自动化不该崩主流程）。
+ * Run the review micro-flow on a PR and persist the session. Returns the finished AgentSession (done on
+ * success / failed on failure). Tool failures inside the micro-flow throw; here they are caught into a
+ * failed session rather than re-thrown (background automation shouldn't crash the main flow).
  */
 export async function runReview(
   pr: StoredPullRequest,
   deps: ReviewDeps,
   now: () => Date = () => new Date(),
 ): Promise<AgentSession> {
-  // 步数上限按微流程模板推导：describe + review + ≤N 追问 + 总结（+判定余量）。
+  // The step cap is derived from the micro-flow template: describe + review + ≤N follow-up asks + summary (+ judgment margin).
   const session = await startAgentSession(
     deps.stateStore,
     { prLocalId: pr.localId, maxSteps: 3 + deps.maxFollowupAsks + 1 },
     now,
   );
 
-  // AutoPilot 触发时，机器人标记只打在本次评审的**首步**上（首步即「生成 PR 描述与审查发现」）。
+  // On AutoPilot trigger, the robot mark is placed only on this review's **first step** (the first step being "generate PR description and review findings").
   let firstStep = true;
   try {
     const result = await runReviewMicroflow(
@@ -95,7 +96,7 @@ export async function runReview(
           if (run.status !== 'succeeded') {
             throw new Error(`pr-agent ${tool} 未成功：${run.errorMessage ?? run.status}`);
           }
-          // 回带 runId / findings / askVerdict：供 judge 按 id 点名 finding、asks 复评关联与自动关闭。
+          // Carry back runId / findings / askVerdict: lets the judge name findings by id, and links asks re-review with auto-close.
           return {
             text: reviewRunText(run),
             usage: run.tokenUsage,
@@ -137,7 +138,7 @@ export async function runReview(
       })) ?? session
     );
   } catch (err) {
-    // 用户停止（abort）→ 干净的 paused 收尾，不当失败报错；其余异常仍记为 failed。
+    // User stop (abort) → clean paused finish, not reported as a failure; other exceptions are still recorded as failed.
     const aborted = deps.signal?.aborted || (err instanceof Error && err.message === 'aborted');
     return (
       (await updateAgentSession(deps.stateStore, pr.localId, {

--- a/apps/desktop/src/main/services/agent/runtime.ts
+++ b/apps/desktop/src/main/services/agent/runtime.ts
@@ -2,38 +2,40 @@ import type { AgentSession, AgentStep, StoredPullRequest, TokenUsage } from '@me
 import type { ServiceContext } from '../context.js';
 import type { RunQueue } from '../pr-agent/index.js';
 
-/** 共享 chat 通道：system + user → 文本 + usage。agent:run 评审与 AutoPilot 都用。 */
+/** Shared chat channel: system + user → text + usage. Used by both agent:run review and AutoPilot. */
 export type AgentChat = (input: {
   system: string;
   user: string;
-  /** 输出 token 上限（轻量路由判读封顶用，见 ChatRunOptions.maxOutputTokens）。 */
+  /** Output token cap (for capping lightweight routing reads, see ChatRunOptions.maxOutputTokens). */
   maxOutputTokens?: number;
 }) => Promise<{ text: string; usage?: TokenUsage }>;
 
 /**
- * 编排运行时：有状态协调器（Orchestrator）暴露给各 flow（review / planning / autopilot）的状态访问 +
- * 共享 helper 面。flow 以自由函数形式按「一任务一文件」拆分，经此 runtime 复用协调器的运行态与公共能力，
- * 而不各自持有可变状态。Orchestrator 实现本接口、把 `this` 作为 runtime 传入各 flow。
+ * Orchestration runtime: the state-access + shared-helper surface the stateful coordinator (Orchestrator)
+ * exposes to the flows (review / planning / autopilot). Flows are split one-task-per-file as free
+ * functions, reusing the coordinator's runtime state and common capabilities via this runtime rather than
+ * each holding mutable state. Orchestrator implements this interface and passes `this` as the runtime into
+ * each flow.
  */
 export interface OrchestratorRuntime {
   readonly ctx: ServiceContext;
   readonly runQueue: RunQueue;
-  /** 注册某 PR 的 AbortController（停止按钮 agent:stop 用）。 */
+  /** Register a PR's AbortController (used by the stop button agent:stop). */
   registerController(localId: string, ac: AbortController): void;
-  /** 清除某 PR 的 AbortController（收尾）。 */
+  /** Clear a PR's AbortController (on finish). */
   clearController(localId: string): void;
-  /** 标记某 PR「执行中」并广播（纯思考阶段也显示）。 */
+  /** Mark a PR "running" and broadcast (shown even in the pure-thinking stage). */
   markRunning(localId: string): void;
-  /** 取消某 PR「执行中」标记并广播。 */
+  /** Clear a PR's "running" mark and broadcast. */
   unmarkRunning(localId: string): void;
-  /** 步骤统一出口：后台日志 + agent:stepProgress 广播。 */
+  /** Unified step exit: background log + agent:stepProgress broadcast. */
   emitStep(pr: StoredPullRequest, sessionId: string, step: AgentStep): void;
-  /** 取出并清空某 PR 的待处理用户消息（中途输入转向）。 */
+  /** Take and clear a PR's pending user messages (mid-run input redirect). */
   takePending(localId: string): string[];
-  /** 设置 LLM env + 临时 chat cwd + chat 函数后运行 fn，收尾清理临时目录。 */
+  /** Set up LLM env + temp chat cwd + chat function, run fn, then clean up the temp dir on finish. */
   withAgentChat<T>(fn: (chat: AgentChat) => Promise<T>, signal?: AbortSignal): Promise<T>;
-  /** 评审收尾统一落地：成功且有总结时追加 assistant 总结消息 + 写台账 + 广播会话变更。 */
+  /** Unified review summary landing: on success with a summary, append the assistant summary message + write the ledger + broadcast the conversation change. */
   recordReviewSummaryMessage(pr: StoredPullRequest, session: AgentSession): Promise<void>;
-  /** AutoPilot 单并发 busy 锁置位 / 复位。 */
+  /** Set / clear the AutoPilot single-concurrency busy lock. */
   setAutopilotBusy(busy: boolean): void;
 }

--- a/apps/desktop/src/main/services/api-server/compat.ts
+++ b/apps/desktop/src/main/services/api-server/compat.ts
@@ -1,35 +1,35 @@
 import { coerce as semverCoerce, lt as semverLt, valid as semverValid } from 'semver';
 
 /**
- * CLI ↔ server 兼容性门控（见 docs/arch/04-integration/01-service-api.md）。
+ * CLI ↔ server compatibility gating (see docs/arch/04-integration/01-service-api.md).
  *
- * CLI 每个请求带上自身版本头，服务端据集中管理的**最低可兼容版本**统一拦截过旧的 CLI——对所有 API 调用
- * 一视同仁，不做按端点的差异化兼容。默认宽松：缺版本头（旧 CLI / 非 CLI 客户端）或版本不可解析（如本地
- * `dev` 构建）均放行，保证既有 CLI 默认可用；仅当版本头**可解析且低于下限**时才门控。
+ * The CLI carries its own version header on every request, and the server uniformly blocks too-old CLIs per a centrally managed **minimum compatible version** — treating all API calls
+ * alike, without per-endpoint differentiated compatibility. Lenient by default: a missing version header (old CLI / non-CLI client) or an unparseable version (e.g. local
+ * `dev` builds) is let through, ensuring existing CLIs work by default; gating applies only when the version header is **parseable and below the lower bound**.
  *
- * **按版本线（major.minor.patch）比对，忽略预发布后缀**：CLI 与 app 同源发版，预发布构建（如
- * `0.9.0-alpha.1`）与其正式版属同一版本线、共享同一线协议。semver 里预发布**低于**其正式版
- * （`0.9.0-alpha.1` < `0.9.0`），若直接比对会把与下限同线的预发布 CLI 误判为过旧（下限 `0.9.0` 时连
- * `0.9.0-alpha.1` 都被拦）。故先把版本 coerce 到 `major.minor.patch` 再比——下限是版本线粒度的
- * 破坏性变更闸门，不区分同线内的预发布序号。
+ * **Compare by version line (major.minor.patch), ignoring the prerelease suffix**: the CLI and app ship from the same source, and a prerelease build (e.g.
+ * `0.9.0-alpha.1`) belongs to the same version line as its release and shares the same line protocol. In semver a prerelease is **lower than** its release
+ * (`0.9.0-alpha.1` < `0.9.0`), so a direct comparison would misjudge a prerelease CLI on the same line as the lower bound as too old (with lower bound `0.9.0`, even
+ * `0.9.0-alpha.1` is blocked). So coerce the version to `major.minor.patch` before comparing — the lower bound is a version-line-grained
+ * breaking-change gate, not distinguishing prerelease ordinals within the same line.
  */
 
-/** CLI 在此请求头声明自身版本（Node 会小写化头名）。与 CLI 端手写常量对齐（无代码级共享）。 */
+/** The CLI declares its own version in this request header (Node lowercases header names). Aligned with the CLI-side hand-written constant (no code-level sharing). */
 export const CLI_VERSION_HEADER = 'x-meebox-cli-version';
 
 /**
- * 服务端可兼容的最低 CLI 版本。破坏性线协议变更时上调此值，即门控掉更旧的 CLI。
- * 取当前 CLI 首发版本为下限（此前无更旧的已发布 CLI），默认不拦截任何在用版本。
+ * The minimum CLI version the server is compatible with. Raise this on a breaking line protocol change to gate out older CLIs.
+ * Set to the current CLI's first-release version as the lower bound (no older published CLI exists before it), blocking no in-use version by default.
  */
 export const MIN_CLI_VERSION = '0.9.0';
 
-/** 请求携带的 CLI 版本是否过旧（应拦截）。缺头 / 不可解析 → false（放行）。 */
+/** Whether the request's carried CLI version is too old (should be blocked). Missing header / unparseable → false (let through). */
 export function isClientTooOld(rawHeader: string | string[] | undefined): boolean {
   const raw = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
   if (!raw) return false;
   const v = semverValid(raw.trim());
-  if (!v) return false; // 不可解析（dev 等）→ 放行
-  // 剥离预发布后缀，按版本线（major.minor.patch）比对，使同线预发布不低于下限（见文件头注释）。
+  if (!v) return false; // unparseable (dev etc.) → let through
+  // Strip the prerelease suffix and compare by version line (major.minor.patch), so a same-line prerelease is not below the lower bound (see file-header comment).
   const line = semverCoerce(v);
   if (!line) return false;
   return semverLt(line, MIN_CLI_VERSION);

--- a/apps/desktop/src/main/services/api-server/http.ts
+++ b/apps/desktop/src/main/services/api-server/http.ts
@@ -2,13 +2,13 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { AppError, ERROR_CODES, type AppErrorMeta, type ErrorCode } from '@meebox/shared';
 
 /**
- * 本地 API 的 HTTP 工具：统一响应封套（{ ok, data } / { ok:false, error }）、请求体读取、
- * 错误 → HTTP 状态码映射。见 docs/arch/04-integration/01-service-api.md。
+ * HTTP utilities for the local API: unified response envelope ({ ok, data } / { ok:false, error }),
+ * request body reading, error → HTTP status code mapping. See docs/arch/04-integration/01-service-api.md.
  */
 
-const MAX_BODY_BYTES = 1024 * 1024; // 1 MiB 请求体上限
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MiB request body limit
 
-/** API 层错误（鉴权 / 路由 / 校验 / 写禁止等）：自带 HTTP 状态码与错误码。 */
+/** API-layer error (auth / route / validation / write-forbidden, etc.): carries its own HTTP status code and error code. */
 export class HttpError extends Error {
   constructor(
     readonly status: number,
@@ -26,12 +26,12 @@ function writeJson(res: ServerResponse, status: number, payload: unknown): void 
   res.end(body);
 }
 
-/** 成功响应：200 + { ok:true, data }。 */
+/** Success response: 200 + { ok:true, data }. */
 export function sendOk(res: ServerResponse, data: unknown): void {
   writeJson(res, 200, { ok: true, data: data ?? null });
 }
 
-/** 失败响应：按错误映射状态码 + { ok:false, error:{ code, meta } }；返回所选状态码 / 码供日志。 */
+/** Failure response: map error to status code + { ok:false, error:{ code, meta } }; return the chosen status / code for logging. */
 export function sendError(res: ServerResponse, err: unknown): { status: number; code: string } {
   const mapped = mapError(err);
   writeJson(res, mapped.status, {
@@ -47,7 +47,7 @@ function mapError(err: unknown): { status: number; code: ErrorCode; meta?: AppEr
   return { status: 500, code: ERROR_CODES.SV_UNCLASSIFIED };
 }
 
-/** 把控制器抛出的 AppError 业务码映射到合适的 HTTP 状态码（未覆盖者归 500）。 */
+/** Map the AppError business code thrown by controllers to a suitable HTTP status code (uncovered ones fall back to 500). */
 function statusForAppCode(code: ErrorCode): number {
   switch (code) {
     case ERROR_CODES.PR_NOT_FOUND:
@@ -66,7 +66,7 @@ function statusForAppCode(code: ErrorCode): number {
   }
 }
 
-/** 读取并解析 JSON 请求体（空体 → undefined）；超限 413、非法 JSON 400，均归一为 SV 错误码。 */
+/** Read and parse the JSON request body (empty body → undefined); over-limit 413, invalid JSON 400, both normalized to SV error codes. */
 export async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   let total = 0;

--- a/apps/desktop/src/main/services/api-server/routes/agent.ts
+++ b/apps/desktop/src/main/services/api-server/routes/agent.ts
@@ -5,11 +5,12 @@ import { toPrAgentRuns } from '../views.js';
 import { NO_EVENT, seg, type Route, type RouteHandler } from './shared.js';
 
 /**
- * 评审 Agent 领域端点：状态 / 会话（浏览），auto review / 指令 / 聊天 / 中断（写入型，复用既有 run 队列），
- * 以及按 run 的发现与取消。Agent `instruct` **仅只读工具**，变更类工具（publish 等）在 API 层硬拒绝。
+ * Review agent domain endpoints: status / conversation (browsing), auto review / instruct / chat / stop
+ * (write-type, reusing the existing run queue), plus per-run discovery and cancellation. Agent `instruct`
+ * is **read-only tools only**; mutating tools (publish, etc.) are hard-rejected at the API layer.
  */
 
-/** API 仅允许的只读 Agent 指令（与工具注册表 isRun 只读族一致；写工具不在此列）。 */
+/** Read-only Agent instructions the API allows (matching the tool registry's isRun read-only family; write tools are excluded). */
 const READ_ONLY_TOOLS: ReadonlySet<ReviewRunTool> = new Set([
   'describe',
   'review',
@@ -25,7 +26,7 @@ const agentHistory: RouteHandler = ({ params }) =>
 
 const agentReview: RouteHandler = ({ params }) => agentCtl.runReview(NO_EVENT, { localId: params.id });
 
-/** 发送只读 Agent 指令（describe / review / ask / improve）；写工具硬拒绝（403），无二次确认。 */
+/** Send a read-only Agent instruction (describe / review / ask / improve); write tools hard-rejected (403), no confirmation. */
 const agentInstruct: RouteHandler = ({ params, body }) => {
   const b = (body ?? {}) as { command?: string; args?: string };
   const command = (b.command ?? '').replace(/^\//, '') as ReviewRunTool;
@@ -38,7 +39,7 @@ const agentInstruct: RouteHandler = ({ params, body }) => {
   return agentCtl.runPragent(NO_EVENT, { localId: params.id, tool: command, question: b.args });
 };
 
-/** 发送自然语言聊天（可触发 Agent 任务）：运行中入队、否则起一轮自由规划兜底。 */
+/** Send a natural-language chat (may trigger an Agent task): enqueue if running, otherwise start a free-planning fallback round. */
 const agentChat: RouteHandler = ({ params, body }) => {
   const b = (body ?? {}) as { message?: string };
   if (!b.message?.trim()) {
@@ -47,17 +48,17 @@ const agentChat: RouteHandler = ({ params, body }) => {
   return agentCtl.enqueueMessage(NO_EVENT, { localId: params.id, message: b.message });
 };
 
-/** 中断该 PR 正在运行的 Agent（思考 / 执行任意阶段即时停）。PR 级停，非按单个工具 run。 */
+/** Stop the Agent currently running on this PR (immediate stop at any thinking / execution stage). PR-level stop, not per-tool run. */
 const agentStop: RouteHandler = ({ params }) =>
   agentCtl.stopAgent(NO_EVENT, { localId: params.id });
 
-/** 该 PR 在运行队列里的 pr-agent runs（active + waiting），供按 run 取消前的发现。 */
+/** This PR's pr-agent runs in the run queue (active + waiting), for discovery before per-run cancellation. */
 const agentRuns: RouteHandler = async ({ params }) => {
   const snapshot = await agentCtl.getQueue(NO_EVENT, undefined);
   return toPrAgentRuns(snapshot, params.id);
 };
 
-/** 取消该 PR 的某个 pr-agent run（active SIGKILL / waiting 出队）。先校验 run 归属该 PR。 */
+/** Cancel one of this PR's pr-agent runs (active SIGKILL / waiting dequeue). Validate the run belongs to this PR first. */
 const agentRunCancel: RouteHandler = async ({ params }) => {
   const snapshot = await agentCtl.getQueue(NO_EVENT, undefined);
   const belongs = [...snapshot.active, ...snapshot.waiting].some(

--- a/apps/desktop/src/main/services/api-server/routes/index.ts
+++ b/apps/desktop/src/main/services/api-server/routes/index.ts
@@ -4,15 +4,15 @@ import { seg, type Route } from './shared.js';
 import { systemRoutes } from './system.js';
 
 /**
- * 本地 API 的路由**聚合注册 + 匹配**。各业务领域的处理器分置于同目录的 system / pr / agent 模块
- * （均复用 IPC controller 同源逻辑）；本文件只做注册与路径匹配，不含业务逻辑。
- * 端点全表与写边界见 docs/arch/04-integration/01-service-api.md。
+ * Route **aggregate registration + matching** for the local API. Handlers for each business domain live in the sibling
+ * system / pr / agent modules (all reusing the same logic as the IPC controllers); this file only does registration and path
+ * matching, no business logic. Full endpoint table and write boundaries: docs/arch/04-integration/01-service-api.md.
  */
 export const routes: Route[] = [...systemRoutes, ...prRoutes, ...agentRoutes];
 
 export type { Route, RouteContext, RouteHandler } from './shared.js';
 
-/** 按方法 + 路径匹配路由，提取 `:param` 路径参数；无匹配返回 null。 */
+/** Match a route by method + path, extracting `:param` path parameters; return null when no match. */
 export function matchRoute(
   method: string,
   pathname: string,

--- a/apps/desktop/src/main/services/api-server/routes/pr.ts
+++ b/apps/desktop/src/main/services/api-server/routes/pr.ts
@@ -13,15 +13,16 @@ import { toPrListItem } from '../views.js';
 import { NO_EVENT, seg, type Route, type RouteHandler } from './shared.js';
 
 /**
- * PR 领域端点：列表 / 详情 / diff / 动态 / 提交 / 评审人（浏览），刷新（refresh）与分类词表（categories），
- * 以及评审写动作（approve / needswork / comment，真实远端写，复用 GUI 同源 controller）。
- * 仍**不**暴露 merge（合并）。写边界见 docs/arch/04-integration/01-service-api.md。
+ * PR domain endpoints: list / detail / diff / activity / commits / reviewers (browsing), refresh and
+ * category vocabulary (categories), plus review write actions (approve / needswork / comment, real remote
+ * writes, reusing the GUI's same-source controller). Still does **not** expose merge. Write boundary see
+ * docs/arch/04-integration/01-service-api.md.
  */
 
-/** 列表分页默认页大小（`limit` 缺省 / 非法 / ≤0 时取此值）。 */
+/** List pagination default page size (used when `limit` is missing / invalid / ≤0). */
 const DEFAULT_LIMIT = 100;
 
-/** 当前启用平台下可用的分类标签：`categories`（平台发现分类）+ `statuses`（状态 / 合并态筛选）。 */
+/** Category labels available under the currently active platform: `categories` (platform discovery filters) + `statuses` (status / merge-state filters). */
 const categories: RouteHandler = () => {
   const ctx = getContext();
   const activeId = ctx.bootstrap.config.active_connection_id;
@@ -40,16 +41,18 @@ const categories: RouteHandler = () => {
 };
 
 /**
- * 触发一次立即轮询刷新（等价 GUI 的手动刷新 / 窗口聚焦刷新）：拉取所有连接的最新 PR、落本地，
- * 返回本轮计数汇总（fetched / changed / added / removed / errors）。复用 GUI 同源 poller.tick
- * （`prs:refresh`）。无远端写副作用（纯读远端 + 落本地），列为安全的开放动作。
+ * Trigger an immediate polling refresh (equivalent to the GUI's manual refresh / window-focus refresh):
+ * fetch the latest PRs across all connections, persist locally, and return this round's count summary
+ * (fetched / changed / added / removed / errors). Reuses the GUI's same-source poller.tick
+ * (`prs:refresh`). No remote write side effects (pure remote read + local persist), listed as a safe open action.
  */
 const refresh: RouteHandler = () => prCtl.refreshPrs(NO_EVENT, undefined);
 
 /**
- * PR 列表：`category`（一级发现分类）+ `status`（二级状态 / 合并态）过滤 + `q` 检索 +
- * `skip`/`limit` 分页（默认 limit 100）。过滤语义复用 @meebox/shared 的纯谓词（与渲染层侧栏同源）；
- * 返回**精简列表投影**（{@link toPrListItem}，去 description 明细、人员仅 slug），此处仅解析参数 + 委派。
+ * PR list: `category` (primary discovery filter) + `status` (secondary status / merge-state) filtering + `q`
+ * search + `skip`/`limit` pagination (default limit 100). Filter semantics reuse @meebox/shared's pure
+ * predicates (same source as the renderer sidebar); returns a **compact list projection** ({@link toPrListItem},
+ * drops description detail, people as slug only). Here only parses params + delegates.
  */
 const listPrs: RouteHandler = async ({ query }) => {
   const all = await prCtl.listPrs(NO_EVENT, undefined);
@@ -69,7 +72,7 @@ const showPr: RouteHandler = ({ params }) => getContext().pr.findPrOrThrow(param
 const reviewers: RouteHandler = async ({ params }) =>
   (await getContext().pr.findPrOrThrow(params.id)).reviewers;
 
-/** 无 path → 变更文件列表；带 path → 取该文件某一侧（默认 head）内容。 */
+/** No path → changed file list; with path → get that file's content on one side (default head). */
 const diff: RouteHandler = ({ params, query }) => {
   const path = query.get('path');
   if (path) {
@@ -84,15 +87,15 @@ const activity: RouteHandler = ({ params }) =>
 
 const commits: RouteHandler = ({ params }) => prCtl.listCommits(NO_EVENT, { localId: params.id });
 
-/** 评审决断「通过」：先写远端评审状态、再落本地（复用 GUI 同源 setPrStatus）。 */
+/** Review verdict "approve": write the remote review status first, then persist locally (reuses the GUI's same-source setPrStatus). */
 const approve: RouteHandler = ({ params }) =>
   prCtl.setPrStatus(NO_EVENT, { localId: params.id, status: 'approved' });
 
-/** 评审决断「需修改」：先写远端评审状态、再落本地。 */
+/** Review verdict "needs work": write the remote review status first, then persist locally. */
 const needswork: RouteHandler = ({ params }) =>
   prCtl.setPrStatus(NO_EVENT, { localId: params.id, status: 'needs_work' });
 
-/** 发一条顶层（不锚文件）评论到远端 PR。body.body 为评论正文，空则 400。 */
+/** Post a top-level (not file-anchored) comment to the remote PR. body.body is the comment text; empty → 400. */
 const comment: RouteHandler = ({ params, body }) => {
   const b = (body ?? {}) as { body?: string };
   if (!b.body?.trim()) {

--- a/apps/desktop/src/main/services/api-server/routes/shared.ts
+++ b/apps/desktop/src/main/services/api-server/routes/shared.ts
@@ -1,12 +1,13 @@
 import type { IpcMainInvokeEvent } from 'electron';
 
 /**
- * 路由框架原语，供同目录各业务领域模块（system / pr / agent）与聚合器（index）共用。
- * 各域处理器**复用 IPC controller 同源逻辑**——controller 形态为 `(event, req)` 且这些路径不触碰
- * event，故以 {@link NO_EVENT} 占位调用，避免在 HTTP 侧另起一套实现。
+ * Route framework primitives, shared by the same-directory business domain modules (system / pr / agent)
+ * and the aggregator (index). Each domain handler **reuses the IPC controller's same-source logic**—the
+ * controller shape is `(event, req)` and these paths never touch event, so they call with {@link NO_EVENT}
+ * as a placeholder, avoiding a separate implementation on the HTTP side.
  */
 
-/** 单条路由处理器的入参：路径参数 / 查询串 / 已解析 body。 */
+/** A single route handler's inputs: path params / query string / parsed body. */
 export interface RouteContext {
   params: Record<string, string>;
   query: URLSearchParams;
@@ -21,10 +22,10 @@ export interface Route {
   handler: RouteHandler;
 }
 
-/** 把 `/api/v1/prs/:id` 切成非空段数组（注册与匹配共用）。 */
+/** Split `/api/v1/prs/:id` into a non-empty segment array (shared by registration and matching). */
 export function seg(path: string): string[] {
   return path.split('/').filter(Boolean);
 }
 
-/** controller 形参 event 在被复用的只读 / 队列路径中均未使用，占位即可。 */
+/** The controller's event parameter is unused across the reused read-only / queue paths, so a placeholder suffices. */
 export const NO_EVENT = undefined as unknown as IpcMainInvokeEvent;

--- a/apps/desktop/src/main/services/api-server/routes/system.ts
+++ b/apps/desktop/src/main/services/api-server/routes/system.ts
@@ -3,13 +3,14 @@ import { getContext } from '../../context.js';
 import { seg, type Route, type RouteHandler } from './shared.js';
 
 /**
- * 系统性 / 会话级端点：与具体 PR / Agent 无关的工具层信息——身份（whoami）与版本（version）。
- * 对应 CLI 的根层级系统性命令。
+ * System / session-level endpoints: tool-layer info unrelated to any specific PR / Agent—identity (whoami)
+ * and version (version). Corresponds to the CLI's root-level system commands.
  */
 
 /**
- * 当前身份与集成平台：活动连接的 PAT 所属用户（name / displayName / slug）+ 平台种类 +
- * 连接显示名。无活动连接时各项为 null。刻意收窄——不带 capabilities（那是 GUI 降级用的大对象）。
+ * Current identity and integration platform: the active connection's PAT owner (name / displayName / slug) +
+ * platform kind + connection display name. All null when there's no active connection. Deliberately narrowed—no
+ * capabilities (that's the large object the GUI uses for degradation).
  */
 const whoami: RouteHandler = () => {
   const ctx = getContext();
@@ -30,7 +31,7 @@ const whoami: RouteHandler = () => {
   };
 };
 
-/** 服务端（桌面应用）版本，供 CLI `version` 同时展示客户端 + 服务端版本。 */
+/** Server (desktop app) version, for CLI `version` to show client + server versions together. */
 const version: RouteHandler = () => ({ version: buildAppInfo(getContext().bootstrap).appVersion });
 
 export const systemRoutes: Route[] = [

--- a/apps/desktop/src/main/services/api-server/server.ts
+++ b/apps/desktop/src/main/services/api-server/server.ts
@@ -8,11 +8,12 @@ import { HttpError, readJsonBody, sendError, sendOk } from './http.js';
 import { matchRoute } from './routes/index.js';
 
 /**
- * 本地 API 服务监听器（见 docs/arch/04-integration/01-service-api.md）。
+ * Local API service listener (see docs/arch/04-integration/01-service-api.md).
  *
- * 主进程内置 HTTP listener，作为渲染层 IPC 之外的「第二前端」：复用同一 ControllerContext 与 service 层，
- * 把只读 PR / Agent 能力暴露给外部 CLI / 工具。默认关闭；开启即强制 bearer token 鉴权。生命周期由 main 装配：
- * start（按 config 决定是否 listen）/ stop（退出时优雅关闭）/ reconfigure（配置变更停旧起新）。
+ * A built-in HTTP listener in the main process, acting as a "second frontend" beyond the renderer IPC: it reuses the same
+ * ControllerContext and service layer to expose read-only PR / Agent capabilities to external CLI / tools. Off by default;
+ * enabling it enforces bearer token auth. Lifecycle wired up by main:
+ * start (decides whether to listen per config) / stop (graceful close on exit) / reconfigure (stop old, start new on config change).
  */
 export interface ApiServerDeps {
   bootstrap: BootstrapResult;
@@ -24,12 +25,12 @@ export class ApiServer {
 
   constructor(private readonly deps: ApiServerDeps) {}
 
-  /** 实时读内存 service 配置（token 变更无需重建即生效）。 */
+  /** Read the in-memory service config live (token changes take effect without rebuild). */
   private get cfg() {
     return this.deps.bootstrap.config.service;
   }
 
-  /** 按配置启动监听（未启用 / token 为空则不启动）。监听失败为非致命：记录后不抛，不拖垮应用启动。 */
+  /** Start listening per config (skip if disabled / token empty). Listen failure is non-fatal: log and don't throw, so it won't drag down app startup. */
   async start(): Promise<void> {
     if (this.server) return;
     const cfg = this.cfg;
@@ -59,7 +60,7 @@ export class ApiServer {
     });
   }
 
-  /** 优雅关闭：停止接收新连接、放行 in-flight 后落定。 */
+  /** Graceful close: stop accepting new connections, let in-flight requests drain, then settle. */
   async stop(): Promise<void> {
     const server = this.server;
     if (!server) return;
@@ -68,13 +69,13 @@ export class ApiServer {
     this.deps.logger.info('local API server stopped');
   }
 
-  /** 配置（开关 / host / port）变更：停旧起新。 */
+  /** Config (toggle / host / port) change: stop old, start new. */
   async reconfigure(): Promise<void> {
     await this.stop();
     await this.start();
   }
 
-  /** 常数时间比对 bearer token；缺 token 配置 / 非 Bearer 头 / 长度不符均判失败。 */
+  /** Constant-time compare of the bearer token; missing token config / non-Bearer header / length mismatch all fail. */
   private authorized(req: IncomingMessage): boolean {
     const token = this.cfg.token;
     if (!token) return false;
@@ -97,7 +98,7 @@ export class ApiServer {
     let outcome: { status: number; code?: string };
     try {
       if (!this.authorized(req)) throw new HttpError(401, ERROR_CODES.SV_UNAUTHORIZED);
-      // 兼容性门控：对所有 API 调用统一拦截过旧的 CLI（缺版本头 / 不可解析 → 放行）。
+      // Compatibility gate: uniformly reject too-old CLIs on all API calls (missing version header / unparseable → let through).
       if (isClientTooOld(req.headers[CLI_VERSION_HEADER])) {
         throw new HttpError(426, ERROR_CODES.SV_CLIENT_TOO_OLD, {
           minVersion: MIN_CLI_VERSION,

--- a/apps/desktop/src/main/services/api-server/views.ts
+++ b/apps/desktop/src/main/services/api-server/views.ts
@@ -9,59 +9,59 @@ import type {
 } from '@meebox/shared';
 
 /**
- * PR 列表视图项：`GET /prs` 对外暴露的**精简投影**。这是「请求接口视图层的树结构约束方法」——
- * 单一投影函数 {@link toPrListItem} 定义列表返回的字段集合与次序，避免直接把整条
- * StoredPullRequest（含 description 明细、完整人员对象等）泄给列表消费方。
+ * PR list view item: the **slim projection** exposed by `GET /prs`. This is the view-layer tree-structure constraint for the
+ * request interface — a single projection function {@link toPrListItem} defines the field set and order returned by the list,
+ * avoiding leaking the entire StoredPullRequest (with description details, full people objects, etc.) to list consumers.
  *
- * 收窄原则：
- * - 只给标识与概览，**去掉 description 明细**（详情走 `GET /prs/{id}`）；
- * - **人员信息只留 slug**（reviewer 另带 status）；头像 / 展示名等留给详情；
- * - **字段顺序即输出顺序**：id / title / author / createdAt 优先，再给其余概览字段。
+ * Narrowing principles:
+ * - Give only identifiers and overview, **drop description details** (details go through `GET /prs/{id}`);
+ * - **Keep only slug for people info** (reviewer additionally carries status); avatar / display name, etc. left to details;
+ * - **Field order is output order**: id / title / author / createdAt first, then the remaining overview fields.
  */
 export interface PrListItem {
-  /** PR 的本地稳定标识（== StoredPullRequest.localId）；写操作与详情端点均按此定位。 */
+  /** The PR's local stable identifier (== StoredPullRequest.localId); write operations and the details endpoint both locate by this. */
   id: string;
   title: string;
-  /** 作者 slug（缺失时回退 name）；不含展示名 / 头像。 */
+  /** Author slug (falls back to name when missing); no display name / avatar. */
   author: string;
   createdAt: string;
-  /** 本人评审决断（pending / approved / needs_work）。 */
+  /** Own review verdict (pending / approved / needs_work). */
   status: LocalPrStatus;
   state: 'open' | 'merged' | 'declined';
   draft: boolean;
   platform: PlatformKind;
-  /** `projectKey/repoSlug`。 */
+  /** `projectKey/repoSlug`. */
   repo: string;
-  /** 远端平台 PR 编号。 */
+  /** Remote platform PR number. */
   remoteId: string;
   updatedAt: string;
   hasConflict: boolean;
-  /** 远端判定可直接合并（== mergeStatus.canMerge）。 */
+  /** Remote-determined directly mergeable (== mergeStatus.canMerge). */
   mergeable: boolean;
-  /** 命中的发现分类（一级 category）。 */
+  /** Matched discovery categories (top-level category). */
   categories: PrDiscoveryFilter[];
-  /** 评审人：仅 slug + status。 */
+  /** Reviewers: slug + status only. */
   reviewers: Array<{ slug: string; status: ReviewerStatus }>;
   unread: boolean;
   unreadMentionCount: number;
 }
 
 /**
- * 某 PR 在运行队列里的一个 pr-agent run 视图项：`GET /prs/{id}/agent/runs` 的投影。用于让调用方
- * 发现可取消的 run（runId + tool + 运行 / 排队态），配合 `…/runs/{runId}/cancel` 做按 run 取消。
+ * View item for one pr-agent run of a PR in the run queue: the projection of `GET /prs/{id}/agent/runs`. Lets the caller
+ * discover cancelable runs (runId + tool + running / queued state), paired with `…/runs/{runId}/cancel` for per-run cancel.
  */
 export interface PrAgentRunItem {
   runId: string;
   tool: ReviewRunTool;
-  /** active = 正在执行；waiting = 排队中。 */
+  /** active = executing; waiting = queued. */
   state: 'active' | 'waiting';
-  /** 开始执行时间（ISO）；waiting 为 null。 */
+  /** Execution start time (ISO); null when waiting. */
   startedAt: string | null;
   enqueuedAt: string;
   question?: string;
 }
 
-/** 从队列快照筛出属于该 PR 的 run（active 在前、waiting 在后），投影为精简项。 */
+/** Filter the runs belonging to this PR from the queue snapshot (active first, waiting after), projected to slim items. */
 export function toPrAgentRuns(
   queue: { active: PragentRunInfo[]; waiting: PragentRunInfo[] },
   prId: string,
@@ -80,7 +80,7 @@ export function toPrAgentRuns(
   ];
 }
 
-/** 把存储态 PR 投影为列表视图项。对象字面量的键序即 JSON 输出顺序（CLI 视图层据此渲染）。 */
+/** Project a stored-state PR to a list view item. The object literal's key order is the JSON output order (the CLI view layer renders accordingly). */
 export function toPrListItem(pr: StoredPullRequest): PrListItem {
   return {
     id: pr.localId,

--- a/apps/desktop/src/main/services/app.ts
+++ b/apps/desktop/src/main/services/app.ts
@@ -4,7 +4,7 @@ import type { ConnectionSummary } from '@meebox/ipc';
 import type { AppInfo } from '@meebox/shared';
 import type { BuiltAdapter } from '../adapters.js';
 
-/** 应用 / 运行时版本信息（app:info）。纯数据组装，不依赖 controller 上下文。 */
+/** App / runtime version info (app:info). Pure data assembly, no controller context needed. */
 export function buildAppInfo(bootstrap: BootstrapResult): AppInfo {
   return {
     appVersion: app.getVersion(),
@@ -17,12 +17,12 @@ export function buildAppInfo(bootstrap: BootstrapResult): AppInfo {
   };
 }
 
-/** 当前活动连接的状态摘要（app:connections）。 */
+/** Status summary of the currently active connection (app:connections). */
 export function buildConnectionSummaries(
   bootstrap: BootstrapResult,
   adapters: readonly BuiltAdapter[],
 ): ConnectionSummary[] {
-  // 单活动连接模型：状态栏只展示当前活动连接的启用状态（与 poller 只轮询活动连接一致）。
+  // Single-active-connection model: the status bar only shows the enabled state of the current active connection (consistent with poller only polling the active connection).
   const activeId = bootstrap.config.active_connection_id;
   return adapters
     .filter(({ connectionId }) => connectionId === activeId)

--- a/apps/desktop/src/main/services/avatar.ts
+++ b/apps/desktop/src/main/services/avatar.ts
@@ -5,7 +5,7 @@ import type { Logger } from 'pino';
 import type { PlatformAdapter } from '@meebox/platform-core';
 import { sniffImageContentType } from '../utils/image.js';
 
-// 与 app.ts 头像缓存同约定：目录 <cacheDir>/avatars/，键 sha256(connectionId|slug) 前 24 hex；原始字节存 .bin。
+// Same convention as app.ts avatar cache: directory <cacheDir>/avatars/, key is first 24 hex of sha256(connectionId|slug); raw bytes stored as .bin.
 const AVATAR_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const EXT_BY_CONTENT_TYPE: Record<string, string> = {
   'image/png': 'png',
@@ -16,17 +16,17 @@ const EXT_BY_CONTENT_TYPE: Record<string, string> = {
 
 export interface AvatarFileDeps {
   cacheDir: string;
-  /** 取指定连接的 adapter（拉头像用）；找不到回 null。 */
+  /** Get the adapter for the given connection (for fetching avatars); returns null if not found. */
   getAdapter: (connectionId: string) => PlatformAdapter | null;
   logger: Logger;
 }
 
 /**
- * 确保 (connectionId, slug) 的头像已落盘，并返回一个**带正确图片扩展名**的本地文件绝对路径。
+ * Ensures the avatar for (connectionId, slug) is persisted to disk, and returns the absolute path of a local file **with the correct image extension**.
  *
- * 背景：Windows toast 的 `<image src>` 需要本地文件且按扩展名识别格式；而头像缓存只存裸字节 `.bin`。
- * 故此处在 `.bin` 之外按嗅探到的 content-type 旁挂一份 `<hash>.<ext>` 供 toast 引用。命中且未过期的缓存复用，
- * 缺失 / 过期经 adapter 拉取并落盘。无 adapter / 拉取失败 / 非位图（svg 等 toast 不支持）→ 返回 null（调用方降级为无头像）。
+ * Background: Windows toast's `<image src>` needs a local file and identifies the format by extension; but the avatar cache only stores raw bytes as `.bin`.
+ * So besides the `.bin`, this attaches a `<hash>.<ext>` copy based on the sniffed content-type for the toast to reference. A hit that has not expired is reused,
+ * a miss / expiry is fetched via the adapter and persisted. No adapter / fetch failure / non-bitmap (svg etc. not supported by toast) → returns null (caller falls back to no avatar).
  */
 export async function ensureAvatarFile(
   deps: AvatarFileDeps,
@@ -47,7 +47,7 @@ export async function ensureAvatarFile(
     const stat = await fs.stat(binPath);
     if (Date.now() - stat.mtimeMs < AVATAR_TTL_MS) bytes = await fs.readFile(binPath);
   } catch {
-    // .bin 不存在 / 读失败 → 走拉取
+    // .bin missing / read failed → go fetch
   }
   if (!bytes) {
     const adapter = deps.getAdapter(connectionId);
@@ -65,15 +65,15 @@ export async function ensureAvatarFile(
   }
 
   const ext = EXT_BY_CONTENT_TYPE[sniffImageContentType(bytes)];
-  if (!ext) return null; // svg / 未知格式：Windows toast 不可靠，降级无头像
+  if (!ext) return null; // svg / unknown format: unreliable for Windows toast, fall back to no avatar
   const imgPath = path.join(avatarDir, `${hash}.${ext}`);
   try {
     let needWrite = true;
     try {
       const [binStat, imgStat] = await Promise.all([fs.stat(binPath), fs.stat(imgPath)]);
-      needWrite = imgStat.mtimeMs < binStat.mtimeMs; // 副本比原始字节旧 → 重写
+      needWrite = imgStat.mtimeMs < binStat.mtimeMs; // copy older than raw bytes → rewrite
     } catch {
-      needWrite = true; // 副本不存在
+      needWrite = true; // copy does not exist
     }
     if (needWrite) await fs.writeFile(imgPath, bytes);
     return imgPath;

--- a/apps/desktop/src/main/services/broadcast.ts
+++ b/apps/desktop/src/main/services/broadcast.ts
@@ -2,9 +2,9 @@ import { BrowserWindow } from 'electron';
 import type { IpcEvents } from '@meebox/ipc';
 
 /**
- * 向所有窗口广播一条 main → renderer 推送事件。收口原先散落各处的
- * `for (const win of BrowserWindow.getAllWindows()) win.webContents.send(...)`，
- * 并按 IpcEvents 强类型约束 event ↔ payload。
+ * Broadcasts a main → renderer push event to all windows. Consolidates the previously
+ * scattered `for (const win of BrowserWindow.getAllWindows()) win.webContents.send(...)`,
+ * and strongly constrains event ↔ payload via IpcEvents.
  */
 export function broadcast<E extends keyof IpcEvents>(event: E, payload: IpcEvents[E]): void {
   for (const win of BrowserWindow.getAllWindows()) {

--- a/apps/desktop/src/main/services/comments.ts
+++ b/apps/desktop/src/main/services/comments.ts
@@ -2,23 +2,23 @@ import type { PrComment } from '@meebox/shared';
 import type { PlatformAdapter } from '@meebox/platform-core';
 
 /**
- * 给每条评论 (含 replies 子树) 打 canDelete / canEdit 标志。不依赖 controller 上下文。
+ * Tags each comment (including the replies subtree) with canDelete / canEdit flags. No controller context needed.
  *
- * - canDelete: author.name === 当前 PAT 用户 && 无 reply && 有 version
- *   (Bitbucket 拒删带 reply 的；DELETE 必带 version 乐观锁)
- * - canEdit:   author.name === 当前 PAT 用户 && 有 version
- *   (Bitbucket 允许编辑带 reply 的评论；PUT 也带 version)
+ * - canDelete: author.name === current PAT user && no reply && has version
+ *   (Bitbucket refuses to delete ones with a reply; DELETE must carry a version optimistic lock)
+ * - canEdit:   author.name === current PAT user && has version
+ *   (Bitbucket allows editing comments with a reply; PUT also carries a version)
  *
- * 当前用户拿不到 (ping 未完成 / 失败) → 全部 false。renderer 直读 flag 不再
- * 自己比对 author / version / replies，链路最短最稳。
+ * If the current user is unavailable (ping not done / failed) → all false. The renderer reads the flag directly and no longer
+ * compares author / version / replies itself, keeping the path shortest and most stable.
  */
 export function annotateOwnership(comments: PrComment[], adapter: PlatformAdapter): PrComment[] {
   const me = adapter.connection.getCurrentUser();
   if (!me) {
     return setOwnershipRecursive(comments, () => ({ canDelete: false, canEdit: false }));
   }
-  // 「带 reply 的评论不可删」是 Bitbucket 限制（删父评论会孤立子评论）；GitHub / GitLab 允许删
-  // 自己的评论（含有 reply 的）。用乐观锁能力位作 Bitbucket 代理。
+  // "Comments with a reply cannot be deleted" is a Bitbucket limitation (deleting a parent comment would orphan child comments); GitHub / GitLab allow deleting
+  // one's own comments (including those with a reply). Use the optimistic-lock capability bit as a proxy for Bitbucket.
   const noDeleteWithReplies = adapter.connection.capabilities().commentOptimisticLock;
   return setOwnershipRecursive(comments, (c) => {
     const isMine = c.author.name === me.name;

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -12,53 +12,53 @@ import { broadcast } from './broadcast.js';
 import { PrService } from './pr-service.js';
 import type { RunQueue } from './pr-agent/index.js';
 
-/** registerIpcHandlers 的外部依赖（由 main/index.ts 注入）。 */
+/** External dependencies of registerIpcHandlers (injected by main/index.ts). */
 export interface RegisterDeps {
   bootstrap: BootstrapResult;
   logger: Logger;
-  /** 惰性取 pr-agent 探测状态：探测异步进行（不阻塞建窗），await 拿最终结果 */
+  /** Lazily get pr-agent probe status: probing runs async (does not block window creation); await for the final result */
   getPrAgentStatus: () => Promise<PrAgentStatus>;
-  /** 惰性取 bridge 实例；探测未完成 / 不可用 (embedded / CLI 都没有) 时为 null */
+  /** Lazily get the bridge instance; null when probing is unfinished / unavailable (neither embedded nor CLI) */
   getPrAgentBridge: () => PrAgentBridge | null;
-  /** 嵌入式运行时解释器路径（embedded 策略下执行期补 .secrets.toml 用），非 embedded 可空 */
+  /** Embedded runtime interpreter path (used to patch .secrets.toml at execution time under the embedded strategy); may be empty for non-embedded */
   embeddedPythonPath?: string;
   stateStore: JsonFileStateStore;
-  /** 归档 PR 冷存储（archived/ 根，与 state/ 平级）：「已关闭」视图列表 + 打开已归档 PR 详情时读。 */
+  /** Archived PR cold storage (archived/ root, sibling of state/): read for the "closed" view list + when opening an archived PR's details. */
   archiveStore: JsonFileStateStore;
   poller: Poller;
-  /** 可变连接运行时（全量 adapters + adapterByHost）；设置页改连接后被 reconfigure 原地替换 */
+  /** Mutable connection runtime (full adapters + adapterByHost); replaced in place by reconfigure after connections change in the settings page */
   connectionRuntime: ConnectionRuntime;
-  /** 重建 adapters/poller 使连接变更热生效（config:setConnections 写盘后调用） */
+  /** Rebuild adapters/poller so connection changes take effect hot (called after config:setConnections is written to disk) */
   reconfigureConnections: () => Promise<void>;
   repoMirror: RepoMirrorManager;
-  /** 重建本地 API 监听器使 service 配置（开关 / host / port）变更热生效（config:setService 写盘后调用）。 */
+  /** Rebuild the local API listener so service config (toggle / host / port) changes take effect hot (called after config:setService is written to disk). */
   reconfigureApiServer: () => Promise<void>;
 }
 
 /**
- * 各 service 共享的运行时上下文：外部依赖 + 跨域工具（广播 / Agent 目录）+ PR 领域服务。
- * 跨域服务（run 队列 / Agent 编排）在此之上由 ipc.ts 合成 ControllerContext，避免构造环。
+ * Runtime context shared by all services: external dependencies + cross-cutting utilities (broadcast / Agent dir) + PR domain service.
+ * On top of this, cross-cutting services (run queue / Agent orchestration) are composed by ipc.ts into ControllerContext, avoiding a construction cycle.
  */
 export interface ServiceContext extends RegisterDeps {
-  /** 向所有窗口广播 main → renderer 事件（按 IpcEvents 强类型）。 */
+  /** Broadcast main → renderer events to all windows (strongly typed by IpcEvents). */
   broadcast: typeof broadcast;
-  /** 生效的 Agent 目录：用户配置优先，未配置则回落默认位置（~/.code-meeseeks/agent）。 */
+  /** The effective Agent dir: user config takes precedence, falling back to the default location (~/.code-meeseeks/agent) when unset. */
   effectiveAgentDir(): string;
   /**
-   * 取生效 Agent 目录并**幂等补齐**上下文模版（SOUL/AGENTS/MEMORY/USER + rules/）后返回其路径。
-   * 「用时初始化」：与现读现装配同口径——无论目录经启动默认 / 应用内热切换 / 直改配置文件后重启而来，
-   * 每次加载前都先确保已初始化，不依赖首启或设置交互这类一次性时机。幂等（已存在不覆盖）；失败仅告警、
-   * 不抛（loadAgentContext / loadAgentRules 仍会按缺失文件降级）。
+   * Get the effective Agent dir, **idempotently backfill** the context templates (SOUL/AGENTS/MEMORY/USER + rules/), then return its path.
+   * "Initialize on use": same approach as read-and-assemble-on-demand — regardless of whether the dir comes from the startup default / in-app hot switch / a restart after directly editing the config file,
+   * always ensure it is initialized before each load, not relying on one-off moments like first launch or settings interaction. Idempotent (does not overwrite if present); on failure only warns,
+   * does not throw (loadAgentContext / loadAgentRules still degrade per missing files).
    */
   ensureAgentDir(): Promise<string>;
-  /** PR 领域服务：PR 定位 / adapter / 镜像 / diff base / 评论缓存。 */
+  /** PR domain service: PR lookup / adapter / mirror / diff base / comments cache. */
   pr: PrService;
 }
 
 /**
- * controller 层统一上下文：在 ServiceContext 之上再挂两个跨域 service（run 队列 / Agent 编排），
- * 使所有 controller 共享同一 `ctx` 入参即可拿到全部能力，签名统一为 `(ctx, req, evt)`。
- * 两个跨域服务以基础 ServiceContext 构建（见 ipc.ts 装配顺序），构建完成后合成本上下文。
+ * Unified controller-layer context: on top of ServiceContext, attach two more cross-cutting services (run queue / Agent orchestration),
+ * so all controllers share the same `ctx` input to access every capability, with a uniform `(ctx, req, evt)` signature.
+ * The two cross-cutting services are built from the base ServiceContext (see ipc.ts assembly order), and this context is composed once they are built.
  */
 export interface ControllerContext extends ServiceContext {
   runQueue: RunQueue;
@@ -92,18 +92,18 @@ export function createServiceContext(deps: RegisterDeps): ServiceContext {
   };
 }
 
-// === controller 层进程级单例上下文 ===
-// registerIpcHandlers 启动时合成一次 ControllerContext（base + runQueue + orchestrator）并安装；
-// controller 经 getContext() 取用，从而 handler 签名回归标准 ipcMain.handle 形态 (req, evt)、不带 ctx。
-// 单一真相、随进程生命周期存活；测试可先 setControllerContext(mock) 再调 controller。
+// === process-level singleton context of the controller layer ===
+// At startup registerIpcHandlers composes a ControllerContext once (base + runQueue + orchestrator) and installs it;
+// controllers access it via getContext(), so handler signatures return to the standard ipcMain.handle form (req, evt) without ctx.
+// Single source of truth, lives for the process lifecycle; tests can setControllerContext(mock) first then call the controller.
 let currentContext: ControllerContext | undefined;
 
-/** 由 registerIpcHandlers 在装配完成后调用，安装进程级 controller 上下文单例。 */
+/** Called by registerIpcHandlers after assembly completes, to install the process-level controller context singleton. */
 export function setControllerContext(ctx: ControllerContext): void {
   currentContext = ctx;
 }
 
-/** 取 controller 上下文单例；未初始化（registerIpcHandlers 之前 / 模块加载期）即抛错兜住时序。 */
+/** Get the controller context singleton; throws if uninitialized (before registerIpcHandlers / during module load) to guard timing. */
 export function getContext(): ControllerContext {
   if (!currentContext) {
     throw new Error('ControllerContext 尚未初始化（registerIpcHandlers 未调用）');

--- a/apps/desktop/src/main/services/notifications.ts
+++ b/apps/desktop/src/main/services/notifications.ts
@@ -7,19 +7,19 @@ import { broadcast } from './broadcast.js';
 import { ensureAvatarFile, type AvatarFileDeps } from './avatar.js';
 
 /**
- * 系统通知 + 应用角标。两条路径：
- * - 系统通知（toast）：poll 投影的本轮事件按类型开关弹原生通知；受 OS 权限约束，用户在系统设置关闭后静默降级。
- *   Windows 走 toastXml 富样式（圆形发起人头像 + 类型 emoji + 仓库行）；其他平台用 title/body 文本（含仓库，无头像，
- *   因 Electron 在 macOS 固定显示应用图标、不支持 per-notification 头像）。
- * - dock 角标（本期仅 macOS）：renderer 据 PR 列表派生「待回应」计数后推送，主进程落地到 dock 图标。
+ * System notifications + app badge. Two paths:
+ * - System notification (toast): this round's poll-projected events fire native notifications per type toggle; subject to OS permission, silently degrades after the user disables it in system settings.
+ *   Windows uses toastXml rich style (circular initiator avatar + type emoji + repo line); other platforms use title/body text (with repo, no avatar,
+ *   because Electron fixes the app icon on macOS and does not support per-notification avatars).
+ * - dock badge (macOS only this iteration): renderer derives the "awaiting response" count from the PR list and pushes it, the main process lands it on the dock icon.
  *
- * 文案走主进程 i18n（与 dialog / pr-agent 同一实例，语言随启动配置定档）。
+ * Text goes through main-process i18n (same instance as dialog / pr-agent, language fixed by startup config).
  */
 
-/** 一轮最多单独弹的通知条数（各带定位）；超出部分折叠为一条「查看更多」提示，避免涌入时的通知风暴。 */
+/** Max number of notifications fired individually per round (each with anchoring); the overflow is collapsed into one "see more" prompt, avoiding a notification storm on influx. */
 const INDIVIDUAL_LIMIT = 5;
 
-/** 通知事件类型 → i18n 文案分组名（new_pr 的 key 为 newPr，authored_* 转驼峰，其余同名）。 */
+/** Notification event type → i18n text group name (new_pr's key is newPr, authored_* is camel-cased, the rest same name). */
 const I18N_GROUP: Record<PollNotificationEvent['kind'], string> = {
   new_pr: 'newPr',
   mention: 'mention',
@@ -29,7 +29,7 @@ const I18N_GROUP: Record<PollNotificationEvent['kind'], string> = {
   authored_conflict: 'authoredConflict',
 };
 
-/** 类型 emoji（Windows toast 单图标槽给了头像，故类型用 emoji 在标题前标记）。 */
+/** Type emoji (the Windows toast single icon slot is given to the avatar, so the type is marked with an emoji before the title). */
 const TYPE_EMOJI: Record<PollNotificationEvent['kind'], string> = {
   new_pr: '🔀',
   mention: '💬',
@@ -39,7 +39,7 @@ const TYPE_EMOJI: Record<PollNotificationEvent['kind'], string> = {
   authored_conflict: '⚠️',
 };
 
-/** 点击通知：唤起并聚焦主窗口（最小化则先还原）。 */
+/** On notification click: raise and focus the main window (restore first if minimized). */
 function focusMainWindow(): void {
   const win = BrowserWindow.getAllWindows()[0];
   if (!win) return;
@@ -57,7 +57,7 @@ function showNotification(
   n.show();
 }
 
-/** 点击通知 → 聚焦窗口 + 推导航意图给 renderer（选中 PR / 跳 diff 行 / 开活动标签，见 IpcEvents['notification:activate']）。 */
+/** On notification click → focus the window + push a navigation intent to the renderer (select PR / jump to diff line / open activity tab, see IpcEvents['notification:activate']). */
 function activateOnClick(e: PollNotificationEvent): () => void {
   return () => {
     focusMainWindow();
@@ -80,7 +80,7 @@ function escapeXml(s: string): string {
     .replace(/'/g, '&apos;');
 }
 
-/** 构造 Windows ToastGeneric XML：标题（emoji+类型）+ 正文（#编号 标题）+ 归属行（仓库）+ 圆形头像（可选）。 */
+/** Build Windows ToastGeneric XML: title (emoji+type) + body (#number title) + attribution line (repo) + circular avatar (optional). */
 function buildToastXml(line1: string, line2: string, attribution: string, avatarPath: string | null): string {
   const logo = avatarPath
     ? `<image placement="appLogoOverride" hint-crop="circle" src="${escapeXml(pathToFileURL(avatarPath).href)}"/>`
@@ -95,7 +95,7 @@ function buildToastXml(line1: string, line2: string, attribution: string, avatar
   );
 }
 
-/** 弹单条通知：Windows 富样式（头像 + emoji + 仓库），失败 / 其他平台回退为 title/body 文本（含仓库）。 */
+/** Fire a single notification: Windows rich style (avatar + emoji + repo), falling back to title/body text (with repo) on failure / other platforms. */
 async function showOne(
   e: PollNotificationEvent,
   avatarDeps: AvatarFileDeps,
@@ -128,9 +128,9 @@ async function showOne(
 }
 
 /**
- * 按通知配置弹系统通知。总开关关 / 平台不支持通知 → 直接返回（静默降级）。按类型开关过滤后：
- * 最多前 {@link INDIVIDUAL_LIMIT} 条逐条弹（各带头像富样式 + 点击定位）；超出部分（第 6 条起）折叠为一条
- * 「查看更多最新动态」提示，点击仅打开主界面、不做定位。
+ * Fire system notifications per notification config. Master toggle off / platform does not support notifications → return directly (silent degrade). After filtering by type toggle:
+ * fire at most the first {@link INDIVIDUAL_LIMIT} one by one (each with avatar rich style + click anchoring); the overflow (from the 6th on) is collapsed into one
+ * "see more recent activity" prompt, whose click only opens the main UI without anchoring.
  */
 export async function showPollNotifications(
   events: ReadonlyArray<PollNotificationEvent>,
@@ -158,7 +158,7 @@ export async function showPollNotifications(
     }
     const overflow = filtered.length - shown.length;
     if (overflow > 0) {
-      // 溢出提示：点击走默认 focusMainWindow（仅打开主界面、不定位），让用户自行查看更多最新动态。
+      // Overflow prompt: click goes to the default focusMainWindow (only opens the main UI, no anchoring), letting users browse more recent activity themselves.
       showNotification({
         title: t('notifications.more.title'),
         body: t('notifications.more.body', { count: overflow }),
@@ -170,7 +170,7 @@ export async function showPollNotifications(
 }
 
 /**
- * 设置应用角标计数（本期仅 macOS dock）。count≤0 清除角标。renderer 已据通知配置派生计数，主进程仅落地。
+ * Set the app badge count (macOS dock only this iteration). count≤0 clears the badge. The renderer has already derived the count per notification config; the main process only lands it.
  */
 export function applyBadgeCount(count: number): void {
   if (process.platform !== 'darwin') return;

--- a/apps/desktop/src/main/services/pr-agent/index.ts
+++ b/apps/desktop/src/main/services/pr-agent/index.ts
@@ -1,6 +1,7 @@
 /**
- * pr-agent run 子系统：调度（RunQueue：并发 / 优先级 / 取消）+ 执行（RunExecutor，内部协作件，不外暴露）。
- * 对外只暴露 RunQueue 与队列相关类型。
+ * pr-agent run subsystem: scheduling (RunQueue: concurrency / priority / cancel) + execution
+ * (RunExecutor, an internal collaborator, not exposed). Only RunQueue and queue-related types
+ * are exposed outward.
  */
 export { RunQueue } from './run-queue.js';
 export type { QueueItem, RunPriority } from './run-queue.js';

--- a/apps/desktop/src/main/services/pr-agent/run-executor.ts
+++ b/apps/desktop/src/main/services/pr-agent/run-executor.ts
@@ -41,44 +41,48 @@ import {
 } from './usage.js';
 import { neutralizeWorktreeInstructions } from './worktree-sanitize.js';
 
-/** finishReviewRun 的收尾 patch 类型（收尾 helper 的返回）。 */
+/** Finalization patch type for finishReviewRun (return of the finalization helper). */
 type FinishPatch = Parameters<typeof finishReviewRun>[3];
 
 /**
- * pr-agent run 的**执行器**（与队列调度 RunQueue 分离）：给定一个已 dequeue 的队列项，跑完一个 run。
- * 调度（并发 / 优先级 / 取消 / 泵）归 RunQueue；本类只管「怎么跑一个 run」，无队列状态。
+ * The **executor** for a pr-agent run (separate from queue scheduling in RunQueue): given an
+ * already-dequeued queue item, it runs one run to completion. Scheduling (concurrency / priority /
+ * cancel / pump) belongs to RunQueue; this class only handles "how to run one run", with no queue state.
  *
- * execute 编排五个阶段：startRun（落盘 + 标记开始）→ prepareWorkspace（镜像 + worktree）→
- * buildInvocation（env + 提示词组装）→ bridge.run（spawn）→ collectOutput（读产物 + 解析）→ 收尾落盘。
+ * execute orchestrates five stages: startRun (persist + mark started) → prepareWorkspace (mirror + worktree)
+ * → buildInvocation (env + prompt assembly) → bridge.run (spawn) → collectOutput (read artifacts + parse) → finalize persist.
  */
 export class RunExecutor {
   private readonly execFileP = promisify(execFile);
-  /** embedded .secrets.toml 兜底的 memo（只在首个 embedded run 解析一次目录 + 写文件）。 */
+  /** Memo for the embedded .secrets.toml fallback (resolve dir + write file only once, on the first embedded run). */
   private embeddedSecretsEnsured: Promise<void> | null = null;
 
   constructor(private readonly ctx: ServiceContext) {}
 
   /**
-   * 真正执行一个 queue item：startRun → worktree → bridge.run → finishWith。
-   * 由 RunQueue.pump() 调用；任何抛错都被调度层兜成 Promise reject，外层 pragent:run 调用方收到。
-   * notifyStarted：startedAt 落定后回调调度层广播队列变化（执行器不持队列态）。
+   * Actually execute one queue item: startRun → worktree → bridge.run → finishWith.
+   * Called by RunQueue.pump(); any thrown error is caught by the scheduling layer into a Promise reject,
+   * received by the outer pragent:run caller.
+   * notifyStarted: once startedAt is settled, calls back into the scheduling layer to broadcast queue
+   * changes (the executor holds no queue state).
    */
   async execute(item: QueueItem, notifyStarted: () => void): Promise<ReviewRun> {
     const { getPrAgentBridge, embeddedPythonPath, broadcast } = this.ctx;
     const bridge = getPrAgentBridge();
     if (!bridge) throw new AppError(ERROR_CODES.AG_PR_AGENT_NOT_READY);
     const { req, pr } = item;
-    // per-PR 存储路由：对已归档（已关闭范围）的合并 / 仍开放 PR 补跑评审时，run 数据落归档冷存储，
-    // 不写活跃存储（否则被下轮 poll 对账连同归档数据误删，见 PrService.storeForPr）。
+    // per-PR storage routing: when re-running review for an already-archived (closed-scope) merged /
+    // still-open PR, run data goes to archived cold storage, not the active store (otherwise the next
+    // poll reconciliation would wrongly delete it along with archived data, see PrService.storeForPr).
     const stateStore = await this.ctx.pr.storeForPr(pr.localId);
 
     const run = await this.startRun(item, bridge, notifyStarted);
     const t0 = Date.now();
-    // 真实 token 用量累加器：sitecustomize 的 litellm callback 把每次调用的 usage 以
-    // `@@MEEBOX_USAGE@@ {json}` 哨兵行打到 stderr，下面 onLine 拦截累加（无需临时文件 / env）。
+    // Real token usage accumulator: sitecustomize's litellm callback emits each call's usage as a
+    // `@@MEEBOX_USAGE@@ {json}` sentinel line to stderr; onLine below intercepts and accumulates (no temp file / env needed).
     const usageAcc = newUsageAcc();
     const onLine = (line: string, stream: 'stdout' | 'stderr'): void => {
-      // 拦截 usage 哨兵行：累加后不转发给 renderer（避免污染实时日志）。
+      // Intercept usage sentinel lines: accumulate then don't forward to the renderer (avoid polluting live logs).
       if (stream === 'stderr' && accumulateUsageSentinel(line, usageAcc)) return;
       broadcast('pragent:runProgress', { runId: run.id, line, stream });
     };
@@ -96,14 +100,16 @@ export class RunExecutor {
         wt.path,
       );
 
-      // CLI 模式 /ask 把子进程 cwd 落到 worktree（取完整文件上下文，buildInvocation 已设 MEEBOX_CLI_WORKDIR）。
-      // 落 cwd 前先清空仓库自带的 agent 指令文件，避免被 CLI 自动加载污染回答。env key 在 = 走此路径。
+      // In CLI mode /ask sets the subprocess cwd to the worktree (for full file context; buildInvocation
+      // already set MEEBOX_CLI_WORKDIR). Before landing cwd, clear the repo's own agent instruction files
+      // to avoid the CLI auto-loading them and polluting the answer. Presence of the env key gates this path.
       if (env['MEEBOX_CLI_WORKDIR']) {
         await neutralizeWorktreeInstructions(env['MEEBOX_CLI_WORKDIR'], this.ctx.logger);
       }
 
-      // embedded 策略：执行期在嵌入式安装目录补空 .secrets.toml 压掉启动告警（memo 化只首次做）。
-      // local-cli 不需要（pipx 装的 pr-agent 路径不同，告警也不出）。
+      // embedded strategy: at execution time write an empty .secrets.toml into the embedded install dir
+      // to suppress the startup warning (memoized, done only on the first run).
+      // local-cli doesn't need it (pipx-installed pr-agent has a different path and the warning doesn't appear).
       if (bridge.strategy === 'embedded' && embeddedPythonPath) {
         await this.ensureEmbeddedSecrets(embeddedPythonPath);
       }
@@ -118,7 +124,7 @@ export class RunExecutor {
         extraArgs,
         signal: item.ac!.signal,
       });
-      // 真实 token 用量（onLine 累加的 stderr 哨兵行），落到 succeeded / llm-failed 收尾。
+      // Real token usage (stderr sentinel lines accumulated by onLine), carried into succeeded / llm-failed finalization.
       const tokenUsage = finalizeUsage(usageAcc);
       const { parsed, fileContent } = await this.collectOutput(
         wt,
@@ -135,7 +141,7 @@ export class RunExecutor {
       const finished = await finishWith(
         this.finishPatchForError(err, tokenUsage, t0, run.id),
       );
-      // 非预期异常（非 PrAgentRunError）：落 failed 后仍把异常往上抛，避免吞掉。
+      // Unexpected exception (not PrAgentRunError): after persisting failed, still rethrow to avoid swallowing it.
       if (!(err instanceof PrAgentRunError)) throw err;
       return finished;
     } finally {
@@ -144,10 +150,10 @@ export class RunExecutor {
   }
 
   /**
-   * 成功路径收尾 patch：parsed.llmFailure → failed(reason=llm-error)，否则 succeeded。
-   * pr-agent CLI 可能 exit 0 但 stdout 其实是 LLM 调用全失败（litellm AuthenticationError /
-   * "Failed to generate prediction with any model" 等 marker）→ 不算 succeeded，UI 用红色失败 chip 渲染。
-   * stdout 持久化「LLM 真实产出」(文件内容)；原 stdout 留作日志在折叠区供排障。
+   * Success-path finalization patch: parsed.llmFailure → failed(reason=llm-error), otherwise succeeded.
+   * The pr-agent CLI may exit 0 while stdout is actually a total LLM-call failure (litellm AuthenticationError /
+   * "Failed to generate prediction with any model" and similar markers) → not counted as succeeded, UI renders a red failure chip.
+   * stdout persists the "real LLM output" (file content); the original stdout is kept as a log in a collapsed area for troubleshooting.
    */
   private finishPatchForResult(
     result: { exitCode: number; stdout: string; stderr: string },
@@ -173,7 +179,7 @@ export class RunExecutor {
         { runId, reason: parsed.llmFailure.message },
         'pragent exit 0 but LLM call failed; marking run as failed',
       );
-      // 失败任务不做结构化采集——findings 置空，UI 只展示原始输出（不转 chatpane finding 卡）。
+      // Failed runs get no structured collection — findings set empty, UI shows only raw output (no chatpane finding card).
       return {
         ...base,
         status: 'failed',
@@ -187,14 +193,15 @@ export class RunExecutor {
       status: 'succeeded',
       findings: parsed.findings,
       summary: parsed.summary,
-      // 复评裁决（解析自复评 /ask 的 <verdict>）；非复评 / 未给则 undefined。
+      // Re-review verdict (parsed from the re-review /ask's <verdict>); undefined if not a re-review / not given.
       askVerdict: parsed.askVerdict,
     };
   }
 
   /**
-   * 异常路径收尾 patch：PrAgentRunError → cancelled（用户取消）/ failed（其它 reason），尽量解析已收集的
-   * 部分 stdout + 记已产生的 token 用量；其它非预期异常 → failed（仅 errorMessage，避免 run 卡在 running）。
+   * Error-path finalization patch: PrAgentRunError → cancelled (user cancel) / failed (other reason), parsing
+   * whatever partial stdout was collected + recording token usage already produced; other unexpected exceptions
+   * → failed (errorMessage only, to avoid a run stuck in running).
    */
   private finishPatchForError(
     err: unknown,
@@ -203,13 +210,13 @@ export class RunExecutor {
     runId: string,
   ): FinishPatch {
     if (err instanceof PrAgentRunError) {
-      // 用户主动取消 → cancelled，其它 reason → failed；二者都落盘让 UI 能从历史 run 里看到该事件。
+      // User-initiated cancel → cancelled, other reason → failed; both are persisted so the UI can see the event in run history.
       const status: ReviewRunStatus = err.reason === 'cancelled' ? 'cancelled' : 'failed';
       this.ctx.logger.warn(
         { runId, reason: err.reason, exitCode: err.result.exitCode },
         `pragent run ${status}`,
       );
-      // 失败 / 取消的任务不做结构化采集——只保留原始输出（stdout/stderr）供展示，不解析成 finding 卡。
+      // Failed / cancelled runs get no structured collection — keep only raw output (stdout/stderr) for display, not parsed into finding cards.
       return {
         status,
         finishedAt: new Date().toISOString(),
@@ -231,7 +238,7 @@ export class RunExecutor {
     };
   }
 
-  /** 阶段①：落盘 startReviewRun（用入队预分配 runId）+ 标记 startedAt 并通知调度层广播 + 记日志。 */
+  /** Stage 1: persist startReviewRun (using the runId pre-assigned at enqueue) + mark startedAt + notify scheduling layer to broadcast + log. */
   private async startRun(
     item: QueueItem,
     bridge: PrAgentBridge,
@@ -240,10 +247,10 @@ export class RunExecutor {
     const { bootstrap, logger } = this.ctx;
     const { req, pr } = item;
     const stateStore = await this.ctx.pr.storeForPr(pr.localId);
-    // 提前 resolve active LLM profile — model 字段要随 startReviewRun 一起落盘，让 UI 在 meta 行展示
-    // "这次 run 用的什么模型"（持久化用 profile.model 原文，不做 normalizeModel 前缀处理，跟 Settings 一致）。
+    // Resolve the active LLM profile early — the model field must be persisted together with startReviewRun so the
+    // UI shows "which model this run used" in the meta row (persist profile.model verbatim, no normalizeModel prefix handling, consistent with Settings).
     const activeLlmForRecord = resolveActiveLlmProfile(bootstrap.config.llm);
-    // 用入队预分配的 runId 覆盖 startReviewRun 的自生 id，让 cancel(runId) 在 active 状态也能精确定位。
+    // Override startReviewRun's self-generated id with the runId pre-assigned at enqueue, so cancel(runId) can precisely locate it even in active state.
     const run = await startReviewRun(stateStore, {
       id: item.info.runId,
       prLocalId: pr.localId,
@@ -252,14 +259,14 @@ export class RunExecutor {
       prAgentVersion: bridge.version,
       strategy: bridge.strategy,
       model: activeLlmForRecord?.model || undefined,
-      // 复评引用前向链：随 run 落盘，UI 据此在 /ask 卡上展示「复评自…」徽标 + 裁决动作。
+      // Re-review reference forward chain: persisted with the run, the UI uses it to show a "re-reviewed from…" badge + verdict action on the /ask card.
       referencedFinding: req.tool === 'ask' ? req.referencedFinding : undefined,
-      // 触发来源随 run 落盘：user 来源的 run 由 ChatPane 补命令回显气泡；agent 子 run 不回显。
+      // Trigger origin persisted with the run: user-origin runs get a command echo bubble added by ChatPane; agent sub-runs don't echo.
       origin: item.priority,
-      // 单 commit 评审范围随 run 落盘：结果卡据此展示范围徽标。
+      // Single-commit review scope persisted with the run: the result card uses it to show a scope badge.
       scope: req.scope,
     });
-    // 把入队时 startedAt=null 的 info 升级为 active 形态 + 广播（经调度层）。
+    // Upgrade the info (startedAt=null at enqueue) to active form + broadcast (via the scheduling layer).
     item.info = { ...item.info, startedAt: run.startedAt };
     notifyStarted();
     logger.info(
@@ -270,30 +277,31 @@ export class RunExecutor {
   }
 
   /**
-   * 阶段②：同步镜像 + 物化 worktree（与 UI diff 同源，评审基于 PR 自分叉的改动）。
-   * 缺省按固定 merge-base 定界 PR 全量（head=PR 源 sha，base=merge-base）；传入单 commit 范围（scope）时
-   * 改按该 commit 自身改动定界（head=scope.sha，base=scope.parent），pr-agent 只见 parent..sha 的 diff。
+   * Stage 2: sync mirror + materialize worktree (same source as the UI diff; review is based on the PR's forked changes).
+   * By default bounds the full PR by a fixed merge-base (head=PR source sha, base=merge-base); when a single-commit scope
+   * is passed, bounds by that commit's own changes instead (head=scope.sha, base=scope.parent), so pr-agent sees only the parent..sha diff.
    */
   private async prepareWorkspace(pr: QueueItem['pr'], scope?: QueueItem['req']['scope']) {
     const { repoMirror, pr: prService } = this.ctx;
     const repoId = prService.repoIdentityFor(pr);
-    // 走 ensureMirrorReadyForPr（而非裸 syncMirror）：与 UI diff 同源，且复用其自愈——源分支被删 / 强推后
-    // 按平台精确 fetch PR 头引用补齐 head sha，否则 materializeWorktree 建 head 分支会因对象缺失失败。
+    // Use ensureMirrorReadyForPr (rather than bare syncMirror): same source as the UI diff, and reuses its self-healing —
+    // after the source branch is deleted / force-pushed, it precisely fetches the PR head ref per platform to fill in the head sha,
+    // otherwise materializeWorktree building the head branch would fail on the missing object.
     await prService.ensureMirrorReadyForPr(pr);
     if (scope) {
-      // 单 commit 范围：head=目标 commit，base=其父 commit → LOCAL__TARGET_BRANCH 指向 parent，
-      // pr-agent 只见该 commit 自身改动。parent 是 head 的祖先、随镜像同步而在，无需另取。
+      // Single-commit scope: head=target commit, base=its parent commit → LOCAL__TARGET_BRANCH points at parent,
+      // pr-agent sees only that commit's own changes. parent is an ancestor of head and present via mirror sync, no extra fetch needed.
       return repoMirror.materializeWorktree(repoId, scope.sha, scope.parent, pr.localId);
     }
-    // pr-agent 的 LOCAL__TARGET_BRANCH 用固定 merge-base，而非 targetRef.sha 漂移后混入别的 PR 的两点对比。
+    // pr-agent's LOCAL__TARGET_BRANCH uses a fixed merge-base, rather than a two-dot comparison that would mix in another PR after targetRef.sha drifts.
     const diffBase = await prService.resolveDiffBaseSha(pr);
     return repoMirror.materializeWorktree(repoId, pr.sourceRef.sha, diffBase, pr.localId);
   }
 
   /**
-   * 阶段③：组装 bridge.run 的 env + 位置参数。代理 env 铺底 + buildToolEnv（凭据/模型/响应语言/per-tool），
-   * 再注入 EXTRA_INSTRUCTIONS（PR 上下文 + 命中规则，local provider 不会自己拉，须现读；/ask 跳过）。
-   * /ask 把问题作位置参数并在末尾追加目标语言要求（近因位置提升按 UI 语言作答的遵循度）。
+   * Stage 3: assemble bridge.run's env + positional args. Proxy env as the base + buildToolEnv (credentials/model/response language/per-tool),
+   * then inject EXTRA_INSTRUCTIONS (PR context + matched rules; the local provider won't fetch them itself, must read now; /ask skips this).
+   * /ask passes the question as a positional arg and appends the target-language requirement at the end (recency position improves adherence to answering in the UI language).
    */
   private async buildInvocation(
     req: QueueItem['req'],
@@ -307,8 +315,8 @@ export class RunExecutor {
   }> {
     const { bootstrap, logger, ensureAgentDir, pr: prService } = this.ctx;
     const activeLlm = resolveActiveLlmProfile(bootstrap.config.llm);
-    // 代理 env 先铺底（非 pr-agent 范畴，仅 HTTP(S)_PROXY 类）；LLM 凭据/模型 + 响应语言 + per-tool 配置
-    // 由 bridge 的 buildToolEnv 按意图组装——契约 key 收口在 @meebox/pr-agent-bridge。
+    // Proxy env as the base first (not pr-agent's domain, just HTTP(S)_PROXY-type); LLM credentials/model + response language + per-tool config
+    // are assembled by intent via the bridge's buildToolEnv — contract keys are consolidated in @meebox/pr-agent-bridge.
     const env: Record<string, string> = {
       ...buildProxyEnv(bootstrap.config.proxy),
       ...buildToolEnv(activeLlm, {
@@ -319,8 +327,8 @@ export class RunExecutor {
       }),
     };
 
-    // CLI 模式 /ask：把子进程 cwd 落到（待净化的）worktree，让自由问答能读完整文件（shim cli/install.py
-    // 据此 env 切 cwd）。describe/review 不下发、维持中性临时目录；API 模式不涉及（远程接口只有 diff）。
+    // CLI mode /ask: set the subprocess cwd to the (to-be-sanitized) worktree so free-form Q&A can read full files
+    // (shim cli/install.py switches cwd based on this env). describe/review don't set it and keep a neutral temp dir; API mode is unaffected (the remote interface only has the diff).
     if (req.tool === 'ask' && activeLlm?.provider === 'cli') {
       env['MEEBOX_CLI_WORKDIR'] = wtPath;
     }
@@ -354,34 +362,34 @@ export class RunExecutor {
         matchedRuleInstructions = combineRuleInstructions(matched);
         matchedRuleIds = matched.map((r) => r.id);
       }
-      // 始终记一条：让用户从日志确认规则加载/命中情况（0 命中也输出，便于排查「为何规则没生效」）。
+      // Always log one line: let users confirm rule loading/matching from logs (output even on 0 matches, to help debug "why the rule didn't take effect").
       logger.info(
         { runId, tool: req.tool, rulesLoaded: rules.length, rulesMatched: matched.length, ruleIds: matchedRuleIds },
         'pragent run: rules',
       );
     }
 
-    // 提示词组装收口到 @meebox/pr-agent-bridge 的 prompts：语言指示 / anchor marker / 排版 / PR 上下文 / 命中规则。
+    // Prompt assembly is consolidated into @meebox/pr-agent-bridge's prompts: language directive / anchor marker / formatting / PR context / matched rules.
     const extraInstructions = buildExtraInstructions({
       tool: req.tool,
       language: getMainLanguage(),
       prContext,
       matchedRuleInstructions,
-      // /ask 选中行引用 + 复评裁决：拼进「问题」（user turn），见下方 askQuestion 组装。
+      // /ask selected-line reference + re-review verdict: spliced into the "question" (user turn), see askQuestion assembly below.
       referencedContext: req.tool === 'ask' ? req.referencedContext : undefined,
-      // /ask 复评模式：引用了某条 finding 时注入裁决（replace/keep/drop）指示。
+      // /ask re-review mode: inject verdict (replace/keep/drop) directive when a finding is referenced.
       referencedFinding: req.tool === 'ask' ? !!req.referencedFinding : undefined,
-      // /ask 代码建议数量软约束（与 /review /improve 共用同一设置）。
+      // /ask code-suggestion count soft constraint (shares the same setting as /review /improve).
       maxCodeSuggestions:
         req.tool === 'ask' ? bootstrap.config.agent.strategy.max_code_suggestions : undefined,
-      // /ask 代码检索指引：仅 CLI 提供方（子进程 cwd 落在完整 worktree、可用文件工具）注入，引导定向检索
-      // （内置只读搜索 / grep 查符号 · 只读所需行段）替代整文件通读，降低 agentic 探索成本。刻意只用只读工具集
-      // （headless default 模式下非只读工具会中止会话，故不诱导 rg）。API 提供方无文件访问、不注入。
+      // /ask code-retrieval guidance: injected only for the CLI provider (subprocess cwd is in the full worktree, file tools available), steering targeted retrieval
+      // (built-in read-only search / grep for symbols · read only the needed line ranges) instead of reading whole files, lowering agentic exploration cost. Deliberately uses only the read-only tool set
+      // (in headless default mode non-read-only tools abort the session, so don't induce rg). The API provider has no file access, not injected.
       worktreeRetrieval: req.tool === 'ask' && activeLlm?.provider === 'cli',
     });
-    // /ask 的 pr_questions prompt **不渲染 extra_instructions**（与 describe/review/improve 不同），
-    // 经 env 注入对 /ask 是死字段。故 /ask 的指令改为拼进「问题」（user turn，见下方 askQuestion），
-    // env 注入仅用于其它三个工具。
+    // /ask's pr_questions prompt **does not render extra_instructions** (unlike describe/review/improve),
+    // so env injection is a dead field for /ask. Thus /ask's instructions are instead spliced into the "question"
+    // (user turn, see askQuestion below); env injection is only used for the other three tools.
     if (extraInstructions && req.tool !== 'ask') {
       env[extraInstructionsEnvKey(req.tool)] = extraInstructions;
     }
@@ -392,15 +400,15 @@ export class RunExecutor {
       );
     }
 
-    // ask 工具：问题作为位置参数（user turn，spawn args 单元素，含空格也是一个 arg 不切分），并在问题
-    // **末尾**硬性追加语言要求。系统侧 CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS 对自由问答常被大量
-    // 英文 diff 盖过 → 模型用英文作答；在 user turn 末尾（近因位置、用目标语言书写）再要求一次。en-US 返回空。
+    // ask tool: the question is a positional arg (user turn, a single spawn-args element; spaces don't split it into multiple args),
+    // and the language requirement is hard-appended at the **end** of the question. System-side CONFIG__RESPONSE_LANGUAGE / EXTRA_INSTRUCTIONS
+    // for free-form Q&A are often drowned out by the large English diff → the model answers in English; ask again at the end of the user turn (recency position, written in the target language). en-US returns empty.
     const askLangSuffix = req.tool === 'ask' ? askLanguageSuffixFor(getMainLanguage()) : '';
     let askQuestion: string | undefined;
     if (req.tool === 'ask' && req.question) {
-      // /ask 的指令（结构化分段 / anchor marker / 复评裁决 / 引用上下文）拼进 user turn——pr_questions
-      // 不读 extra_instructions，唯有问题文本真正到达模型。语言后缀放最末（近因位置最促使按目标语言作答）。
-      // 回显（pr-agent 把问题原样写进产物）由 collectOutput 的 stripAskQuestionEcho 整段剥掉。
+      // /ask's instructions (structured sections / anchor marker / re-review verdict / referenced context) are spliced into the user turn —
+      // pr_questions doesn't read extra_instructions, only the question text actually reaches the model. The language suffix goes last (recency position most encourages answering in the target language).
+      // The echo (pr-agent writes the question verbatim into the artifact) is stripped entirely by collectOutput's stripAskQuestionEcho.
       const parts = [req.question];
       if (extraInstructions) parts.push(extraInstructions);
       if (askLangSuffix) parts.push(askLangSuffix);
@@ -411,9 +419,9 @@ export class RunExecutor {
   }
 
   /**
-   * 阶段⑤：读 local provider 写到 worktree 根的产物文件（落盘文件名见 PRAGENT_LOCAL_OUTPUT），/ask 去掉
-   * 回显的问题行，解析为 findings/summary；/review 成功时丢弃旧 pending 草稿（让本轮 finding 成新候选源）。
-   * 文件缺失则回退用 stdout 解析。返回解析结果 + 原始文件内容（供收尾拼日志）。
+   * Stage 5: read the artifact file the local provider wrote to the worktree root (persisted filename see PRAGENT_LOCAL_OUTPUT), /ask removes
+   * the echoed question line, parse into findings/summary; on /review success drop old pending drafts (letting this round's findings become the new candidate source).
+   * If the file is missing, fall back to parsing stdout. Returns the parse result + raw file content (for finalization log splicing).
    */
   private async collectOutput(
     wt: { path: string },
@@ -424,7 +432,7 @@ export class RunExecutor {
   ): Promise<{ parsed: ReturnType<typeof parseReviewOutput>; fileContent: string }> {
     const { logger, broadcast } = this.ctx;
     const stateStore = await this.ctx.pr.storeForPr(req.localId);
-    // cleanup 前必须先把文件读出来（与 buildToolEnv 的 LOCAL__REVIEW_PATH 同源）。
+    // The file must be read out before cleanup (same source as buildToolEnv's LOCAL__REVIEW_PATH).
     const outFile = PRAGENT_LOCAL_OUTPUT[req.tool];
     let fileContent = '';
     try {
@@ -435,22 +443,22 @@ export class RunExecutor {
         'pr-agent local provider output file missing; fall back to stdout',
       );
     }
-    // /ask 输出里 pr-agent 把问题原样回显在 answer body 顶部（跟 chat 输入气泡重复）；解析前逐字删掉。
+    // In /ask output pr-agent echoes the question verbatim at the top of the answer body (duplicating the chat input bubble); delete it verbatim before parsing.
     const cleanedContent =
       req.tool === 'ask' && req.question?.trim()
         ? stripAskQuestionEcho(fileContent, req.question, askLangSuffix)
         : fileContent;
     const parsed = parseReviewOutput(cleanedContent || resultStdout, req.tool);
-    // 复评 /ask（引用了某条 finding）：
-    // - 裁决 replace → 把建议提升为带定位的代码评论（取原 finding 的 anchor），渲染 / 采纳同 /review 代码反馈；
-    // - 裁决 replace / drop → 静默关闭被引用的原 finding（建立关闭关系 + 广播），无需用户手动点关闭。
-    // keep / 无裁决：原评论保留、不动。
+    // Re-review /ask (a finding was referenced):
+    // - verdict replace → promote the suggestion to a positioned code comment (taking the original finding's anchor), rendered / adopted like /review code feedback;
+    // - verdict replace / drop → silently close the referenced original finding (establish the closure relation + broadcast), no need for the user to manually click close.
+    // keep / no verdict: the original comment is kept, untouched.
     if (req.tool === 'ask' && req.referencedFinding && parsed.askVerdict && !parsed.llmFailure) {
       const ref = req.referencedFinding;
       const anchor = ref.anchor;
       if (parsed.askVerdict === 'replace' && anchor && typeof anchor.startLine === 'number') {
-        // 已自带定位的 code-suggestion（模型按 marker 锚到引用处）保持不动；否则把建议（退到 summary）
-        // 兜底锚到被引用评论的原位置并升为代码反馈，保证取代评论始终带定位、可采纳。
+        // A code-suggestion that already carries positioning (the model anchored to the reference via the marker) is left untouched; otherwise the suggestion (fallen back to summary)
+        // is fallback-anchored to the referenced comment's original position and promoted to code feedback, ensuring the replacing comment always carries positioning and is adoptable.
         const sug =
           parsed.findings.find(
             (f) => f.sectionKey === 'code-suggestion' || f.sectionKey === 'ask-suggestions',
@@ -475,7 +483,7 @@ export class RunExecutor {
         }
       }
     }
-    // M4 草稿再摄入：/review 成功完成时丢掉 pending+finding 旧草稿（edited/posted/rejected/manual 保留）。
+    // M4 draft re-ingestion: on successful /review completion drop old pending+finding drafts (edited/posted/rejected/manual are kept).
     if (req.tool === 'review') {
       try {
         const dropped = await dropPendingFindingDrafts(stateStore, req.localId);
@@ -494,10 +502,10 @@ export class RunExecutor {
   }
 
   /**
-   * embedded 策略：执行期在嵌入式安装目录的 settings/ 与 settings_prod/ 补空 .secrets.toml
-   * （pr-agent 启动会去找该文件，缺失就打 WARNING；我们走 env 传密钥不用 secrets.toml，写个空
-   * 文件压掉告警）。memo 化：只在首个 embedded run 解析一次目录 + 写文件，后续直接复用。
-   * importlib.util.find_spec 仅定位不 import pr_agent，快；失败仅 warn 不阻断 run。
+   * embedded strategy: at execution time write an empty .secrets.toml into the embedded install dir's settings/ and settings_prod/
+   * (pr-agent looks for this file at startup and prints a WARNING when missing; we pass secrets via env and don't use secrets.toml, so write an empty
+   * file to suppress the warning). Memoized: resolve dir + write file only once on the first embedded run, reused afterwards.
+   * importlib.util.find_spec only locates pr_agent without importing it, fast; on failure only warn, don't block the run.
    */
   private ensureEmbeddedSecrets(pythonPath: string): Promise<void> {
     this.embeddedSecretsEnsured ??= (async () => {

--- a/apps/desktop/src/main/services/pr-agent/run-queue.ts
+++ b/apps/desktop/src/main/services/pr-agent/run-queue.ts
@@ -10,12 +10,12 @@ import {
 import type { ServiceContext } from '../context.js';
 import { RunExecutor } from './run-executor.js';
 
-/** pr-agent run 优先级泳道：user（手动发起，高）/ agent（编排 / AutoPilot 派发，低）。 */
+/** pr-agent run priority lane: user (manually initiated, high) / agent (orchestration / AutoPilot dispatch, low). */
 export type RunPriority = 'user' | 'agent';
 
 /**
- * 队列项：一次入队的 pr-agent run 的全部上下文（含 resolve/reject 回原始调用方）。归调度器所有；执行器
- * （run-executor）仅以 `import type` 引用本类型，类型在运行时被擦除，故不构成运行时循环依赖。
+ * Queue item: all context of one enqueued pr-agent run (including resolve/reject back to the original caller). Owned by the scheduler; the executor
+ * (run-executor) references this type only via `import type`, and the type is erased at runtime, so it forms no runtime circular dependency.
  */
 export interface QueueItem {
   info: PragentRunInfo;
@@ -30,35 +30,35 @@ export interface QueueItem {
   pr: StoredPullRequest;
   resolve: (run: ReviewRun) => void;
   reject: (err: Error) => void;
-  /** 优先级泳道：user（手动发起，高）/ agent（编排 / AutoPilot 派发，低）。 */
+  /** Priority lane: user (manually initiated, high) / agent (orchestration / AutoPilot dispatch, low). */
   priority: RunPriority;
-  /** 仅 active 状态填；用于 cancel SIGKILL */
+  /** Filled only in active state; used for cancel SIGKILL */
   ac?: AbortController;
 }
 
 /**
- * pr-agent run 队列服务。
+ * pr-agent run queue service.
  *
- * FIFO 队列，并发上限 maxConcurrency（post-Docker 下每个 run 独立 worktree + 独立子进程，
- * 并发安全）。其余在 waiting 排队；每次 active 完成 / 取消 → 自动泵下一条。
+ * FIFO queue, concurrency cap maxConcurrency (post-Docker, each run has an independent worktree + independent subprocess,
+ * concurrency-safe). The rest queue in waiting; each time an active run completes / cancels → automatically pump the next one.
  *
- * 设计要点：
- *   - runId 在入队时就分配（跟最终落盘 ReviewRun.id 一致），cancel(runId) 在 active / waiting
- *     两种状态都能精确定位
- *   - queued 状态不落盘；被取消时直接 reject 原 Promise，不留 disk artifact
- *   - 真正 dequeue 才 startReviewRun 写 disk + 跑 pr-agent
- *   - 每次队列变化广播 'pragent:queueChanged'，renderer store 同步
+ * Design points:
+ *   - runId is assigned at enqueue (consistent with the finally-persisted ReviewRun.id), so cancel(runId) can precisely locate it
+ *     in both active / waiting states
+ *   - queued state is not persisted; when cancelled it directly rejects the original Promise, leaving no disk artifact
+ *   - only on actual dequeue does startReviewRun write disk + run pr-agent
+ *   - each queue change broadcasts 'pragent:queueChanged', syncing the renderer store
  *
- * 队列与运行态（waiting / active / 并发上限）是实例可变状态，故以 class 封装；PR 领域操作
- * （镜像 / diff base / adapter）经注入的 ctx.pr 取用。
+ * The queue and running state (waiting / active / concurrency cap) are instance-mutable state, hence encapsulated in a class; PR domain operations
+ * (mirror / diff base / adapter) are accessed via the injected ctx.pr.
  */
 export class RunQueue {
   private readonly waiting: QueueItem[] = [];
-  /** 并发运行中的 run（runId → item）；上限 maxConcurrency。 */
+  /** Concurrently running runs (runId → item); capped at maxConcurrency. */
   private readonly active = new Map<string, QueueItem>();
-  /** 并发上限；可经 setMaxConcurrency 热替换（config:setMaxConcurrency）。 */
+  /** Concurrency cap; hot-swappable via setMaxConcurrency (config:setMaxConcurrency). */
   private maxConcurrency: number;
-  /** run 执行器（落盘 / worktree / spawn / 解析收尾）；调度与执行分离，本类只负责并发 / 优先级 / 取消。 */
+  /** Run executor (persist / worktree / spawn / parse finalize); scheduling and execution are separated, this class only handles concurrency / priority / cancel. */
   private readonly executor: RunExecutor;
 
   constructor(private readonly ctx: ServiceContext) {
@@ -67,8 +67,8 @@ export class RunQueue {
   }
 
   /**
-   * 入队一个 pr-agent run（与用户手动 run 共用同一队列 / 并发 / 取消机制）。dedup：同 PR
-   * 同工具已在执行 / 排队则抛错（/ask 不限）。resolve 完成的 ReviewRun。
+   * Enqueue a pr-agent run (shares the same queue / concurrency / cancel mechanism as a user's manual run). dedup: if the same PR
+   * with the same tool is already executing / queued, throw (/ask is unrestricted). Resolves the completed ReviewRun.
    */
   enqueuePragentRun(
     pr: StoredPullRequest,
@@ -80,8 +80,8 @@ export class RunQueue {
     scope?: ReviewRun['scope'],
   ): Promise<ReviewRun> {
     const { logger } = this.ctx;
-    // dedup 仅约束「PR 全量」的同工具重复；/ask 每次问题不同、单 commit 范围（scope）是定向动作，均放行
-    // （允许全量 review 之外再对某 commit 单独 review，互不视作重复）。
+    // dedup only constrains same-tool duplicates for the "full PR"; /ask (a different question each time) and single-commit scope (a targeted action) are both let through
+    // (allowing a per-commit review in addition to the full review, without treating them as duplicates).
     if (tool !== 'ask' && !scope) {
       const sameTask = (q: QueueItem): boolean =>
         q.info.prLocalId === pr.localId && q.info.tool === tool;
@@ -89,7 +89,7 @@ export class RunQueue {
         throw new AppError(ERROR_CODES.AG_DUPLICATE_TASK, { tool });
       }
     }
-    // 入队时就分配 runId；后续 cancel(runId) 在 waiting / active 都能定位
+    // Assign runId at enqueue; a later cancel(runId) can locate it in both waiting / active
     const runId = makeRunId(new Date());
     return new Promise<ReviewRun>((resolve, reject) => {
       const item: QueueItem = {
@@ -105,15 +105,15 @@ export class RunQueue {
           enqueuedAt: new Date().toISOString(),
           startedAt: null,
         },
-        // referencedContext / referencedFinding 仅入 req（内存态，不进 info/PragentRunInfo）→ 不进队列广播。
-        // referencedFinding 会在 run-executor startRun 时落到 ReviewRun（前向链持久化）。
+        // referencedContext / referencedFinding only go into req (in-memory state, not into info/PragentRunInfo) → not in the queue broadcast.
+        // referencedFinding is persisted to the ReviewRun during run-executor startRun (forward-chain persistence).
         req: {
           localId: pr.localId,
           tool,
           question,
           referencedContext: tool === 'ask' ? referencedContext : undefined,
           referencedFinding: tool === 'ask' ? referencedFinding : undefined,
-          // 单 commit 范围对所有工具生效（不限 ask）：executor 据此物化 parent..sha 的 worktree。
+          // Single-commit scope applies to all tools (not just ask): the executor uses it to materialize the parent..sha worktree.
           scope,
         },
         pr,
@@ -121,7 +121,7 @@ export class RunQueue {
         resolve,
         reject,
       };
-      // 优先级插队：user 任务排到所有 agent 任务之前（同泳道内仍 FIFO）；不打断在跑的 run。
+      // Priority jump-in: user tasks queue ahead of all agent tasks (still FIFO within the same lane); does not interrupt a running run.
       if (priority === 'user') {
         const firstAgentIdx = this.waiting.findIndex((q) => q.priority === 'agent');
         if (firstAgentIdx >= 0) this.waiting.splice(firstAgentIdx, 0, item);
@@ -138,25 +138,25 @@ export class RunQueue {
   }
 
   /**
-   * 热替换并发上限（config:setMaxConcurrency）。调大后立即泵队列填满新名额；调小不打断在跑的 run，
-   * 自然随其完成收敛（pump 仅在 active 降到新上限以下才起跑后续）。
+   * Hot-swap the concurrency cap (config:setMaxConcurrency). After raising it, immediately pump the queue to fill the new slots; lowering it does not interrupt running runs,
+   * converging naturally as they complete (pump only starts subsequent runs once active drops below the new cap).
    */
   setMaxConcurrency(max: number): void {
     this.maxConcurrency = max;
     this.pump();
   }
 
-  /** 取消一个 run（pragent:cancel）：active→SIGKILL；waiting→出队 + reject；都不匹配→ok:false。 */
+  /** Cancel one run (pragent:cancel): active→SIGKILL; waiting→dequeue + reject; neither matches→ok:false. */
   cancel(runId: string): { ok: boolean } {
     const { logger } = this.ctx;
-    // active 命中 → SIGKILL (finally 会写 cancelled 到 disk)
+    // active hit → SIGKILL (finally will write cancelled to disk)
     const running = this.active.get(runId);
     if (running) {
       logger.info({ runId }, 'pragent run cancel: active');
       running.ac?.abort();
       return { ok: true };
     }
-    // waiting 命中 → 从队列删除 + reject 原 Promise，不写盘 (从未真正跑过)
+    // waiting hit → remove from queue + reject the original Promise, no disk write (never actually ran)
     const idx = this.waiting.findIndex((q) => q.info.runId === runId);
     if (idx >= 0) {
       const [removed] = this.waiting.splice(idx, 1);
@@ -168,7 +168,7 @@ export class RunQueue {
     return { ok: false };
   }
 
-  /** 当前队列快照（pragent:queue / 广播用）。 */
+  /** Current queue snapshot (for pragent:queue / broadcast). */
   snapshot(): { active: PragentRunInfo[]; waiting: PragentRunInfo[] } {
     return {
       active: [...this.active.values()].map((q) => q.info),
@@ -176,7 +176,7 @@ export class RunQueue {
     };
   }
 
-  /** 取消某 PR 的全部 run：active 的 SIGKILL，waiting 的出队 + reject。 */
+  /** Cancel all runs for a PR: SIGKILL the active ones, dequeue + reject the waiting ones. */
   cancelRunsForPr(localId: string): void {
     for (const item of this.active.values()) if (item.req.localId === localId) item.ac?.abort();
     let removed = false;
@@ -190,7 +190,7 @@ export class RunQueue {
     if (removed) this.broadcastQueueChanged();
   }
 
-  /** active + waiting 涉及的 PR localId 集合（terminateAgentsForGonePrs 用）。 */
+  /** Set of PR localIds involved in active + waiting (used by terminateAgentsForGonePrs). */
   queuedPrLocalIds(): string[] {
     const ids: string[] = [];
     for (const item of this.active.values()) ids.push(item.req.localId);
@@ -198,7 +198,7 @@ export class RunQueue {
     return ids;
   }
 
-  /** 应用退出时中止所有进行中的 run，返回被中止的 run 数。 */
+  /** Abort all in-progress runs on app exit, returning the number of aborted runs. */
   abortAllActiveRuns(): number {
     let n = 0;
     for (const item of this.active.values()) {
@@ -213,8 +213,8 @@ export class RunQueue {
   }
 
   /**
-   * 队列泵：在并发未达上限且 waiting 非空时，连续 dequeue 起跑，直到填满 maxConcurrency。
-   * 每条 run 结束（成功/失败/取消）后从 active 移除并再泵一次，自然续上后续任务。
+   * Queue pump: while concurrency is below the cap and waiting is non-empty, continuously dequeue and start runs until maxConcurrency is filled.
+   * After each run ends (success/failure/cancel) it is removed from active and the pump runs again, naturally continuing subsequent tasks.
    */
   private pump(): void {
     while (this.active.size < this.maxConcurrency && this.waiting.length > 0) {
@@ -230,7 +230,7 @@ export class RunQueue {
         .finally(() => {
           this.active.delete(item.info.runId);
           this.broadcastQueueChanged();
-          // 放微任务里再泵，避免递归栈累积
+          // Pump again in a microtask to avoid recursive stack buildup
           queueMicrotask(() => this.pump());
         });
     }

--- a/apps/desktop/src/main/services/pr-agent/usage.ts
+++ b/apps/desktop/src/main/services/pr-agent/usage.ts
@@ -1,6 +1,6 @@
 import type { TokenUsage } from '@meebox/shared';
 
-// litellm usage 哨兵行前缀（与 sitecustomize.py 的 _emit 保持一致）。
+// litellm usage sentinel-line prefix (kept consistent with sitecustomize.py's _emit).
 export const USAGE_SENTINEL = '@@MEEBOX_USAGE@@';
 
 export interface UsageAcc {
@@ -8,22 +8,22 @@ export interface UsageAcc {
   completion: number;
   total: number;
   calls: number;
-  /** 累计提示缓存读取 token（cache_read），是 prompt 的一部分 */
+  /** Cumulative prompt-cache read tokens (cache_read), part of prompt */
   cacheRead: number;
-  /** 累计模型交互轮次：CLI agentic 模式来自各次哨兵的 num_turns（一次 run 内可累加多段） */
+  /** Cumulative model interaction turns: in CLI agentic mode comes from each sentinel's num_turns (can accumulate multiple segments within one run) */
   turns: number;
   any: boolean;
 }
 
-/** 新建一个空 usage 累加器。 */
+/** Create a new empty usage accumulator. */
 export function newUsageAcc(): UsageAcc {
   return { prompt: 0, completion: 0, total: 0, calls: 0, cacheRead: 0, turns: 0, any: false };
 }
 
 /**
- * 解析一行 stderr：若含 usage 哨兵（`@@MEEBOX_USAGE@@ {json}`，sitecustomize 注入）则累加到
- * acc 并返回 true（调用方据此吞掉该行、不转发给 renderer / 不入日志）。普通行返回 false。
- * 坏 JSON 也返回 true（仍吞掉，避免漏进实时日志），只是不计数。容错优先。
+ * Parse one stderr line: if it contains a usage sentinel (`@@MEEBOX_USAGE@@ {json}`, injected by sitecustomize), accumulate into
+ * acc and return true (the caller thus swallows the line, not forwarding to the renderer / not logging). Normal lines return false.
+ * Bad JSON also returns true (still swallowed, to avoid leaking into live logs), just not counted. Fault-tolerance first.
  */
 export function accumulateUsageSentinel(line: string, acc: UsageAcc): boolean {
   const i = line.indexOf(USAGE_SENTINEL);
@@ -52,29 +52,29 @@ export function accumulateUsageSentinel(line: string, acc: UsageAcc): boolean {
     if (typeof r.cache_read_tokens === 'number') acc.cacheRead += r.cache_read_tokens;
     if (typeof r.turns === 'number') acc.turns += r.turns;
   } catch {
-    // 坏哨兵行：仍吞掉，不计数
+    // Bad sentinel line: still swallowed, not counted
   }
   return true;
 }
 
-/** 累加器 → TokenUsage；无任何有效数据返回 undefined（未捕获到，如非 embedded / 流式 / 未调 LLM）。 */
+/** Accumulator → TokenUsage; returns undefined if there's no valid data (nothing captured, e.g. non-embedded / streaming / LLM never called). */
 export function finalizeUsage(acc: UsageAcc): TokenUsage | undefined {
   if (!acc.any) return undefined;
   return {
     promptTokens: acc.prompt,
     completionTokens: acc.completion,
-    // 优先各次 total 累加；个别次缺 total 时用 prompt+completion 兜底
+    // Prefer accumulating each call's total; fall back to prompt+completion when an individual call lacks total
     totalTokens: acc.total || acc.prompt + acc.completion,
     calls: acc.calls,
-    // cache_read 无命中（0）则不带；turns 优先 CLI 上报的轮次，缺失回退为调用次数
+    // Omit cache_read when there's no hit (0); turns prefers the CLI-reported turns, falling back to the call count when missing
     cacheReadTokens: acc.cacheRead || undefined,
     turns: acc.turns || acc.calls,
   };
 }
 
 /**
- * 持久化前从 stderr 去掉 usage 哨兵行：onLine 实时已拦截不转发，但 exec 内部把全量 stderr
- * 累加进 result.stderr（含哨兵），落盘前清掉这些噪声行。
+ * Strip usage sentinel lines from stderr before persistence: onLine already intercepts them in real time without forwarding, but exec internally
+ * accumulates all stderr into result.stderr (including sentinels), so clear these noise lines before persisting.
  */
 export function stripUsageSentinels(stderr: string | undefined): string | undefined {
   if (!stderr) return stderr;

--- a/apps/desktop/src/main/services/pr-agent/worktree-sanitize.ts
+++ b/apps/desktop/src/main/services/pr-agent/worktree-sanitize.ts
@@ -3,33 +3,33 @@ import path from 'node:path';
 import type { Logger } from 'pino';
 
 /**
- * CLI 模式下 /ask 会把子进程 cwd 落到一次性 worktree 以取得完整文件上下文（见 run-executor +
- * pragent-shim cli/install.py）。但被评审仓库可能自带 agent 指令文件（claude / codex / gemini /
- * cursor / copilot 的项目记忆），在 cwd 命中后会被 CLI 自动加载、污染 /ask 回答（含潜在 prompt 注入）。
+ * In CLI mode /ask sets the subprocess cwd to a one-shot worktree to obtain full file context (see run-executor +
+ * pragent-shim cli/install.py). But the reviewed repo may carry its own agent instruction files (project memory for
+ * claude / codex / gemini / cursor / copilot), which after the cwd lands are auto-loaded by the CLI and pollute the /ask answer (including potential prompt injection).
  *
- * 这里把 worktree 内这些指令文件**清空（present-but-blank）**：文件仍在、内容为空 → CLI 加载到空指令，
- * 等同未配置。worktree 用后即弃（cleanup 直接 rm -rf），就地改写无副作用；pr-agent 的 diff 走 commit 级
- * merge-base，不读工作树状态，故清空不影响评审 diff。仅 /ask 走此路径，describe/review 维持中性临时目录。
+ * Here we **blank out (present-but-blank)** these instruction files within the worktree: the file remains, content empty → the CLI loads empty instructions,
+ * equivalent to unconfigured. The worktree is discarded after use (cleanup just rm -rf), so in-place rewriting has no side effects; pr-agent's diff uses a commit-level
+ * merge-base and doesn't read working-tree state, so blanking doesn't affect the review diff. Only /ask takes this path; describe/review keep a neutral temp dir.
  */
 
-/** 按文件名匹配、任意层级都清空的项目记忆文件（claude / codex / gemini）。 */
+/** Project-memory files matched by filename and blanked at any level (claude / codex / gemini). */
 const INSTRUCTION_BASENAMES = new Set(['CLAUDE.md', 'AGENTS.md', 'GEMINI.md', '.cursorrules']);
-/** 递归时跳过的目录（体积大 / 与指令无关）。 */
+/** Directories skipped during recursion (large / unrelated to instructions). */
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'vendor']);
-/** 根级固定路径的指令资源（相对 worktree 根，path.sep 归一）。 */
+/** Fixed-path instruction resource at the root level (relative to worktree root, path.sep normalized). */
 const GITHUB_COPILOT = path.join('.github', 'copilot-instructions.md');
 
-/** rel（相对 worktree 根）是否属于需清空的指令文件。 */
+/** Whether rel (relative to worktree root) is an instruction file that needs blanking. */
 function isInstructionFile(rel: string): boolean {
   if (INSTRUCTION_BASENAMES.has(path.basename(rel))) return true;
   if (rel === GITHUB_COPILOT) return true;
-  // cursor 规则目录 `.cursor/rules/**` 下任意文件。
+  // Any file under the cursor rules directory `.cursor/rules/**`.
   const parts = rel.split(path.sep);
   if (parts[0] === '.cursor' && parts[1] === 'rules') return true;
   return false;
 }
 
-/** 递归收集 worktree 内全部文件路径（跳过 SKIP_DIRS）。 */
+/** Recursively collect all file paths within the worktree (skipping SKIP_DIRS). */
 async function collectFiles(dir: string, acc: string[]): Promise<void> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const e of entries) {
@@ -43,8 +43,8 @@ async function collectFiles(dir: string, acc: string[]): Promise<void> {
 }
 
 /**
- * 清空一次性 worktree 内被评审仓库自带的 agent 指令文件。Best-effort：整体或单文件失败仅 warn，
- * 不阻断 /ask（最坏退回「可能读到仓库指令」，不致命）。
+ * Blank out the reviewed repo's own agent instruction files within the one-shot worktree. Best-effort: on overall or single-file failure only warn,
+ * don't block /ask (worst case falls back to "might read repo instructions", not fatal).
  */
 export async function neutralizeWorktreeInstructions(dir: string, logger?: Logger): Promise<void> {
   try {

--- a/apps/desktop/src/main/services/pr-service.ts
+++ b/apps/desktop/src/main/services/pr-service.ts
@@ -19,38 +19,38 @@ import type { JsonFileStateStore } from '@meebox/state-store';
 import type { ConnectionRuntime } from '../adapters.js';
 import { broadcast } from './broadcast.js';
 
-/** PrService 构造依赖（由 context 注入）。 */
+/** PrService construction dependencies (injected by context). */
 export interface PrServiceDeps {
   bootstrap: BootstrapResult;
   stateStore: JsonFileStateStore;
-  /** 归档 PR 冷存储：定位 PR 时活跃库未命中后兜底（「已关闭」视图打开已归档 PR 详情）。 */
+  /** Archived PR cold storage: fallback when the active store misses during PR lookup (opening an archived PR's details from the "closed" view). */
   archiveStore: JsonFileStateStore;
-  /** 可变连接运行时；reconfigure 原地替换内容，本服务经引用读到最新 adapters。 */
+  /** Mutable connection runtime; reconfigure replaces the contents in place, and this service reads the latest adapters via the reference. */
   connectionRuntime: ConnectionRuntime;
   repoMirror: RepoMirrorManager;
 }
 
 /**
- * PR 领域服务：PR 定位 / 连接 adapter 解析 / 仓库镜像就位 / diff base 解析 / 评论缓存失效。
+ * PR domain service: PR lookup / connection adapter resolution / repo mirror readiness / diff base resolution / comments cache invalidation.
  *
- * 把原先散落在 common/ 的 pr-lookup·mirror·comments-cache 收拢为单一强领域类，依赖经构造注入、
- * 各方法共享 `this.deps`，避免逐函数透传。controller 一律经 `ctx.pr.<method>()` 调用；调用方
- * 应以实例方法形式调用（勿解构方法，否则丢失 this 绑定）。
+ * Collects the pr-lookup·mirror·comments-cache previously scattered in common/ into a single strong domain class, with dependencies injected via the constructor and
+ * each method sharing `this.deps`, avoiding per-function pass-through. Controllers always call via `ctx.pr.<method>()`; callers
+ * should invoke as instance methods (do not destructure methods, or the this binding is lost).
  */
 export class PrService {
   /**
-   * 按 localId 索引正在跑的 resolveDiffBaseSha。打开 PR 时 listChangedFiles / getFileContent /
-   * getBlame / listCommits / getCommitCount 等多个 handler 会并发解析同一 PR 的 diff-base：去重后
-   * 只算一次 merge-base、只写一次 diff-base.json，避免对同一 key 的并发写（Windows 上会触发 rename
-   * EPERM，见 JsonFileStateStore 自愈）。
+   * Indexes in-flight resolveDiffBaseSha by localId. When opening a PR, multiple handlers such as listChangedFiles / getFileContent /
+   * getBlame / listCommits / getCommitCount concurrently resolve the same PR's diff-base: after dedup,
+   * merge-base is computed once and diff-base.json is written once, avoiding concurrent writes to the same key (which triggers rename
+   * EPERM on Windows, see JsonFileStateStore self-heal).
    */
   private readonly diffBaseInFlight = new Map<string, Promise<string>>();
 
   constructor(private readonly deps: PrServiceDeps) {}
 
   /**
-   * 按 localId 在状态库定位 PR，找不到抛错（统一错误文案）。先查活跃库；未命中再兜底归档冷存储，
-   * 使「已关闭」视图打开已归档 PR 时其 diff / 评论等路径仍可解析。
+   * Locate a PR by localId in the state store, throwing if not found (uniform error text). Query the active store first; on miss fall back to archived cold storage,
+   * so an archived PR's diff / comments paths still resolve when opened from the "closed" view.
    */
   async findPrOrThrow(localId: string): Promise<StoredPullRequest> {
     const prs = await listStoredPullRequests(this.deps.stateStore);
@@ -62,18 +62,18 @@ export class PrService {
   }
 
   /**
-   * 解析某 PR 的 per-PR 存储根：已归档（索引 `archivedAt` 非空）→ 归档冷存储，否则活跃存储。
+   * Resolve a PR's per-PR storage root: archived (index `archivedAt` non-empty) → archived cold storage, otherwise the active store.
    *
-   * 所有 per-PR 子树读写（评论缓存 / 草稿 / 关闭关系 / 评审 run / 会话 / 台账 / diff-base 缓存）都应
-   * 经此解析后落到正确的根——否则对已归档 PR 的写会落进活跃存储，被下轮 poll 对账（`relocateTree` 源覆盖
-   * 目的、先清空目的）连同归档数据一并误删（见 docs/arch/99-core/01-state-storage）。索引始终只在活跃存储维护，故据它判定。
+   * All per-PR subtree reads/writes (comments cache / drafts / close relations / review run / sessions / ledger / diff-base cache) should
+   * land on the correct root after this resolution — otherwise a write for an archived PR lands in the active store and gets erroneously deleted along with archived data by the next poll reconciliation (`relocateTree` source overwrites
+   * destination, clearing destination first) (see docs/arch/99-core/01-state-storage). The index is always maintained only in the active store, so decide by it.
    */
   async storeForPr(localId: string): Promise<JsonFileStateStore> {
     const index = await readPrIndex(this.deps.stateStore);
     return index?.prs[localId]?.archivedAt ? this.deps.archiveStore : this.deps.stateStore;
   }
 
-  /** PR → RepoIdentity（host / projectKey / repoSlug）；connection 缺失抛错。 */
+  /** PR → RepoIdentity (host / projectKey / repoSlug); throws if the connection is missing. */
   repoIdentityFor(pr: StoredPullRequest): RepoIdentity {
     const conn = this.deps.bootstrap.config.connections.find((c) => c.id === pr.connectionId);
     if (!conn) throw new Error(`connection not found: ${pr.connectionId}`);
@@ -84,13 +84,13 @@ export class PrService {
     };
   }
 
-  /** PR 对应连接的 adapter；连接无 adapter 时返回 undefined。 */
+  /** The adapter of the PR's connection; returns undefined when the connection has no adapter. */
   adapterFor(pr: StoredPullRequest): PlatformAdapter | undefined {
     return this.deps.connectionRuntime.adapters.find((a) => a.connectionId === pr.connectionId)
       ?.adapter;
   }
 
-  /** 同 adapterFor，但无 adapter 时抛错（绝大多数 handler 走它）。 */
+  /** Same as adapterFor, but throws when there is no adapter (the vast majority of handlers use it). */
   adapterForOrThrow(pr: StoredPullRequest): PlatformAdapter {
     const adapter = this.adapterFor(pr);
     if (!adapter) throw new Error(`no adapter for connection ${pr.connectionId}`);
@@ -98,14 +98,14 @@ export class PrService {
   }
 
   /**
-   * 打开 PR 时镜像就位的保障。优先快速路径：本地 bare 已含 head+base 两个 sha
-   * → 直接回 mirrorPath，不打远端。两 sha 都齐意味着上次 sync 已经覆盖了本 PR
-   * 的 commit 范围（PR sha 是 immutable 的），renderer 可以直接走本地 diff 计算。
+   * Guarantees mirror readiness when opening a PR. Prefer the fast path: local bare already contains both head+base shas
+   * → return mirrorPath directly, no remote call. Both shas present means the last sync already covered this PR's
+   * commit range (PR sha is immutable), so the renderer can compute the diff locally.
    *
-   * 缺 sha (任一) → 走 syncMirror 兜底走 git fetch。
+   * Missing sha (either one) → go through syncMirror falling back to git fetch.
    *
-   * 后台 poll 在拿到 PR 状态更新后会主动 syncMirror，所以正常打开 PR 时
-   * 快速路径命中率应该很高。
+   * Background poll actively syncMirror after getting PR status updates, so on a normal PR open
+   * the fast-path hit rate should be high.
    */
   async ensureMirrorReadyForPr(
     pr: StoredPullRequest,
@@ -116,13 +116,13 @@ export class PrService {
       this.deps.repoMirror.hasCommit(id, pr.targetRef.sha),
     ]);
     if (hasHead && hasBase) {
-      // 快速路径：mirror 已含 head + base，直接回不打远端。命中频繁，不打 log
+      // Fast path: mirror already contains head + base, return directly without a remote call. Frequently hit, so no log.
       return { mirrorPath: this.deps.repoMirror.mirrorPath(id), freshClone: false };
     }
     const r = await this.deps.repoMirror.syncMirror(id);
-    // 自愈：源分支被删 / 强推后 head sha 不在 refs/heads，syncMirror（只抓 heads + Bitbucket 通配 PR 引用）
-    // 仍补不齐 → 按平台 + PR 号精确 fetch PR 头引用（GitHub refs/pull/<n>/head 等，通配取不到，必须精确）。
-    // 补齐后 diff base...head 才不报 "Invalid symmetric difference"。best-effort，仍缺则由下游 diff 抛可读错误。
+    // Self-heal: after the source branch is deleted / force-pushed, head sha is not in refs/heads, and syncMirror (only fetches heads + Bitbucket wildcard PR refs)
+    // still cannot backfill → precisely fetch the PR head ref by platform + PR number (GitHub refs/pull/<n>/head etc., unreachable by wildcard, must be precise).
+    // Only after backfill does diff base...head not report "Invalid symmetric difference". Best-effort; if still missing, downstream diff throws a readable error.
     if (!(await this.deps.repoMirror.hasCommit(id, pr.sourceRef.sha))) {
       const refspec = pullRequestHeadRefspec(pr.platform, pr.remoteId);
       if (refspec) await this.deps.repoMirror.fetchRefspecs(id, [refspec]);
@@ -131,24 +131,24 @@ export class PrService {
   }
 
   /**
-   * 解析 PR diff 的固定 base（merge-base）——见 `@meebox/poller` diff-base-cache。
+   * Resolve a PR diff's fixed base (merge-base) — see `@meebox/poller` diff-base-cache.
    *
-   * PR diff 的语义基准是「源分支自目标分支分叉处」= `merge-base(targetRef.sha, sourceRef.sha)`，
-   * 而非目标分支当前 tip（会随别的 PR 合入前移）。首次算出后固化于 `prs/<localId>/diff-base.json`，
-   * 之后 listChangedFiles / 文件内容 / commitCount / blame / pr-agent worktree 一律以它为 base：
-   * - 内容（Monaco 左栏）锚到 merge-base → 编辑器即真三点，目标漂移不再把别的 PR 改动倒挂进来；
-   * - 行锚点（评论 / finding）有了固定参照，目标漂移不致错位。
+   * A PR diff's semantic baseline is "where the source branch forked from the target branch" = `merge-base(targetRef.sha, sourceRef.sha)`,
+   * not the target branch's current tip (which advances as other PRs merge in). Once computed, it is fixed in `prs/<localId>/diff-base.json`,
+   * and thereafter listChangedFiles / file content / commitCount / blame / pr-agent worktree all use it as base:
+   * - content (Monaco left column) anchored to merge-base → the editor is a true three-dot diff, and target drift no longer back-hangs other PRs' changes;
+   * - line anchors (comment / finding) have a fixed reference, so target drift does not misalign them.
    *
-   * 失效重算：
-   * - 固化 base 不再是当前 head 的祖先（源分支被 rebase）；
-   * - 当前 target 已经成为 head 的祖先，说明源分支把目标分支 merge 进来了，旧分叉点会把 merge
-   *   带来的目标分支内容也算进 PR diff。
-   * 算不出（缺对象 / 无共同祖先）→ 兜底退回 targetRef.sha 且**不固化**，下次再试。
+   * Invalidate and recompute when:
+   * - the fixed base is no longer an ancestor of the current head (source branch was rebased);
+   * - the current target has become an ancestor of head, meaning the source branch merged the target branch in, and the old fork point would count the merge-brought
+   *   target branch content into the PR diff too.
+   * Uncomputable (missing object / no common ancestor) → fall back to targetRef.sha and **do not fix it**, retry next time.
    *
-   * 前置：mirror 已含 head + targetRef.sha（diff 入口已 ensureMirrorReadyForPr / syncMirror）。
+   * Precondition: mirror already contains head + targetRef.sha (the diff entry has already done ensureMirrorReadyForPr / syncMirror).
    */
   async resolveDiffBaseSha(pr: StoredPullRequest): Promise<string> {
-    // 并发去重：同一 PR 的多路并发解析复用同一 in-flight Promise，只算一次、只写一次 diff-base.json。
+    // Concurrency dedup: multiple concurrent resolutions of the same PR reuse the same in-flight Promise, computing once and writing diff-base.json once.
     const existing = this.diffBaseInFlight.get(pr.localId);
     if (existing) return existing;
     const promise = this.computeDiffBaseSha(pr).finally(() => {
@@ -161,7 +161,7 @@ export class PrService {
   private async computeDiffBaseSha(pr: StoredPullRequest): Promise<string> {
     const id = this.repoIdentityFor(pr);
     const head = pr.sourceRef.sha;
-    // 已归档 PR（已关闭范围打开看 diff）其 diff-base 缓存须落归档存储，避免写活跃存储被对账误删。
+    // For an archived PR (opened from the closed scope to view diff), its diff-base cache must land in archived storage, to avoid a write to the active store being erroneously deleted by reconciliation.
     const store = await this.storeForPr(pr.localId);
     const cached = await readDiffBaseCache(store, pr.localId);
     if (
@@ -187,16 +187,16 @@ export class PrService {
   }
 
   /**
-   * 清掉某 PR 的评论缓存并广播 `comments:changed`，让 CommentsPanel / DiffView 内嵌评论重拉刷新。
-   * 收口 comments reply/delete/edit 与 drafts:publishBatch 共用的链路（清 `prs/<localId>/comments`
-   * 缓存 → 下次 listComments force 拉远端 → 广播触发重拉）。cache miss 无所谓，吞掉异常。
+   * Clear a PR's comments cache and broadcast `comments:changed`, so CommentsPanel / DiffView inline comments re-fetch and refresh.
+   * Consolidates the path shared by comments reply/delete/edit and drafts:publishBatch (clear `prs/<localId>/comments`
+   * cache → next listComments force-fetches remote → broadcast triggers a re-fetch). A cache miss is fine, swallow the exception.
    */
   async invalidateCommentsCache(localId: string): Promise<void> {
     try {
       const store = await this.storeForPr(localId);
       await store.delete(`prs/${localId}/comments`);
     } catch {
-      /* cache miss 也无所谓 */
+      /* cache miss is fine */
     }
     broadcast('comments:changed', { localId });
   }

--- a/apps/desktop/src/main/utils/agent.ts
+++ b/apps/desktop/src/main/utils/agent.ts
@@ -1,6 +1,6 @@
 import type { LlmProfile } from '@meebox/shared';
 
-/** 从 llm config 拿当前选中的 profile；active_id 空或找不到都返回 null。 */
+/** Get the currently selected profile from llm config; returns null when active_id is empty or not found. */
 export function resolveActiveLlmProfile(llm: {
   profiles: LlmProfile[];
   active_id: string;

--- a/apps/desktop/src/main/utils/connection-state.ts
+++ b/apps/desktop/src/main/utils/connection-state.ts
@@ -2,24 +2,26 @@ import type { PlatformUser } from '@meebox/shared';
 import type { StateStore } from '@meebox/state-store';
 
 /**
- * 连接级本地状态（按 connectionId 持久化在 state store）。当前只存「上次 ping 拿到的当前
- * 用户身份」用于预热 poller 判 approved（首轮即正确、不必等 ping）；结构刻意留作可扩展，
- * 后续可在此追加其它连接级交互状态（如最近查看时间、列表偏好等）。
+ * Connection-level local state (persisted per connectionId in the state store). Currently only
+ * stores the "current user identity from the last ping" to warm up the poller's approved check
+ * (correct from the first round, no need to wait for a ping); the structure is intentionally left
+ * extensible so other connection-level interaction state (e.g. last-viewed time, list preferences)
+ * can be appended here later.
  */
 export interface ConnectionState {
-  /** 上次 ping 得到的当前 PAT 所属用户；用于建连接时预热 adapter 的 currentUser 缓存。 */
+  /** The user owning the current PAT from the last ping; used to warm up the adapter's currentUser cache when establishing a connection. */
   user?: PlatformUser | null;
 }
 
 interface ConnectionStateFile {
   schema_version: 1;
-  /** connectionId → 该连接的本地状态 */
+  /** connectionId → local state of that connection */
   connections: Record<string, ConnectionState>;
 }
 
 const KEY = 'connections/state';
 
-/** 读取全部连接状态；无文件返回空表。 */
+/** Read all connection states; returns an empty table when there is no file. */
 export async function readConnectionStates(
   store: StateStore,
 ): Promise<Record<string, ConnectionState>> {
@@ -27,7 +29,7 @@ export async function readConnectionStates(
   return file?.connections ?? {};
 }
 
-/** 整表写回连接状态。 */
+/** Write the whole table of connection states back. */
 export async function writeConnectionStates(
   store: StateStore,
   connections: Record<string, ConnectionState>,

--- a/apps/desktop/src/main/utils/image.ts
+++ b/apps/desktop/src/main/utils/image.ts
@@ -1,9 +1,11 @@
 /**
- * 按文件头魔数嗅探常见图片格式；嗅不出退到 octet-stream（浏览器仍可能解码 PNG）。
+ * Sniff common image formats by file-header magic numbers; falls back to octet-stream when it
+ * can't be sniffed (the browser may still decode PNG).
  *
- * 用于 Bitbucket 头像本地落盘后回读时还原 content-type —— 落盘时只存裸字节，回读后
- * 还要拼 data URL，content-type 缺失会导致 <img src> 不渲染。Bitbucket 实际只可能
- * 返回 PNG / JPEG / GIF / WebP / SVG 其中之一，但作为防御性嗅探留全。
+ * Used to restore the content-type when reading back a Bitbucket avatar after it was persisted
+ * locally — only raw bytes are stored on write, and reading back still needs to build a data URL,
+ * so a missing content-type would keep <img src> from rendering. Bitbucket can in practice only
+ * return one of PNG / JPEG / GIF / WebP / SVG, but the full set is kept as defensive sniffing.
  */
 export function sniffImageContentType(bytes: Uint8Array): string {
   if (
@@ -34,7 +36,7 @@ export function sniffImageContentType(bytes: Uint8Array): string {
   ) {
     return 'image/webp';
   }
-  // SVG / XML 以 '<' 起；blame avatar 应该不会出 SVG 但兜底
+  // SVG / XML starts with '<'; a blame avatar shouldn't be SVG but this is a fallback
   if (bytes.length >= 1 && bytes[0] === 0x3c) {
     return 'image/svg+xml';
   }

--- a/apps/desktop/src/main/utils/pr-context.ts
+++ b/apps/desktop/src/main/utils/pr-context.ts
@@ -6,26 +6,29 @@ interface BuildPrContextOpts {
   pr: StoredPullRequest;
   adapter: PlatformAdapter;
   logger?: Logger;
-  /** 取最近 N 条 comment (top-level + 嵌套 replies 合计)，默认 20 */
+  /** Take the most recent N comments (top-level + nested replies combined), default 20 */
   maxComments?: number;
-  /** 每条 comment body 截到 N 字符，默认 300 */
+  /** Truncate each comment body to N characters, default 300 */
   maxCommentLen?: number;
 }
 
 /**
- * 把 PR 自身的非 diff 维度信息拼成一段 markdown，注给 pr-agent 作 EXTRA_INSTRUCTIONS。
+ * Assemble the PR's own non-diff information into a markdown block, injected into pr-agent as
+ * EXTRA_INSTRUCTIONS.
  *
- * 包含：
- * - 标题
- * - 描述（PR.description，作者写的；为空时跳过 —— 这正是 /describe 要生成的内容）
- * - 已有评论（按 top-level 时间倒序取最多 N 条 + 嵌套 replies）
+ * Includes:
+ * - Title
+ * - Description (PR.description, written by the author; skipped when empty — this is exactly what
+ *   /describe is meant to generate)
+ * - Existing comments (up to N, top-level in reverse chronological order + nested replies)
  *
- * pr-agent local provider 自己不会去 Bitbucket 拉这些信息（local provider 只看 worktree
- * 的 git diff），所以必须我们这边主动提供。这段会跟 rules.instructions 拼接，让
- * /describe / /review 都能感知背景。
+ * The pr-agent local provider won't fetch this information from Bitbucket itself (the local
+ * provider only looks at the worktree's git diff), so we must provide it proactively. This block
+ * is concatenated with rules.instructions so that both /describe and /review can perceive the
+ * background.
  *
- * 失败 safe：comments fetch 失败 → warn + 跳过；标题以外字段都缺 → 返回空串
- * (调用方可以判断是否要发)。
+ * Fail-safe: comments fetch fails → warn + skip; every field but the title missing → return an
+ * empty string (the caller can decide whether to send it).
  */
 export async function buildPrContext({
   pr,
@@ -62,8 +65,9 @@ export async function buildPrContext({
     );
   }
 
-  // 只有 title 一项时（无描述、无评论）通常意味着 PR 刚开，没什么背景信息可言；
-  // 让调用方拿到空串决定是否注入，避免给 prompt 加无用前缀
+  // When there's only the title (no description, no comments) it usually means the PR was just
+  // opened with no background to speak of; let the caller get an empty string and decide whether
+  // to inject, avoiding a useless prefix on the prompt
   if (sections.length === 1 && !desc && comments.length === 0) {
     return '';
   }
@@ -71,11 +75,11 @@ export async function buildPrContext({
 }
 
 /**
- * 把嵌套评论树拍扁为 markdown 列表：
- * - top-level 按 createdAt 倒序 (最新在前)
- * - 同一 thread 内 replies 跟父节点，保留原顺序
- * - 每行：`<indent>- @<author>[ (file:line)] <YYYY-MM-DD>: <body>`
- * - body 中的换行替换成空格，截到 maxLen 字符
+ * Flatten the nested comment tree into a markdown list:
+ * - top-level sorted by createdAt in reverse order (newest first)
+ * - replies within the same thread follow their parent node, preserving the original order
+ * - each line: `<indent>- @<author>[ (file:line)] <YYYY-MM-DD>: <body>`
+ * - newlines in body replaced with spaces, truncated to maxLen characters
  */
 function formatComments(
   comments: ReadonlyArray<PrComment>,

--- a/apps/desktop/src/main/utils/proxy.ts
+++ b/apps/desktop/src/main/utils/proxy.ts
@@ -1,21 +1,21 @@
-// 出站网络代理 plumbing。读 config.proxy，产出三种形态：
-//   - buildProxyEnv：子进程 env（给 ① pr-agent、③ git HTTPS，litellm/git 认 HTTP(S)_PROXY）
-//   - buildProxyDispatcher：undici ProxyAgent（给 ② Bitbucket Server REST 的 fetch）
-//   - shouldBypass：loopback/本地是否直连（② 在调用点据此决定要不要挂 dispatcher）
-// 一期仅 HTTP 代理；enabled=false 时全部产出「空/直连」，调用点无需各自判断开关。
+// Outbound network proxy plumbing. Reads config.proxy and produces three forms:
+//   - buildProxyEnv: child-process env (for ① pr-agent, ③ git HTTPS; litellm/git honor HTTP(S)_PROXY)
+//   - buildProxyDispatcher: undici ProxyAgent (for ② the fetch to Bitbucket Server REST)
+//   - shouldBypass: whether loopback/local goes direct (② decides at the call site whether to attach a dispatcher)
+// Phase one is HTTP proxy only; when enabled=false all forms yield "empty/direct connection", so call sites need not each check the switch.
 import { ProxyAgent, type Dispatcher } from 'undici';
 import { ERROR_CODES, errorCodeMessage, type ProxyConfig } from '@meebox/shared';
 
-// loopback / 本地：始终直连，不经代理。env 路径靠 NO_PROXY，dispatcher 路径靠 shouldBypass。
+// loopback / local: always direct connection, never through the proxy. The env path relies on NO_PROXY, the dispatcher path on shouldBypass.
 const NO_PROXY = 'localhost,127.0.0.1,::1';
 
-/** loopback / 本地 host → true（应直连，不走代理）。 */
+/** loopback / local host → true (should go direct connection, not through the proxy). */
 export function shouldBypass(host: string): boolean {
-  const h = host.toLowerCase().replace(/^\[|\]$/g, ''); // 去掉 IPv6 字面量方括号
+  const h = host.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 literal brackets
   return h === 'localhost' || h.endsWith('.localhost') || h === '127.0.0.1' || h === '::1';
 }
 
-/** 拼标准代理 URL：`<protocol>://[user:pass@]host:port`。关闭 / 无 host 时 undefined。 */
+/** Build a standard proxy URL: `<protocol>://[user:pass@]host:port`. undefined when disabled / no host. */
 export function proxyUrl(proxy: ProxyConfig): string | undefined {
   if (!proxy.enabled || !proxy.host) return undefined;
   const auth = proxy.username
@@ -25,9 +25,9 @@ export function proxyUrl(proxy: ProxyConfig): string | undefined {
 }
 
 /**
- * 子进程 env：HTTP_PROXY/HTTPS_PROXY/ALL_PROXY + NO_PROXY（大小写都给——不同库读法不一，
- * httpx/git/curl 多认小写，部分认大写）。NO_PROXY 把 loopback/本地排除在代理外。
- * 关闭时返回 {}，调用点 spread 即无副作用。
+ * Child-process env: HTTP_PROXY/HTTPS_PROXY/ALL_PROXY + NO_PROXY (both cases given — libraries read differently,
+ * httpx/git/curl mostly honor lowercase, some honor uppercase). NO_PROXY excludes loopback/local from the proxy.
+ * Returns {} when disabled, so spreading at the call site has no side effect.
  */
 export function buildProxyEnv(proxy: ProxyConfig): Record<string, string> {
   const url = proxyUrl(proxy);
@@ -45,8 +45,8 @@ export function buildProxyEnv(proxy: ProxyConfig): Record<string, string> {
 }
 
 /**
- * undici ProxyAgent（含 Basic Auth，凭据嵌在 URL）。关闭时 undefined。
- * 注意：ProxyAgent 自身不认 NO_PROXY —— loopback 绕过由调用点先过 shouldBypass 决定。
+ * undici ProxyAgent (includes Basic Auth, credentials embedded in the URL). undefined when disabled.
+ * Note: ProxyAgent itself does not honor NO_PROXY — loopback bypass is decided by the call site running shouldBypass first.
  */
 export function buildProxyDispatcher(proxy: ProxyConfig): Dispatcher | undefined {
   const url = proxyUrl(proxy);
@@ -54,12 +54,12 @@ export function buildProxyDispatcher(proxy: ProxyConfig): Dispatcher | undefined
   return new ProxyAgent(url);
 }
 
-// 测试连通用的中性外部端点：返回 204、体积极小。代理能转发到它即说明出网正常。
+// Neutral external endpoint for connectivity testing: returns 204, extremely small. If the proxy can forward to it, outbound networking works.
 const PROXY_TEST_URL = 'https://www.google.com/generate_204';
 
 /**
- * 用给定代理配置试连一个外部地址，验证代理是否可用（设置页「测试连通」）。
- * 拿到任意 HTTP 响应即视为代理转发成功；407 视为认证失败；超时/网络错误归一成 reason。
+ * Try connecting to an external address with the given proxy config to verify the proxy is usable (the settings page "test connectivity").
+ * Any HTTP response counts as a successful proxy forward; 407 counts as auth failure; timeout/network errors are normalized into reason.
  */
 export async function testProxyConnectivity(
   proxy: ProxyConfig,
@@ -84,9 +84,9 @@ export async function testProxyConnectivity(
 }
 
 /**
- * 给某目标 host 造一个「代理感知」的 fetch，注入 BitbucketClient 的 opts.fetch。
- * host 命中 loopback/本地 → 返回 undefined（调用点用默认全局 fetch 直连）。
- * 否则返回带 dispatcher 的 fetch 包装。代理关闭也返回 undefined。
+ * Build a "proxy-aware" fetch for a target host, to inject into BitbucketClient's opts.fetch.
+ * host hits loopback/local → returns undefined (the call site uses the default global fetch for a direct connection).
+ * Otherwise returns a fetch wrapper carrying the dispatcher. Also returns undefined when the proxy is disabled.
  */
 export function proxyFetchForHost(
   proxy: ProxyConfig,

--- a/apps/desktop/src/main/utils/update-check.ts
+++ b/apps/desktop/src/main/utils/update-check.ts
@@ -1,6 +1,6 @@
-// 版本更新检测（仅检测 + 提示，不下载 / 安装）。查 GitHub Releases 最新**稳定版**
-// （/releases/latest 天然排除 prerelease/alpha），与当前版本做 semver 比对。
-// 走配置的出站代理（企业内网友好）；匿名 GitHub API（低频，启动 + 手动），无需 token。
+// Version update check (check + notify only, no download / install). Queries the latest **stable release**
+// from GitHub Releases (/releases/latest naturally excludes prerelease/alpha) and does a semver comparison against the current version.
+// Goes through the configured outbound proxy (enterprise-intranet friendly); anonymous GitHub API (low frequency, startup + manual), no token needed.
 
 import type { ProxyConfig, UpdateCheckResult } from '@meebox/shared';
 import { gt as semverGt, valid as semverValid } from 'semver';
@@ -21,7 +21,7 @@ interface GithubRelease {
 }
 
 /**
- * 检测是否有新版本。任何网络 / 解析失败都收敛成 ok=false + error，不抛。
+ * Check whether a new version exists. Any network / parse failure collapses into ok=false + error, never throws.
  */
 export async function checkForUpdate(
   currentVersion: string,
@@ -34,11 +34,11 @@ export async function checkForUpdate(
     error,
   });
 
-  // semver.valid 容忍前缀 v、拒绝尾部垃圾（1.2.3beta / 1.2.3.4 → null）
+  // semver.valid tolerates a leading v, rejects trailing garbage (1.2.3beta / 1.2.3.4 → null)
   const current = semverValid(currentVersion);
   if (!current) return fail(`Unable to parse the current version: ${currentVersion}`);
 
-  // 代理感知 fetch（命中本地/代理关闭则用全局 fetch 直连）
+  // proxy-aware fetch (hits local / proxy disabled → uses global fetch for a direct connection)
   const doFetch = proxyFetchForHost(proxy, API_HOST) ?? fetch;
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
@@ -47,14 +47,14 @@ export async function checkForUpdate(
       signal: ctrl.signal,
       headers: {
         Accept: 'application/vnd.github+json',
-        // GitHub API 要求 UA；用内部代号（OWNER/REPO 是真实仓库路径，属对外内容，保留）
+        // GitHub API requires a UA; use the internal codename (OWNER/REPO are the real repo path, outward-facing content, kept)
         'User-Agent': 'meebox-updater',
       },
     });
     if (!res.ok) return fail(`GitHub API ${String(res.status)}`);
     const data = (await res.json()) as GithubRelease;
-    // 只提示正式版：/releases/latest 本就排除 prerelease/draft；此处再防御一道，
-    // 万一拿到 prerelease/draft 一律视为「无更新」，不引导用户升到预发布。
+    // Only notify for stable releases: /releases/latest already excludes prerelease/draft; defend once more here,
+    // in case a prerelease/draft comes through treat it uniformly as "no update", never steering the user to a prerelease.
     if (data.prerelease || data.draft) {
       return { ok: true, hasUpdate: false, currentVersion };
     }

--- a/apps/desktop/src/main/utils/update-state.ts
+++ b/apps/desktop/src/main/utils/update-state.ts
@@ -1,22 +1,22 @@
-// 版本更新检测的**单一真相源**：手动检查（设置页 app:checkUpdate）与定时检查
-// （runUpdateCheckIfDue）都把结果交给这里，统一缓存 + 在确有新版时广播给所有窗口。
-// 这样手动查到的新版能同步到状态栏，且任意窗口 / 状态栏挂载时可经 app:getUpdateStatus 水合
-// 已知结果（不必等下一次广播 / 重新发起网络）。进程内缓存，不落盘——重启后由下次检查重填。
+// **Single source of truth** for the version update check: both the manual check (settings page app:checkUpdate)
+// and the scheduled check (runUpdateCheckIfDue) hand their result here, for unified caching + broadcasting to all windows when a new version is confirmed.
+// This way a manually found new version syncs to the status bar, and any window / status bar can, on mount, hydrate
+// the known result via app:getUpdateStatus (no need to wait for the next broadcast / re-initiate a network call). In-process cache, not persisted — refilled by the next check after restart.
 
 import { BrowserWindow } from 'electron';
 import type { UpdateCheckResult } from '@meebox/shared';
 
 let lastResult: UpdateCheckResult | null = null;
 
-/** 最近一次**成功**（ok=true）的检测结果；尚未成功检测过时为 null。 */
+/** The most recent **successful** (ok=true) check result; null when no successful check has occurred yet. */
 export function getLastUpdateResult(): UpdateCheckResult | null {
   return lastResult;
 }
 
 /**
- * 记录一次检测结果并按需广播。失败（ok=false）不覆盖已知好结果、也不广播——保证
- * 「网络拿不到」对用户零打扰；成功结果（无论 hasUpdate）覆盖缓存，仅 hasUpdate 才推
- * app:updateAvailable（与既有「仅有新版才提示」的设计一致）。
+ * Record a check result and broadcast as needed. A failure (ok=false) neither overwrites a known good result nor broadcasts — guaranteeing
+ * "network unreachable" causes zero disturbance to the user; a successful result (regardless of hasUpdate) overwrites the cache, but only hasUpdate pushes
+ * app:updateAvailable (consistent with the existing "notify only on a new version" design).
  */
 export function publishUpdateResult(result: UpdateCheckResult): void {
   if (!result.ok) return;

--- a/apps/desktop/src/main/utils/window-state.ts
+++ b/apps/desktop/src/main/utils/window-state.ts
@@ -3,32 +3,32 @@ import path from 'node:path';
 import type { StateStore } from '@meebox/state-store';
 
 /**
- * 主窗口的本地状态（持久化在 state store），让下次启动沿用上次的窗口大小。
- * 只存尺寸 + 最大化态，不存 x/y 位置 —— 多显示器/分辨率变化时按坐标恢复易把窗口摆到屏幕外，
- * 尺寸恢复无此风险，也契合「记住窗口大小」的诉求（建窗时按当前显示器工作区居中，见 window-manager）。
+ * Local state of the main window (persisted in the state store), so the next launch reuses the previous window size.
+ * Stores only size + maximized state, not x/y position — with multiple displays / resolution changes, restoring by coordinates easily places the window off-screen,
+ * whereas size restoration has no such risk and matches the "remember window size" intent (on window creation, centered within the current display's work area, see window-manager).
  */
 export interface WindowState {
   width?: number;
   height?: number;
-  /** 上次关闭时是否最大化；是则下次启动以正常尺寸建窗后再 maximize。 */
+  /** Whether it was maximized at last close; if so, the next launch creates the window at normal size then maximizes. */
   maximized?: boolean;
 }
 
 const KEY = 'window/state';
 
-/** 读取窗口状态；无文件 / 读取失败由调用方兜底为空。 */
+/** Read the window state; on no file / read failure the caller falls back to empty. */
 export async function readWindowState(store: StateStore): Promise<WindowState> {
   return (await store.read<WindowState>(KEY)) ?? {};
 }
 
-/** 写回窗口状态（in-session 防抖回写走 store，并发安全 + 原子）。 */
+/** Write the window state back (in-session debounced writeback goes through the store, concurrency-safe + atomic). */
 export async function writeWindowState(store: StateStore, state: WindowState): Promise<void> {
   await store.write<WindowState>(KEY, state);
 }
 
 /**
- * 关窗同步落盘：`close` 事件后进程即退出（Windows/Linux 关最后一个窗口即 quit），异步写来不及 flush
- * → 尺寸丢失。故关窗走同步写兜底。路径与 JsonFileStateStore 的 key→path 映射一致（`<stateDir>/window/state.json`）。
+ * Synchronous write to disk on window close: after the `close` event the process exits immediately (Windows/Linux quit on closing the last window), an async write cannot flush in time
+ * → size lost. So window close uses a synchronous write as fallback. The path matches JsonFileStateStore's key→path mapping (`<stateDir>/window/state.json`).
  */
 export function writeWindowStateSync(stateDir: string, state: WindowState): void {
   const file = path.join(stateDir, `${KEY}.json`);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
-// preload 跑在渲染进程，可用 window / DOM 事件类型；tsconfig.node 默认无 DOM lib，
-// 故在此显式引入（仅类型，不影响产物）。
+// preload runs in the renderer process, so window / DOM event types are available; tsconfig.node has no DOM lib by default,
+// hence the explicit reference here (types only, no impact on output).
 import { contextBridge, ipcRenderer } from 'electron';
 import type {
   IpcBridge,
@@ -40,12 +40,12 @@ try {
   console.error('[preload] failed to expose window.api:', e);
 }
 
-// 渲染层全局错误兜底：转发到 main 落进 meebox.log（renderer 自己的 console 不进文件）。
-// 在 preload 装监听 → 能捕获 React 挂载前的早期错误；用 ipcRenderer.invoke 直连，
-// 不经 contextBridge。转发失败静默（避免错误处理自身再抛）。
+// Renderer global error fallback: forward to main so it lands in meebox.log (renderer's own console does not go to file).
+// Installing the listener in preload → can capture early errors before React mounts; uses ipcRenderer.invoke directly,
+// not via contextBridge. Forwarding failures are silent (to avoid the error handling itself throwing again).
 function reportRendererError(msg: string, meta: Record<string, unknown>): void {
   void ipcRenderer.invoke('log:write', { level: 'error', msg, meta }).catch(() => {
-    /* main 未就绪 / 通道异常时静默 */
+    /* silent when main is not ready / channel error */
   });
 }
 window.addEventListener('error', (e: ErrorEvent) => {


### PR DESCRIPTION
## What & why

Backfill Chinese → English for **code comments in the desktop main process (backend)** + the preload bridge, completing the code-comment convention (developer-facing code-surface artifacts are English) for `apps/desktop/src/main` and `src/preload`. Follows the packages PR (#184) and the renderer PR (#185).

## Scope of change

Comment text only, by domain — one commit each, each verified `typecheck` + `lint` green:

| Batch | Area | Files |
| --- | --- | --- |
| M1 | bootstrap/*, index, ipc, i18n, adapters (startup + IPC wiring) | 13 |
| M2 | core services + local API server (http/server/views/compat/routes) | 16 |
| M3 | agent orchestration + pr-agent runtime | 14 |
| M4 | IPC controllers + main-process utils | 13 |
| preload | contextBridge module | 1 |

## Left verbatim (out of scope)
Never touched: identifiers, IPC channel names, config keys, LLM prompt strings, error-message string literals, log messages, formatting. A few Chinese error/log string literals remain (e.g. `throw new Error(...)` messages, the splash `启动中…` HTML) — those are a separate strings/logs-in-English concern.

## Verification
- Each batch: only comment lines changed (no code statements), and `desktop` typecheck + lint green.
- Final sweep confirms no untranslated Chinese remains in comment positions under `main/`.
- Comments-only change; no runtime behavior affected.

> Note: `.scss` style-file comments are **not** in this PR — a separate follow-up.