### PR TITLE
refactor: text-free splash + English thrown-error messages

### DIFF
--- a/apps/desktop/src/main/bootstrap/splash.ts
+++ b/apps/desktop/src/main/bootstrap/splash.ts
@@ -44,6 +44,8 @@ const SPLASH_COLORS = {
  * The logo is inlined via base64 (see resolveSplashLogo); the data URL is self-contained, with
  * identical dev/packaged behavior. Colors switch with the effective theme (`dark`), to avoid a dark
  * splash under a light theme.
+ * Intentionally text-free (logo + brand name + spinner only): the splash renders before i18n loads,
+ * so it must not depend on any localized copy — the spinner conveys "loading" without words.
  */
 export function createSplash(dark: boolean): BrowserWindow {
   const c = dark ? SPLASH_COLORS.dark : SPLASH_COLORS.light;
@@ -79,13 +81,12 @@ export function createSplash(dark: boolean): BrowserWindow {
       display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;}
     .logo{width:72px;height:72px;border-radius:16px;}
     .name{font-size:17px;font-weight:600;letter-spacing:.3px;}
-    .row{display:flex;align-items:center;gap:8px;color:${c.sub};font-size:12px;}
-    .ring{width:14px;height:14px;border-radius:50%;border:2px solid ${c.ring};
+    .ring{width:16px;height:16px;border-radius:50%;border:2px solid ${c.ring};
       border-top-color:${c.accent};animation:spin .8s linear infinite;}
     @keyframes spin{to{transform:rotate(360deg);}}
   </style></head><body>
     ${logoEl}<div class="name">Code Meeseeks</div>
-    <div class="row"><div class="ring"></div><span>启动中…</span></div>
+    <div class="ring"></div>
   </body></html>`;
   void splash.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
   splash.once('ready-to-show', () => {

--- a/apps/desktop/src/main/controllers/pr.ts
+++ b/apps/desktop/src/main/controllers/pr.ts
@@ -537,10 +537,10 @@ export const addDraft: IpcController<'drafts:create'> = async (_event, req) => {
   const ctx = getContext();
   const { draft, localId } = req;
   if (draft.origin === 'finding' && !draft.source) {
-    throw new Error('drafts:create: origin=finding 必须传 source { runId, findingId }');
+    throw new Error('drafts:create: origin=finding requires source { runId, findingId }');
   }
   if (draft.origin === 'manual' && draft.source) {
-    throw new Error('drafts:create: origin=manual 不应该传 source');
+    throw new Error('drafts:create: origin=manual must not pass source');
   }
   const created = await createDraft(await ctx.pr.storeForPr(localId), localId, draft);
   ctx.broadcast('drafts:changed', { localId });

--- a/apps/desktop/src/main/services/agent/planning.ts
+++ b/apps/desktop/src/main/services/agent/planning.ts
@@ -136,10 +136,10 @@ export async function runPlanning(
         chat: deps.chat,
         runTool: async ({ tool, question }) => {
           const bare = tool.replace(/^\//, '');
-          if (!READ_RUN_TOOL_IDS.has(bare)) throw new Error(`不支持的工具：${tool}`);
+          if (!READ_RUN_TOOL_IDS.has(bare)) throw new Error(`Unsupported tool: ${tool}`);
           const run = await deps.enqueueRun(pr, bare as ReviewRunTool, question);
           if (run.status !== 'succeeded') {
-            throw new Error(`pr-agent ${bare} 未成功：${run.errorMessage ?? run.status}`);
+            throw new Error(`pr-agent ${bare} did not succeed: ${run.errorMessage ?? run.status}`);
           }
           return { text: reviewRunText(run), usage: run.tokenUsage };
         },

--- a/apps/desktop/src/main/services/agent/review.ts
+++ b/apps/desktop/src/main/services/agent/review.ts
@@ -94,7 +94,7 @@ export async function runReview(
             referencedFinding,
           );
           if (run.status !== 'succeeded') {
-            throw new Error(`pr-agent ${tool} 未成功：${run.errorMessage ?? run.status}`);
+            throw new Error(`pr-agent ${tool} did not succeed: ${run.errorMessage ?? run.status}`);
           }
           // Carry back runId / findings / askVerdict: lets the judge name findings by id, and links asks re-review with auto-close.
           return {

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -106,7 +106,7 @@ export function setControllerContext(ctx: ControllerContext): void {
 /** Get the controller context singleton; throws if uninitialized (before registerIpcHandlers / during module load) to guard timing. */
 export function getContext(): ControllerContext {
   if (!currentContext) {
-    throw new Error('ControllerContext 尚未初始化（registerIpcHandlers 未调用）');
+    throw new Error('ControllerContext not initialized (registerIpcHandlers was not called)');
   }
   return currentContext;
 }

--- a/packages/agent/src/steps/review/shared.ts
+++ b/packages/agent/src/steps/review/shared.ts
@@ -127,7 +127,7 @@ export interface ReviewStepCtx {
   deps: ReviewOrchestratorDeps;
   input: ReviewOrchestratorInput;
   rec: StepRecorder;
-  /** User stop: boundary check at each step; if already aborted, throw `用户暂停` (the thinking phase can be interrupted immediately too). */
+  /** User stop: boundary check at each step; if already aborted, throw the stable code `aborted` (the thinking phase can be interrupted immediately too). */
   checkAbort: () => void;
   maxAsks: number;
   summaryMax: number;

--- a/packages/poller/tests/poller.test.ts
+++ b/packages/poller/tests/poller.test.ts
@@ -25,22 +25,22 @@ import {
 const unusedComments: CommentService = {
   listPullRequestComments: async () => [],
   publishSummaryComment: () =>
-    Promise.reject(new Error('FakeAdapter.publishSummaryComment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.publishSummaryComment not implemented (unused by poller tests)')),
   publishInlineComment: () =>
-    Promise.reject(new Error('FakeAdapter.publishInlineComment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.publishInlineComment not implemented (unused by poller tests)')),
   replyToComment: () =>
-    Promise.reject(new Error('FakeAdapter.replyToComment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.replyToComment not implemented (unused by poller tests)')),
   editComment: () =>
-    Promise.reject(new Error('FakeAdapter.editComment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.editComment not implemented (unused by poller tests)')),
   deleteComment: () =>
-    Promise.reject(new Error('FakeAdapter.deleteComment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.deleteComment not implemented (unused by poller tests)')),
   toggleReaction: () =>
-    Promise.reject(new Error('FakeAdapter.toggleReaction 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.toggleReaction not implemented (unused by poller tests)')),
 };
 const unusedMedia: MediaService = {
   getUserAvatar: async () => null,
   getAttachment: () =>
-    Promise.reject(new Error('FakeAdapter.getAttachment 未实现（poller 测试不使用）')),
+    Promise.reject(new Error('FakeAdapter.getAttachment not implemented (unused by poller tests)')),
   uploadAttachment: async () => null,
 };
 
@@ -108,14 +108,14 @@ class FakeAdapter implements PlatformAdapter {
         return this.prList;
       },
       getSinglePullRequest: () =>
-        Promise.reject(new Error('FakeAdapter.getSinglePullRequest 未实现（poller 测试不使用）')),
+        Promise.reject(new Error('FakeAdapter.getSinglePullRequest not implemented (unused by poller tests)')),
       listPullRequestCommits: async () => [],
       listPullRequestActivity: async () => [],
       setPullRequestReviewStatus: async () => {
         // the test only cares about the poller's own behavior; setReviewStatus is called at the IPC layer, not triggered by the poller
       },
       mergePullRequest: () =>
-        Promise.reject(new Error('FakeAdapter.mergePullRequest 未实现（poller 测试不使用）')),
+        Promise.reject(new Error('FakeAdapter.mergePullRequest not implemented (unused by poller tests)')),
     };
   }
   setPrs(prs: PullRequest[]): void {


### PR DESCRIPTION
## What & why

Two related cleanups for the last Chinese **string literals** in code (not comments — those are already all English).

### 1. Splash: remove the i18n-copy dependency
The startup splash renders in the main process **before the renderer/i18n loads**, so it must not depend on any localized copy. It hardcoded a Chinese `启动中…` label. Now it's **logo + brand name + spinner only** — the spinner conveys "loading" without words, so the splash is language-neutral by design. Documented the intent and removed the now-dead `.row` style.

### 2. Thrown errors → English
Translated the remaining Chinese `throw new Error(...)` messages to English, per the exceptions-in-English convention:
- `drafts:create` origin guards (controllers/pr.ts)
- `ControllerContext` init guard (services/context.ts)
- unsupported-tool / pr-agent-failure throws (agent planning & review)
- poller test-fixture "not implemented" stubs

Also fixed a **stale comment** in `steps/review/shared.ts` that referenced `用户暂停` — the real abort sentinel is the stable code `aborted` (see `orchestrator.ts`), not localized text; no runtime value changed.

## Verification
- `desktop` typecheck + lint green.
- `agent` + `poller` typecheck + lint + test green (130 + 80 tests).
- No functional change beyond the error text and the splash markup; the abort sentinel is unchanged.