### PR TITLE
chore(issue-templates): translate to English and improve the version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
-name: 缺陷报告（Bug report）
-description: 报告一个问题或异常行为
+name: Bug report
+description: Report a problem or unexpected behavior
 labels: [bug]
 assignees:
   - huhamhire
@@ -7,22 +7,29 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: 问题描述（What happened）
-      description: 发生了什么、预期是什么，以及复现步骤。
-      placeholder: 简要描述问题与复现步骤。
+      label: What happened
+      description: What happened, what you expected, and steps to reproduce.
+      placeholder: Briefly describe the problem and how to reproduce it.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: version
     attributes:
-      label: 版本（Version）
-      placeholder: 如 0.6.0-alpha.1
+      label: Version / environment
+      description: Open **Settings → About**, click the copy button, and paste the runtime info here (app version, PR-Agent, OS, etc.).
+      placeholder: |
+        App version: 0.10.0
+        Electron: 33.0.0
+        Node: 22.0.0
+        Operating system: darwin 15.5
+        Architecture: arm64
+        PR-Agent: 0.36.0
     validations:
       required: false
   - type: dropdown
     id: os
     attributes:
-      label: 操作系统（OS）
+      label: OS
       options:
         - Windows
         - macOS
@@ -32,7 +39,7 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: 日志 / 截图（Logs / screenshots）
-      description: 相关日志（`~/.code-meeseeks/`）或截图，便于定位。
+      label: Logs / screenshots
+      description: Relevant logs (`~/.code-meeseeks/`) or screenshots to help diagnose.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
-# 关掉空白 issue，强制走下方模板——模板带 assignees，确保新 issue 默认有处理人。
+# Disable blank issues so every new issue uses a template — templates carry assignees, so each issue has an owner by default.
 blank_issues_enabled: false
 contact_links:
-  - name: 使用文档（Documentation）
+  - name: Documentation
     url: https://github.com/huhamhire/code-meeseeks/tree/master/docs/guide
-    about: 安装、代码平台 / LLM / 代理配置与使用说明，先看这里。
+    about: Installation, code-platform / LLM / proxy setup and usage — check here first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
-name: 功能建议（Feature request）
-description: 提出新功能或改进建议
+name: Feature request
+description: Suggest a new feature or improvement
 labels: [enhancement]
 assignees:
   - huhamhire
@@ -7,14 +7,14 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: 需求 / 痛点（Problem）
-      description: 你希望解决什么问题、当前有何不便。
+      label: Problem / pain point
+      description: What problem do you want to solve, and what is inconvenient today.
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: 期望方案（Proposed solution）
-      description: 期望的功能形态或交互；有备选方案也可一并说明。
+      label: Proposed solution
+      description: The desired feature or interaction; alternatives are welcome too.
     validations:
       required: false


### PR DESCRIPTION
## What & why

The GitHub issue forms were Chinese-primary. Make them **English-only**, consistent with the project's now-English collaboration surface (commits / PRs / CONTRIBUTING / dev docs). English form labels don't force English issue bodies — reporters can still write their report in any language.

## Changes
- `bug_report.yml`, `feature_request.yml`, `config.yml` → English.
- **Bug form version field**: `input` → `textarea`, and dropped the `0.6.0-alpha.1` example. Reporters can open **Settings → About**, click the copy button, and paste the whole runtime-info block (app version / Electron / Node / OS / arch / PR-Agent) — which the About panel already produces as a plain-text snapshot for exactly this purpose. The placeholder shows a non-alpha `0.10.0` example.

No Chinese issue template — a single, globally legible set keeps the tracker searchable and avoids two-version drift.