### PR TITLE
docs: tighten the "Human decides" stance headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Code Meeseeks (internal codename `meebox`) is a **desktop graphical interface (G
 
 Core design stance:
 
-- **The human decides** — every comment must be confirmed / edited by the reviewer before it reaches the remote; the AI only drafts.
+- **Human decides** — every comment must be confirmed / edited by the reviewer before it reaches the remote; the AI only drafts.
 - **Rules stay local** — the reviewer configures their own check rules, style preferences, and LLM provider.
 - **Data stays local** — repository mirrors, PR metadata, and comment drafts all live in a local working directory; friendly to corporate intranets.
 

--- a/website/.vitepress/theme/components/HomeFeatures.vue
+++ b/website/.vitepress/theme/components/HomeFeatures.vue
@@ -24,7 +24,7 @@ function icon(name) {
 const EN = [
   {
     icon: 'gavel',
-    title: 'The human decides',
+    title: 'Human decides',
     points: ["You confirm or edit every comment before it's published", 'The AI only drafts — you keep the final call'],
   },
   {

--- a/website/index.md
+++ b/website/index.md
@@ -5,7 +5,7 @@ pageClass: mb-grid
 hero:
   name: Code Meeseeks
   text: AI code review, on your terms
-  tagline: 'A local, semi-automated AI code-review desktop client for the individual reviewer.<br>The human decides, rules stay local, data stays local.'
+  tagline: 'A local, semi-automated AI code-review desktop client for the individual reviewer.<br>Human decides, rules stay local, data stays local.'
   image:
     src: /logo.png
     alt: Code Meeseeks


### PR DESCRIPTION
Drops the article from the "The human decides" design-stance headline so it reads as a crisper keyword and sits parallel with its siblings ("Rules stay local", "Data stays local", and the site's article-less feature-card titles).

Applied uniformly across the surfaces where it is a **headline / slogan**:

- `README.md` — the design-stance bullet
- `website/index.md` — the hero tagline
- `website/.vitepress/theme/components/HomeFeatures.vue` — the feature-card title

**Left as-is** where it is running prose with an article (`SOUL.md` "you propose, the human decides"; the AutoPilot diagram node) and the `docs/arch/glossary.md` entry that governs that prose usage — those are grammatically correct sentences, not headlines. The Chinese mirrors ("决策权在人" etc.) are article-less already, so no change there.

Website `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)