### PR TITLE
fix(repo-mirror): re-auth git mirror with a fresh token, never persist it

### DIFF
--- a/packages/repo-mirror/src/repo-mirror-manager.ts
+++ b/packages/repo-mirror/src/repo-mirror-manager.ts
@@ -161,7 +161,10 @@ export class RepoMirrorManager {
       return;
     }
     try {
-      await this.withProxyEnv(simpleGit({ baseDir: mp })).raw(['fetch', 'origin', ...refspecs]);
+      // Fetch by a freshly re-assembled authenticated URL (not the stored origin), so a rotated token applies
+      // here too — origin may still carry a historical/stale token on older mirrors.
+      const url = await this.opts.getCloneUrl(repo);
+      await this.withProxyEnv(simpleGit({ baseDir: mp })).raw(['fetch', url, ...refspecs]);
     } catch (err) {
       this.opts.logger?.debug(
         {
@@ -627,6 +630,16 @@ export class RepoMirrorManager {
       if (hasMirror) {
         try {
           this.opts.logger?.debug({ repo: key }, 'mirror exists, fetching');
+          // Re-assemble the authenticated URL fresh every sync and fetch by explicit URL rather than via the
+          // stored `origin` remote: a rotated token then takes effect immediately. Historically the token was
+          // baked into remote.origin.url at clone time, so after a PAT rotation an existing mirror kept fetching
+          // with the stale token → `fatal: Authentication failed` until the cache dir was cleared.
+          const url = await this.opts.getCloneUrl(repo);
+          // Best-effort: rewrite origin to the credential-free URL. Strips a token any historically-cached mirror
+          // baked in (security), and normalizes origin for the health check; the fetch below does not depend on it.
+          await simpleGit({ baseDir: mirrorPath })
+            .raw(['remote', 'set-url', 'origin', stripGitCredentials(url)])
+            .catch(() => undefined);
           // Explicit refspec, force-overwrite fetch:
           //   - refs/heads/*: all branches (including the PR target and source branches)
           //   - refs/pull-requests/*/from: Bitbucket stores the PR source sha separately here.
@@ -636,7 +649,7 @@ export class RepoMirrorManager {
           await this.withProxyEnv(simpleGit({ baseDir: mirrorPath, ...gitProgressOpt })).raw([
             'fetch',
             '--progress',
-            'origin',
+            url,
             '+refs/heads/*:refs/heads/*',
             '+refs/pull-requests/*/from:refs/pull-requests/*/from',
           ]);
@@ -675,6 +688,13 @@ export class RepoMirrorManager {
         '--no-hardlinks',
         '--progress',
       ]);
+      // Never persist the token: `git clone` writes the authenticated URL into remote.origin.url, so immediately
+      // rewrite origin to the credential-free form. Subsequent fetches re-assemble the authenticated URL fresh
+      // (see the fetch path above), so a later token rotation needs no cache clear. Best-effort — a failure here
+      // doesn't invalidate the freshly-cloned mirror.
+      await simpleGit({ baseDir: mirrorPath })
+        .raw(['remote', 'set-url', 'origin', stripGitCredentials(url)])
+        .catch(() => undefined);
       // On systems like Windows the FS may still be flushing after a fresh clone, and the immediately following git diff
       // can hit a "refs/packs state inconsistent" error. Wait until git itself can rev-parse HEAD
       // stably a few times before returning, so the mirror the caller receives is guaranteed usable.
@@ -714,6 +734,27 @@ export class RepoMirrorManager {
       }
     }
     return total;
+  }
+}
+
+/**
+ * Strip any embedded credentials from a git remote URL. The authenticated clone URL carries the PAT
+ * (`https://<user>:<token>@host/...`); we never want that token persisted into the mirror's `.git/config`
+ * (a plaintext-secret / security concern) nor baked into `remote.origin.url` where it goes stale on the next
+ * token rotation (the historical "Authentication failed until you clear the cache" bug). Instead the
+ * authenticated URL is re-assembled fresh (from configured repo + upstream) for each remote op, and only this
+ * credential-free form is stored. scp-like SSH remotes (`git@host:proj/repo.git`) aren't valid URL() inputs and
+ * carry no embedded token, so they're returned unchanged.
+ */
+export function stripGitCredentials(url: string): string {
+  try {
+    const u = new URL(url);
+    if (!u.username && !u.password) return url;
+    u.username = '';
+    u.password = '';
+    return u.toString();
+  } catch {
+    return url;
   }
 }
 

--- a/packages/repo-mirror/tests/repo-mirror-manager.test.ts
+++ b/packages/repo-mirror/tests/repo-mirror-manager.test.ts
@@ -8,6 +8,7 @@ import {
   parseBlamePorcelain,
   parseHunkAddedLines,
   parseMergeTreeConflictsZ,
+  stripGitCredentials,
 } from '../src/repo-mirror-manager.js';
 import type { RepoIdentity } from '../src/types.js';
 
@@ -85,6 +86,39 @@ describe('RepoMirrorManager.syncMirror', () => {
     expect(log.total).toBeGreaterThanOrEqual(2);
   });
 
+  it('fetch re-assembles the URL fresh instead of reusing the stored origin (token rotation)', async () => {
+    // Simulate a token rotation: getCloneUrl returns upstreamA for the clone, then a DIFFERENT upstreamB for the
+    // fetch. If the fetch reused the stored origin (upstreamA) it would miss upstreamB's new commit; the fix fetches
+    // by the freshly re-assembled URL, so the rotated location/token takes effect without clearing the cache.
+    const upstreamB = path.join(tmpRoot, 'upstream-b');
+    await simpleGit(tmpRoot).clone(upstreamPath, upstreamB); // shares history with upstreamA
+    const bGit = simpleGit(upstreamB);
+    await bGit.addConfig('user.email', 'test@example.com', false, 'local');
+    await bGit.addConfig('user.name', 'Test', false, 'local');
+    await bGit.addConfig('commit.gpgsign', 'false', false, 'local');
+    await fs.writeFile(path.join(upstreamB, 'ROTATED.md'), 'after rotate');
+    await bGit.add('.');
+    await bGit.commit('after rotate');
+    const sha2 = (await bGit.revparse(['HEAD'])).trim();
+
+    let call = 0;
+    const mgr = new RepoMirrorManager({
+      reposDir,
+      getCloneUrl: () => Promise.resolve(++call === 1 ? upstreamPath : upstreamB),
+    });
+    await mgr.syncMirror(repo); // clone from upstreamA
+    const r = await mgr.syncMirror(repo); // fetch — must use the fresh URL (upstreamB), not stored origin
+
+    expect(r.freshClone).toBe(false); // fetched, did not fall back to a self-heal re-clone
+    // upstreamB's new commit is only reachable if the fetch used the fresh URL
+    expect(await mgr.hasCommit(repo, sha2)).toBe(true);
+    // origin was migrated to the credential-free URL, and never left pointing at a stale one
+    const originUrl = (
+      await simpleGit(r.mirrorPath).raw(['config', '--get', 'remote.origin.url'])
+    ).trim();
+    expect(originUrl).toBe(upstreamB);
+  });
+
   it('dedups concurrent syncMirror calls for the same repo (shared in-flight)', async () => {
     let urlCalls = 0;
     const mgr = new RepoMirrorManager({
@@ -119,7 +153,9 @@ describe('RepoMirrorManager.syncMirror', () => {
     await mgr.syncMirror(repo);
     // after one sync completes, call again; should trigger a new sync (a fetch here, since the mirror already exists)
     await mgr.syncMirror(repo);
-    expect(urlCalls).toBe(1); // clone only once; fetch does not go through getCloneUrl
+    // clone (1) + fetch (2): the fetch now re-assembles the authenticated URL fresh via getCloneUrl (instead of
+    // reusing the stored origin), so a rotated token takes effect without clearing the cache.
+    expect(urlCalls).toBe(2);
   });
 
   it('serializes syncMirror across different repos via global queue', async () => {
@@ -499,5 +535,30 @@ describe('RepoMirrorManager.materializeWorktree', () => {
     } finally {
       await Promise.all([w1.cleanup(), w2.cleanup(), w3.cleanup()]);
     }
+  });
+});
+
+describe('stripGitCredentials', () => {
+  it('strips user + token from an https clone URL', () => {
+    expect(stripGitCredentials('https://alice:PAT123@bb.example.com/scm/FX/fx-help.git')).toBe(
+      'https://bb.example.com/scm/FX/fx-help.git',
+    );
+  });
+
+  it('strips a token even when only a username (or only a password) is present', () => {
+    expect(stripGitCredentials('https://x-token-auth:tok@host/o/r.git')).toBe('https://host/o/r.git');
+    expect(stripGitCredentials('https://tokenonly@host/o/r.git')).toBe('https://host/o/r.git');
+  });
+
+  it('leaves a credential-free https URL unchanged', () => {
+    expect(stripGitCredentials('https://bb.example.com/scm/FX/fx-help.git')).toBe(
+      'https://bb.example.com/scm/FX/fx-help.git',
+    );
+  });
+
+  it('leaves an scp-like ssh remote unchanged (not a URL, no embedded token)', () => {
+    expect(stripGitCredentials('git@bb.example.com:FX/fx-help.git')).toBe(
+      'git@bb.example.com:FX/fx-help.git',
+    );
   });
 });


### PR DESCRIPTION
Closes #204

## Problem

After rotating a Bitbucket PAT, syncing an existing repo mirror failed with `fatal: Authentication failed` until the cache dir was cleared. The token was baked into `remote.origin.url` at clone time, and every later `git fetch origin` reused that stale token; `getCloneUrl` (fresh token) was only consulted for a brand-new clone.

## Fix

- **Re-assemble the authenticated URL fresh** from configured inputs for each remote op and fetch by explicit URL instead of the stored `origin` (`syncMirror` + `fetchRefspecs`), so a rotated token applies immediately with no cache clear.
- **Never persist the token** — new `stripGitCredentials` helper; after clone and before each fetch, `remote.origin.url` is rewritten to the credential-free form (security + avoids the stale-token failure).
- **No impact on historical mirrors** — fetching by explicit fresh URL means token-baked mirrors keep working without a re-clone; their persisted token is stripped best-effort (non-breaking).

## Tests

- Rotation regression: `getCloneUrl` returns upstream A for the clone, then a different upstream B for the fetch; asserts the mirror gains B's commit, `freshClone === false`, and `origin` is the credential-free B. Fails on the old code.
- `stripGitCredentials` unit tests (https user+token / token-only / no-creds / scp-like ssh).
- Updated the existing "fetch does not go through getCloneUrl" test (now `urlCalls === 2`).

`repo-mirror` tests 31/31 pass; `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)