### PR TITLE
fix(desktop): ping only the active connection at startup

### DIFF
--- a/apps/desktop/src/main/bootstrap/connections-runtime.ts
+++ b/apps/desktop/src/main/bootstrap/connections-runtime.ts
@@ -57,35 +57,41 @@ export class ConnectionRuntimeController {
     );
   }
 
-  /** Fully async ping: refresh remote identity and persist incrementally; if the active connection's identity changes (including first acquisition), run one extra poll (has network, not on the startup critical path). */
+  /**
+   * Fully async ping of the active connection only: refresh its remote identity and persist
+   * incrementally; if the identity changes (including first acquisition), run one extra poll. Non-active
+   * connections are not pinged — their identity has no UI consumer (app:connections filters to the active
+   * one) and is refreshed when they become active (settings save → reconfigure → ping). Has network, not
+   * on the startup critical path.
+   */
   ping(): void {
     const activeId = this.bootstrap.config.active_connection_id;
-    for (const { connectionId, adapter } of this.runtime.adapters) {
-      const isActive = connectionId === activeId;
-      const beforeName = adapter.connection.getCurrentUser()?.name ?? null;
-      // If the active connection has no cached identity at startup → poller.start(immediate=false) skipped the first round; here, after ping settles, it must trigger
-      // the **first sync** (regardless of ping success): "confirm identity first, then sync once immediately".
-      const hadIdentity = beforeName !== null;
-      void adapter.connection.ping().then(
-        async (r) => {
-          this.logger.info(
-            { connectionId, ok: r.ok, serverVersion: r.serverVersion, user: r.user?.name },
-            'adapter ping',
-          );
-          const user = adapter.connection.getCurrentUser();
-          await this.persistConnectionUser(connectionId, user);
-          // Trigger reclassification/first sync: active connection and (identity changed, including first acquisition/account switch, or had no identity and needs the first round).
-          if (isActive && (!hadIdentity || (user?.name ?? null) !== beforeName)) {
-            void this.poller.tick();
-          }
-        },
-        (err: unknown) => {
-          this.logger.warn({ err, connectionId }, 'adapter ping failed');
-          // ping failed but the active connection had no cached identity (first round skipped) → still sync once with the PAT as fallback, to avoid appearing not synced.
-          if (isActive && !hadIdentity) void this.poller.tick();
-        },
-      );
-    }
+    const active = this.runtime.adapters.find((a) => a.connectionId === activeId);
+    if (!active) return;
+    const { connectionId, adapter } = active;
+    const beforeName = adapter.connection.getCurrentUser()?.name ?? null;
+    // If the active connection has no cached identity at startup → poller.start(immediate=false) skipped the first round; here, after ping settles, it must trigger
+    // the **first sync** (regardless of ping success): "confirm identity first, then sync once immediately".
+    const hadIdentity = beforeName !== null;
+    void adapter.connection.ping().then(
+      async (r) => {
+        this.logger.info(
+          { connectionId, ok: r.ok, serverVersion: r.serverVersion, user: r.user?.name },
+          'adapter ping',
+        );
+        const user = adapter.connection.getCurrentUser();
+        await this.persistConnectionUser(connectionId, user);
+        // Trigger reclassification/first sync when the identity changed (including first acquisition/account switch) or there was no identity yet and the first round is needed.
+        if (!hadIdentity || (user?.name ?? null) !== beforeName) {
+          void this.poller.tick();
+        }
+      },
+      (err: unknown) => {
+        this.logger.warn({ err, connectionId }, 'adapter ping failed');
+        // ping failed but there was no cached identity (first round skipped) → still sync once with the PAT as fallback, to avoid appearing not synced.
+        if (!hadIdentity) void this.poller.tick();
+      },
+    );
   }
 
   /** Hot-apply after the settings page changes connections / proxy: rewire + archive non-active connections (local IO) + async ping. */


### PR DESCRIPTION
## Problem

At startup, `ConnectionRuntimeController.ping()` looped over **every** configured connection to refresh its remote identity (`currentUser`) and probe `serverVersion`. For non-active connections this is wasted work:

- Their identity has **no UI consumer** — `app:connections` filters the summary to the active connection (`services/app.ts`), and the connection config schema carries no `user` field, so the connection list can't render it either.
- The persisted identity of a non-active connection is only used to prewarm an in-memory adapter cache, which is refreshed anyway once that connection becomes active.

Meanwhile the cost is real: extra startup network requests to every connection, and — for an unreachable / misconfigured connection (e.g. a TLS cert altname mismatch) — a `adapter ping failed` **WARN on every launch** for a connection that isn't even in use.

## Change

Narrow `ping()` to the **active connection only** (`find(active)` + early return). Because the loop now handles a single connection, the pervasive `isActive` branches collapse (behaviour-equivalent, simpler).

Switching the active connection still re-pings the new active one: the settings-save path sets `active_connection_id` then calls `reconfigureConnections()` → `reconfigure()` → `ping()`. So on-demand identity refresh on switch is preserved — no separate on-switch hook needed.

The active connection's first-sync trigger and PAT fallback (sync-once-even-if-ping-fails) are unchanged.

## Effect

- Startup pings only the active connection; no startup network churn for the rest.
- A broken non-active connection no longer pollutes the startup log with a WARN.
- Active-connection identity refresh / first sync: unchanged.

## Verification

`npx nx typecheck desktop` and `npx nx lint desktop` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)