### PR TITLE
feat: surface the brand website (Settings About link + README nav)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Graphical interface (GUI) for the community [PR-Agent](https://docs.pr-agent.ai/
 
 <sub>Keywords：PR-Agent GUI · pr-agent desktop client · AI code review · Pull Request &amp; Merge Request review · Bitbucket / GitHub reviewer tool · local / self-hosted / private deployment</sub>
 
-**English** · [简体中文](README.zh-CN.md)
+**English** · [简体中文](README.zh-CN.md) · [Website](https://huhamhire.github.io/code-meeseeks/)
 
 </div>
 
@@ -98,7 +98,7 @@ Core design stance:
 
 - **Themes and appearance** — dark / light / follow system, several editor color themes, and a custom monospace font and size.
 - **Command palette** — invoke with `Ctrl/Cmd+Shift+P` to quickly run common actions and centralize scattered features.
-- **Multilingual UI** — Simplified Chinese / English / 日本語 / Deutsch, with the AI's reply language following the UI language.
+- **Multilingual UI** — English / 简体中文 / 日本語 / Deutsch, with the AI's reply language following the UI language.
 - **Frameless window** — a custom-drawn title bar (VS Code style) showing the brand name and current PR title.
 
 <div align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 
 <sub>关键词 / Keywords：PR-Agent GUI · pr-agent desktop client · AI 代码评审 / AI code review · Pull Request &amp; Merge Request review · Bitbucket / GitHub reviewer 工具 · 本地化 / 私有部署 / self-hosted</sub>
 
-[English](README.md) · **简体中文**
+[English](README.md) · **简体中文** · [官网](https://huhamhire.github.io/code-meeseeks/)
 
 </div>
 
@@ -98,7 +98,7 @@ Code Meeseeks（内部开发代号 `meebox`）是命令行工具 [pr-agent](http
 
 - **主题与外观** —— 深色 / 浅色 / 跟随系统，多款编辑器配色主题，自定义等宽字体与字号。
 - **命令面板** —— `Ctrl/Cmd+Shift+P` 唤起，快速执行常用操作并归口分散功能。
-- **多语言界面** —— 简体中文 / English / 日本語 / Deutsch，AI 回复语言随界面语言。
+- **多语言界面** —— English / 简体中文 / 日本語 / Deutsch，AI 回复语言随界面语言。
 - **无边框窗口** —— 自绘标题栏（VS Code 风），展示品牌名与当前 PR 标题。
 
 <div align="center">

--- a/apps/desktop/src/renderer/src/components/features/settings/sections/RuntimeSection.tsx
+++ b/apps/desktop/src/renderer/src/components/features/settings/sections/RuntimeSection.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AppInfo, PrAgentStatus } from '@meebox/shared';
-import { CheckGlyphIcon, CopyIcon, GitHubMarkIcon, IssueIcon, TagIcon } from '../../../common';
+import {
+  CheckGlyphIcon,
+  CopyIcon,
+  GitHubMarkIcon,
+  GlobeIcon,
+  IssueIcon,
+  TagIcon,
+} from '../../../common';
 import { invoke } from '../../../../api';
 import { UpdateCheckButton } from '../elements/UpdateCheckButton';
 
@@ -87,36 +94,47 @@ export function RuntimeSection({ info, updateEnabled }: { info: AppInfo; updateE
           {t('settings.openDevTools')}
         </button>
       </div>
-      {/* About & feedback: low-frequency community links. http(s) external links are intercepted by the App top-level click and routed through openExternal to open in the system browser. */}
+      {/* About & feedback: label on its own line, then a wrapping row of low-frequency community links. http(s) external links are intercepted by the App top-level click and routed through openExternal to open in the system browser. */}
       <div className="settings-about-links">
         <span className="muted settings-about-label">{t('settings.aboutFeedback')}</span>
-        <a
-          className="settings-about-link"
-          href="https://github.com/huhamhire/code-meeseeks"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <GitHubMarkIcon size={14} />
-          {t('settings.starOnGithub')}
-        </a>
-        <a
-          className="settings-about-link"
-          href="https://github.com/huhamhire/code-meeseeks/issues/new"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <IssueIcon size={14} />
-          {t('settings.reportIssue')}
-        </a>
-        <a
-          className="settings-about-link"
-          href="https://github.com/huhamhire/code-meeseeks/releases"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <TagIcon size={14} />
-          {t('settings.releases')}
-        </a>
+        <div className="settings-about-linkrow">
+          <a
+            className="settings-about-link"
+            href="https://huhamhire.github.io/code-meeseeks/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <GlobeIcon size={14} />
+            {t('settings.website')}
+          </a>
+          <a
+            className="settings-about-link"
+            href="https://github.com/huhamhire/code-meeseeks"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <GitHubMarkIcon size={14} />
+            {t('settings.starOnGithub')}
+          </a>
+          <a
+            className="settings-about-link"
+            href="https://github.com/huhamhire/code-meeseeks/issues/new"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <IssueIcon size={14} />
+            {t('settings.reportIssue')}
+          </a>
+          <a
+            className="settings-about-link"
+            href="https://github.com/huhamhire/code-meeseeks/releases"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <TagIcon size={14} />
+            {t('settings.releases')}
+          </a>
+        </div>
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/de-DE.json
@@ -859,6 +859,7 @@
     "updateAvailableLabel": "↑ Neue Version v{{version}} · Zum Download",
     "updateDisabledHint": "Die Update-Prüfung ist in der Konfiguration deaktiviert (config.yaml `update.check_enabled`)",
     "updateDisabledTitle": "Die Update-Prüfung ist in der Konfiguration deaktiviert",
+    "website": "Website",
     "workDirTitle": "Arbeitsverzeichnis"
   },
   "sidebar": {

--- a/apps/desktop/src/renderer/src/i18n/locales/en-US.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en-US.json
@@ -859,6 +859,7 @@
     "updateAvailableLabel": "↑ New version v{{version}} · Go to download",
     "updateDisabledHint": "Update checking is disabled in config (config.yaml `update.check_enabled`)",
     "updateDisabledTitle": "Update checking is disabled in config",
+    "website": "Website",
     "workDirTitle": "Working Directory"
   },
   "sidebar": {

--- a/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/ja-JP.json
@@ -842,6 +842,7 @@
     "updateAvailableLabel": "↑ 新しいバージョン v{{version}} · ダウンロードへ",
     "updateDisabledHint": "アップデートの確認は設定で無効化されています（config.yaml `update.check_enabled`）",
     "updateDisabledTitle": "アップデートの確認は設定で無効化されています",
+    "website": "公式サイト",
     "workDirTitle": "作業ディレクトリ"
   },
   "sidebar": {

--- a/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/zh-CN.json
@@ -842,6 +842,7 @@
     "updateAvailableLabel": "↑ 新版本 v{{version}} · 前往下载",
     "updateDisabledHint": "更新检测已在配置中关闭（config.yaml `update.check_enabled`）",
     "updateDisabledTitle": "更新检测已在配置中关闭",
+    "website": "官网",
     "workDirTitle": "工作目录"
   },
   "sidebar": {

--- a/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
+++ b/apps/desktop/src/renderer/src/styles/features/settings/forms.scss
@@ -207,20 +207,24 @@
   margin-top: 0;
 }
 
-// About & feedback: low-frequency community external-link row (Star / Issue / Releases). A 1px divider + whitespace cleanly separates it from the runtime
-// controls above; each link has its own icon and wider spacing, distinguishable from one another. Restrained text links that don't upstage the runtime controls.
+// About & feedback: a label on its own line, then a wrapping row of low-frequency community external links (Website / Star / Issue / Releases).
+// A 1px divider + whitespace cleanly separates it from the runtime controls above; each link has its own icon and wider spacing, distinguishable
+// from one another. Restrained text links that don't upstage the runtime controls.
 .settings-about-links {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: $space-6;
   margin-top: $space-6;
   padding-top: $space-5;
   border-top: 1px solid $border-default-fade;
   font-size: $fs-sm;
 }
 .settings-about-label {
-  margin-right: $space-2;
+  display: block;
+  margin-bottom: $space-3;
+}
+.settings-about-linkrow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $space-6;
 }
 .settings-about-link {
   display: inline-flex;


### PR DESCRIPTION
## What & why

Make the brand website (GitHub Pages) reachable from the two natural entry points.

### Settings → About & feedback
- Add a **Website** link (GlobeIcon) → `https://huhamhire.github.io/code-meeseeks/`.
- Small layout improvement: the label now sits on its **own line**, with the links (**Website / Star on GitHub / Report an issue / Releases**) wrapping in a row beneath it — clearer now that there are four.
- New i18n key `settings.website` in all four locales (English/中文/日本語/Deutsch), in recursive dictionary order.

### README (both README.md and README.zh-CN.md)
- Add a **Website** link to the top nav line (next to the language switcher).
- Fix the multilingual-UI feature line: **English first**, and use the native endonym **简体中文** instead of "Simplified Chinese".

## Verification
- `desktop` typecheck + lint green; `nx build desktop` compiles the SCSS cleanly.
- App-side external links are already routed through `openExternal` (system browser) by the App top-level click handler.